### PR TITLE
Feature(IL-26): User 및 OAuth 엔티티 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     /* Testing */
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'com.h2database:h2'
 
     /* Docs */
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'

--- a/src/main/java/kr/co/yeogiga/domain/common/entity/BaseTimeEntity.java
+++ b/src/main/java/kr/co/yeogiga/domain/common/entity/BaseTimeEntity.java
@@ -1,0 +1,27 @@
+package kr.co.yeogiga.domain.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    @Column(name = "created_At", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "modified_At")
+    private LocalDateTime modifiedAt;
+
+    @Column(name = "deleted_At")
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/kr/co/yeogiga/domain/common/entity/BaseTimeEntity.java
+++ b/src/main/java/kr/co/yeogiga/domain/common/entity/BaseTimeEntity.java
@@ -21,7 +21,4 @@ public abstract class BaseTimeEntity {
     @LastModifiedDate
     @Column(name = "modified_At")
     private LocalDateTime modifiedAt;
-
-    @Column(name = "deleted_At")
-    private LocalDateTime deletedAt;
 }

--- a/src/main/java/kr/co/yeogiga/domain/oauth/entity/OAuth.java
+++ b/src/main/java/kr/co/yeogiga/domain/oauth/entity/OAuth.java
@@ -1,0 +1,36 @@
+package kr.co.yeogiga.domain.oauth.entity;
+
+import jakarta.persistence.*;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.oauth.type.Platform;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "oauth")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class OAuth {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Platform platform;
+
+    @Column(name = "platform_id", nullable = false)
+    private String platformId;
+
+    @OneToOne(cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Builder
+    public OAuth(Platform platform, String platformId, User user) {
+        this.platform = platform;
+        this.platformId = platformId;
+        this.user = user;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/oauth/repository/OAuthRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/oauth/repository/OAuthRepository.java
@@ -1,0 +1,7 @@
+package kr.co.yeogiga.domain.oauth.repository;
+
+import kr.co.yeogiga.domain.oauth.entity.OAuth;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OAuthRepository extends JpaRepository<OAuth, Long> {
+}

--- a/src/main/java/kr/co/yeogiga/domain/oauth/type/Platform.java
+++ b/src/main/java/kr/co/yeogiga/domain/oauth/type/Platform.java
@@ -1,0 +1,14 @@
+package kr.co.yeogiga.domain.oauth.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Platform {
+    KAKAO("KAKAO"),
+    NAVER("NAVER"),
+    ;
+
+    private final String name;
+}

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.domain.user.entity;
 
 import jakarta.persistence.*;
+import kr.co.yeogiga.domain.common.entity.BaseTimeEntity;
 import kr.co.yeogiga.domain.user.type.Role;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -9,20 +10,14 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity(name = "user")
+@Entity
 @DynamicUpdate
 @SQLRestriction("deleted_at IS NULL")
 @SQLDelete(sql = "UPDATE user SET deleted_at = NOW() WHERE id = ?")
-@EntityListeners(AuditingEntityListener.class)
-public class User {
+public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -40,17 +35,6 @@ public class User {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Role role = Role.USER;
-
-    @CreatedDate
-    @Column(name = "created_At", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(name = "modified_At")
-    private LocalDateTime modifiedAt;
-
-    @Column(name = "deleted_At")
-    private LocalDateTime deletedAt;
 
     @Builder
     public User(String username, String password, String nickname, String email) {

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -35,6 +36,9 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Role role = Role.USER;
+
+    @Column(name = "deleted_At")
+    private LocalDateTime deletedAt;
 
     @Builder
     public User(String username, String password, String nickname, String email) {

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -35,16 +35,17 @@ public class User extends BaseTimeEntity {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private Role role = Role.USER;
+    private Role role;
 
     @Column(name = "deleted_At")
     private LocalDateTime deletedAt;
 
     @Builder
-    public User(String username, String password, String nickname, String email) {
+    public User(String username, String password, String nickname, String email ,Role role) {
         this.username = username;
         this.password = password;
         this.nickname = nickname;
         this.email = email;
+        this.role = role;
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -1,0 +1,62 @@
+package kr.co.yeogiga.domain.user.entity;
+
+import jakarta.persistence.*;
+import kr.co.yeogiga.domain.user.type.Role;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "user")
+@DynamicUpdate
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE user SET deleted_at = NOW() WHERE id = ?")
+@EntityListeners(AuditingEntityListener.class)
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    private String password;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role role = Role.USER;
+
+    @CreatedDate
+    @Column(name = "created_At", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "modified_At")
+    private LocalDateTime modifiedAt;
+
+    @Column(name = "deleted_At")
+    private LocalDateTime deletedAt;
+
+    @Builder
+    public User(String username, String password, String nickname, String email) {
+        this.username = username;
+        this.password = password;
+        this.nickname = nickname;
+        this.email = email;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -13,7 +13,7 @@ import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity
+@Entity(name = "users")
 @DynamicUpdate
 @SQLRestriction("deleted_at IS NULL")
 @SQLDelete(sql = "UPDATE user SET deleted_at = NOW() WHERE id = ?")

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package kr.co.yeogiga.domain.user.repository;
+
+import kr.co.yeogiga.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/kr/co/yeogiga/domain/user/type/Role.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/type/Role.java
@@ -1,0 +1,5 @@
+package kr.co.yeogiga.domain.user.type;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/JpaConfig.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/JpaConfig.java
@@ -1,0 +1,7 @@
+package kr.co.yeogiga.infrastructure.config;
+
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${DATABASE_HOST:localhost}:${DATABASE_PORT:3306}/${DATABASE_NAME:yeogiga}
+    username: ${DATABASE_USER:root}
+    password: ${DATABASE_PASS:password}
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,5 @@
+spring:
+  config:
+    import: "classpath:application-common.yml"
+    activate:
+      on-profile: dev

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,5 @@
+spring:
+  config:
+    import: "classpath:application-common.yml"
+    activate:
+      on-profile: prod

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,17 +1,6 @@
 spring:
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${DATABASE_HOST:localhost}:${DATABASE_PORT:3306}/${DATABASE_NAME:yeogiga}
-    username: ${DATABASE_USER:root}
-    password: ${DATABASE_PASS:password}
-
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
+  profiles:
+    active: ${PROFILE:dev}
 
 api:
   checker:

--- a/src/test/java/kr/co/yeogiga/YeogigaApplicationTests.java
+++ b/src/test/java/kr/co/yeogiga/YeogigaApplicationTests.java
@@ -1,9 +1,8 @@
 package kr.co.yeogiga;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+
 class YeogigaApplicationTests {
 
     @Test

--- a/src/test/java/kr/co/yeogiga/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/kr/co/yeogiga/domain/user/repository/UserRepositoryTest.java
@@ -11,11 +11,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(locations = "classpath:application-test.yml")
 @Import(JpaConfig.class)
 public class UserRepositoryTest {
     @Autowired

--- a/src/test/java/kr/co/yeogiga/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/kr/co/yeogiga/domain/user/repository/UserRepositoryTest.java
@@ -4,6 +4,7 @@ import kr.co.yeogiga.domain.oauth.entity.OAuth;
 import kr.co.yeogiga.domain.oauth.repository.OAuthRepository;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.oauth.type.Platform;
+import kr.co.yeogiga.domain.user.type.Role;
 import kr.co.yeogiga.infrastructure.config.JpaConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,7 @@ public class UserRepositoryTest {
                 .username("tester")
                 .nickname("test")
                 .password("testpw")
+                .role(Role.USER)
                 .build();
 
         // when
@@ -53,6 +55,7 @@ public class UserRepositoryTest {
         User relatedUser = User.builder()
                 .email("fromPlatformt@test.com")
                 .nickname("tempNickname")
+                .role(Role.USER)
                 .build();
 
         OAuth oauth = OAuth.builder()

--- a/src/test/java/kr/co/yeogiga/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/kr/co/yeogiga/domain/user/repository/UserRepositoryTest.java
@@ -1,0 +1,65 @@
+package kr.co.yeogiga.domain.user.repository;
+
+import kr.co.yeogiga.domain.oauth.entity.OAuth;
+import kr.co.yeogiga.domain.oauth.repository.OAuthRepository;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.oauth.type.Platform;
+import kr.co.yeogiga.infrastructure.config.JpaConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaConfig.class)
+public class UserRepositoryTest {
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private OAuthRepository oAuthRepository;
+
+    @Test
+    @DisplayName("일반 User 생성")
+    void 일반_User_생성() {
+        // given
+        User user = User.builder()
+                .email("test@gmail.com")
+                .username("tester")
+                .nickname("test")
+                .password("testpw")
+                .build();
+
+        // when
+        User savedUser = userRepository.save(user);
+
+        // then
+        assertThat(savedUser.getId()).isEqualTo(user.getId());
+    }
+
+    @Test
+    @DisplayName("소셜 로그인 User 생성")
+    void 소셜_로그인_User_생성() {
+        // given
+        User relatedUser = User.builder()
+                .email("fromPlatformt@test.com")
+                .nickname("tempNickname")
+                .build();
+
+        OAuth oauth = OAuth.builder()
+                .platform(Platform.NAVER)
+                .platformId("12345")
+                .user(relatedUser)
+                .build();
+        // when
+        OAuth savedOAuth = oAuthRepository.save(oauth);
+
+        // then
+        assertThat(savedOAuth.getId()).isEqualTo(oauth.getId());
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,4 +1,7 @@
 spring:
+  config:
+    activate:
+      on-profile: test
   h2:
     console:
       enabled: true

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,16 @@
+spring:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  datasource :
+    url: jdbc:h2:mem:test
+    driverClassName: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+    defer-datasource-initialization: true


### PR DESCRIPTION
## 배경
- User 및 OAuth 엔티티 생성
- 테스트 환경 시 h2 database 사용 필요성 대두

## 작업 사항
- User 및 OAuth 엔티티 생성
- UserRepository 및 OAuthRepository 생성
- 실행 환경 별 application.yml 설정 파일 분리

## 추가 논의
### 1. 연관 관계 및 cascade 설정
현재, OAuth 내에 `cascade = CascadeType.PERSIST`로 설정해놓았습니다. OAuth 엔티티 영속화 시에만 cascade 설정이 필요하고 생각되어 위와 같이 설정하였습니다.

## 기타
### 1. 테스트 코드
테스트 코드가 안 익숙하기도 하고, Repository 단 테스트 코드를 작성하면서 비지니스 로직을 테스트하는 것은 아니기에 우선 일반 유저 생성, 소셜 로그인 유저 생성 테스트 코드만 작성하였습니다. 혹시라도 테스트 코드에 보완점이 있다면 말씀해주시면 감사하겠습니다. 추가적으로 탈퇴 유저 조회 시 SoftDelete로 인하여 일반적으로 조회하였을 경우에는 엔티티가 조회되지 않아 아래와 같이 테스트 코드를 작성하여 테스트를 진행하였으나, 현재 PR에서는 불필요한 코드라 생각하여 삭제하였습니다. 아래는 테스트 결과입니다.

```java
@Query(value = "SELECT * " +  
               "FROM user u " +  
               "WHERE deleted_at IS NOT NULL", nativeQuery = true)  
List<User> findAllDeletedUser();
```

```java
@Test  
@DisplayName("일반 User 삭제")  
void 일반_User_삭제() {  
	// given  
	User user = User.builder()  
			.email("delete@test.com")  
			.username("deleteUser")  
			.nickname("deleteNickname")  
			.password("deletepw")  
			.build();  
	User savedUser = userRepository.save(user);  

	// when  
	userRepository.deleteById(savedUser.getId());  

	List<User> deletedUserList = userRepository.findAllDeletedUser();  

	// then  
	for (User delUser : deletedUserList) {  
		if (delUser.getId().equals(savedUser.getId())) {  
			assertThat(delUser.getId()).isEqualTo(savedUser.getId());  
		}  
	}  
}
```

<img width="1811" alt="image" src="https://github.com/user-attachments/assets/4df5e12a-ca1c-49f9-946f-544ac20af706" />


### (추가) 2. SpringBootTest 어노테이션 제거

현재 ci 시에 `-x test` 옵션없이 `build` 명령어만 사용하여 프로젝트를 빌드하여 진행합니다. 
따라서, 테스트 코드도 모두 실행이 됩니다. 

현재 PR에서 Persistence Layer 테스트를 위하여 UserRepository 관련 테스트 코드(유저 생성)를 작성하였고, 이로 인하여 DB에 접근하게 되면서 ci 오류가 발생하였습니다. 

또한, 실행 환경과 테스트 환경에서 환경변수는 별도로 적용되기 때문에 테스트 환경에서 MySQL을 사용하려면 매 케이스마다 모든 환경변수 값을 다 입력해야 하는 상황이 생겨 두 환경에서 데이터베이스를 분리하는 방향으로 생각했습니다.

- 실행 환경: MySQL
- 테스트 환경: H2

```
testRuntimeOnly 'com.h2database:h2'
```

따라서, 실행 환경(프로필) 별 yml 파일을 분리하였습니다. 

- application.yml
- application-dev.yml
- application-prod.yml
- application-commom.yml (dev, prod 파일에서 동시에 사용하는 MySQL datasource 관련 설정 파일)
- application.test.yml 

이로 인하여 데이터베이스에 접근하는 테스트 클래스에서는 아래와 같이 설정 파일 경로와 프로필을 명시해주어야 합니다.

```java
@DataJpaTest
@ActiveProfiles("test")
@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@TestPropertySource(locations = "classpath:application-test.yml")
@Import(JpaConfig.class)
public class UserRepositoryTest {
```

Persistence Layer 테스트는 문제없이 진행이 됩니다.
그러나, 통합 테스트 시 `@SpringBootTest` 어노테이션을 사용하게 되는데, 이 때 여러 `application-xxx.yml` 이 존재하여 바인딩을 제대로 하지 못하여 오류가 발생하는 것 같습니다. 
현재는 **통합 테스트를 진행할 일이 없다고 생각하여 우선은 해당 어노테이션을 주석처리 해놓은 상태**입니다.

[[트러블 슈팅] SpringBoot에서 application.yml 이외의 yml 프로퍼티 적용하기](https://ksh-coding.tistory.com/41)

해당 블로그에서 `@SpringBootTest` 어노테이션에 설정 파일 경로를 지정해주어 해결이 가능하다고 하니, 차후 통합 테스트 시 해결해보도록 하겠습니다.


