### PR TITLE
Feature(IL-37): JWT 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.4'
+    id 'org.springframework.boot' version '3.3.2'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,11 @@ dependencies {
     /* Database */
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    /* JWT */
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
     /* Testing */
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     testRuntimeOnly 'com.h2database:h2'
 
     /* Docs */
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     implementation 'io.github.daeyoung0726:api-link-checker:0.1.1'
 
     /* Image Metadata Extractor */

--- a/src/main/java/kr/co/yeogiga/application/auth/constant/AuthConstants.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/constant/AuthConstants.java
@@ -1,0 +1,13 @@
+package kr.co.yeogiga.application.auth.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthConstants {
+    REFRESH_TOKEN_PREFIX("refreshToken");
+
+    private final String value;
+
+}

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/OAuthSignInDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/OAuthSignInDto.java
@@ -1,7 +1,0 @@
-package kr.co.yeogiga.application.auth.dto;
-
-public class OAuthSignInDto {
-    public record Request(
-            String code
-    ) { }
-}

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
@@ -1,8 +1,19 @@
 package kr.co.yeogiga.application.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 public class SignInDto {
+
+    @Builder
+    @Schema(name = "OAuthRequest", description = "OAuth 로그인 요청 DTO")
+    public record OAuthRequest(
+            @Schema(description = "OAuth 리소스 서버에서 발급받은 인증 코드", example = "abcd123")
+            @NotBlank(message = "인증 코드값은 필수입니다.")
+            String code
+    ) {
+    }
 
     @Builder
     public record Response(

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
@@ -21,4 +21,13 @@ public class SignInDto {
             boolean shouldSignup
     ) {
     }
+
+    public record ResponseToWeb(
+            String accessToken,
+            boolean shouldSignup
+    ) {
+        public static ResponseToWeb from(Response response) {
+            return new ResponseToWeb(response.token.accessToken(), response.shouldSignup());
+        }
+    }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
@@ -21,13 +21,4 @@ public class SignInDto {
             boolean shouldSignup
     ) {
     }
-
-    public record ResponseForWeb(
-            String accessToken,
-            boolean shouldSignup
-    ) {
-        public static ResponseForWeb from(Response response) {
-            return new ResponseForWeb(response.token.accessToken(), response.shouldSignup());
-        }
-    }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
@@ -22,12 +22,12 @@ public class SignInDto {
     ) {
     }
 
-    public record ResponseToWeb(
+    public record ResponseForWeb(
             String accessToken,
             boolean shouldSignup
     ) {
-        public static ResponseToWeb from(Response response) {
-            return new ResponseToWeb(response.token.accessToken(), response.shouldSignup());
+        public static ResponseForWeb from(Response response) {
+            return new ResponseForWeb(response.token.accessToken(), response.shouldSignup());
         }
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
@@ -20,5 +20,13 @@ public class SignInDto {
             TokenDto token,
             boolean shouldSignup
     ) {
+        public Response toWebResponse() {
+            return Response.builder()
+                    .token(TokenDto.builder()
+                            .accessToken(this.token.accessToken())
+                            .build())
+                    .shouldSignup(this.shouldSignup)
+                    .build();
+        }
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
@@ -1,0 +1,13 @@
+package kr.co.yeogiga.application.auth.dto;
+
+import lombok.Builder;
+
+public class SignInDto {
+
+    @Builder
+    public record Response(
+            TokenDto token,
+            boolean shouldSignup
+    ) {
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/TokenDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/TokenDto.java
@@ -1,6 +1,11 @@
 package kr.co.yeogiga.application.auth.dto;
 
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record TokenDto (
     String accessToken,
     String refreshToken

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/TokenDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/TokenDto.java
@@ -1,0 +1,11 @@
+package kr.co.yeogiga.application.auth.dto;
+
+
+public record TokenDto (
+    String accessToken,
+    String refreshToken
+) {
+    public static TokenDto of(String accessToken, String refreshToken) {
+        return new TokenDto(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/auth/service/JwtService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/JwtService.java
@@ -1,0 +1,18 @@
+package kr.co.yeogiga.application.auth.service;
+
+import kr.co.yeogiga.application.auth.dto.TokenDto;
+import kr.co.yeogiga.common.jwt.JwtHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+    private final JwtHelper jwtHelper;
+
+    public TokenDto generateToken(String username, String nickname, Long userId) {
+        return TokenDto.of(
+                jwtHelper.generateAccessToken(username, nickname, userId),
+                jwtHelper.generateRefreshToken(username, nickname, userId));
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -46,7 +46,7 @@ public class OAuthManagementService {
         User user = User.builder()
                 .email(userInfo.email())
                 .role(Role.USER)
-                .nickname(platform + " " + userInfo.platformId())
+                .username(platform + " " + userInfo.platformId())
                 .build();
 
         OAuth oauth = OAuth.builder()

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -68,6 +68,7 @@ public class OAuthManagementService {
                 .email(userInfo.email())
                 .role(Role.USER)
                 .username(platform + " " + userInfo.platformId())
+                .nickname(platform + " " + userInfo.platformId())
                 .build();
 
         OAuth oauth = OAuth.builder()

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -53,9 +53,9 @@ public class OAuthManagementService {
      */
     private UserStatusDto getUserStatus(OAuthPlatform platform, UserInfoDto userInfo) {
         return userService.readByPlatformAndPlatformId(platform, userInfo.platformId())
-                .map(user -> Objects.isNull(user.getPassword())
-                        ? UserStatusDto.of(user, true)
-                        : UserStatusDto.of(user, false)
+                .map(user -> user.isSignedUp()
+                        ? UserStatusDto.of(user, false)
+                        : UserStatusDto.of(user, true)
                 )
                 .orElseGet(() -> UserStatusDto.of(registerUser(platform, userInfo), true));
     }
@@ -102,7 +102,7 @@ public class OAuthManagementService {
             TokenDto token = jwtService.generateToken(username, nickname, userId);
 
             return SignInDto.Response.builder()
-                    .token(TokenDto.of(token.accessToken(), token.refreshToken()))
+                    .token(token)
                     .shouldSignup(userStatus.shouldSignUp())
                     .build();
         }

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -4,7 +4,6 @@ import kr.co.yeogiga.application.auth.dto.SignInDto;
 import kr.co.yeogiga.application.auth.dto.TokenDto;
 import kr.co.yeogiga.application.auth.dto.UserInfoDto;
 import kr.co.yeogiga.application.auth.dto.UserStatusDto;
-import kr.co.yeogiga.common.jwt.JwtHelper;
 import kr.co.yeogiga.domain.oauth.entity.OAuth;
 import kr.co.yeogiga.domain.oauth.service.OAuthService;
 import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
@@ -21,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class OAuthManagementService {
     private final OAuthClientFactory oAuthClientFactory;
     private final OAuthService oAuthService;
-    private final JwtHelper jwtHelper;
+    private final JwtService jwtService;
     private final UserService userService;
 
     /**
@@ -95,11 +94,10 @@ public class OAuthManagementService {
             String nickname = user.getNickname();
             Long userId = user.getId();
 
-            String accessToken = jwtHelper.generateAccessToken(username, nickname, userId);
-            String refreshToken = jwtHelper.generateRefreshToken(username, nickname, userId);
+            TokenDto token = jwtService.generateToken(username, nickname, userId);
 
             return SignInDto.Response.builder()
-                    .token(TokenDto.of(accessToken, refreshToken))
+                    .token(TokenDto.of(token.accessToken(), token.refreshToken()))
                     .shouldSignup(userStatus.shouldSignUp())
                     .build();
         }

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -24,6 +24,13 @@ public class OAuthManagementService {
     private final JwtHelper jwtHelper;
     private final UserService userService;
 
+    /**
+     * OAuth2 로그인
+     *
+     * @param platform      OAuth 로그인 플랫폼
+     * @param code          OAuth 리소스 서버 제공 인증 코드
+     * @return              로그인 응답 정보 (JWT, 추가 정보 입력 필요 여부)
+     */
     @Transactional
     public SignInDto.Response signIn(OAuthPlatform platform, String code) {
         OAuthClient oAuthClient = oAuthClientFactory.getOAuthClient(platform);
@@ -36,12 +43,26 @@ public class OAuthManagementService {
         return getSignInDto(userStatus);
     }
 
+    /**
+     * User 및 추가정보 입력 필요 여부 반환 메서드
+     *
+     * @param platform      OAuth 로그인 플랫폼
+     * @param userInfo      OAuth 리소스 서버 제공 사용자 정보
+     * @return              User, 추가 정보 입력 필요 여부
+     */
     private UserStatusDto getUserStatus(OAuthPlatform platform, UserInfoDto userInfo) {
         return userService.readByPlatformAndPlatformId(platform, userInfo.platformId())
                 .map(user -> UserStatusDto.of(user, false))
                 .orElseGet(() -> UserStatusDto.of(registerUser(platform, userInfo), true));
     }
 
+    /**
+     * User 및 OAuth 저장 메서드
+     *
+     * @param platform      OAuth 로그인 플랫폼
+     * @param userInfo      OAuth 리소스 서버 제공 유저 사용자 정보
+     * @return              User
+     */
     private User registerUser(OAuthPlatform platform, UserInfoDto userInfo) {
         User user = User.builder()
                 .email(userInfo.email())
@@ -60,6 +81,12 @@ public class OAuthManagementService {
         return user;
     }
 
+    /**
+     * 로그인 요청 응답 DTO 생성 메서드
+     *
+     * @param userStatus    User, 추가 정보 입력 여부
+     * @return              로그인 응답 정보 (JWT, 추가 정보 입력 필요 여부)
+     */
     private SignInDto.Response getSignInDto(UserStatusDto userStatus) {
         if (!userStatus.shouldSignUp()) {
             User user = userStatus.user();

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -15,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
+
 @Service
 @RequiredArgsConstructor
 public class OAuthManagementService {
@@ -51,7 +53,10 @@ public class OAuthManagementService {
      */
     private UserStatusDto getUserStatus(OAuthPlatform platform, UserInfoDto userInfo) {
         return userService.readByPlatformAndPlatformId(platform, userInfo.platformId())
-                .map(user -> UserStatusDto.of(user, false))
+                .map(user -> Objects.isNull(user.getPassword())
+                        ? UserStatusDto.of(user, true)
+                        : UserStatusDto.of(user, false)
+                )
                 .orElseGet(() -> UserStatusDto.of(registerUser(platform, userInfo), true));
     }
 

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -15,8 +15,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Objects;
-
 @Service
 @RequiredArgsConstructor
 public class OAuthManagementService {
@@ -41,7 +39,7 @@ public class OAuthManagementService {
 
         UserStatusDto userStatus = getUserStatus(platform, userInfo);
 
-        return getSignInDto(userStatus);
+        return getSignInResponse(userStatus);
     }
 
     /**
@@ -70,7 +68,7 @@ public class OAuthManagementService {
     private User registerUser(OAuthPlatform platform, UserInfoDto userInfo) {
         User user = User.builder()
                 .email(userInfo.email())
-                .role(Role.USER)
+                .role(Role.GUEST)
                 .username(platform + " " + userInfo.platformId())
                 .nickname(platform + " " + userInfo.platformId())
                 .build();
@@ -92,23 +90,18 @@ public class OAuthManagementService {
      * @param userStatus    User, 추가 정보 입력 여부
      * @return              로그인 응답 정보 (JWT, 추가 정보 입력 필요 여부)
      */
-    private SignInDto.Response getSignInDto(UserStatusDto userStatus) {
-        if (!userStatus.shouldSignUp()) {
-            User user = userStatus.user();
-            String username = user.getUsername();
-            String nickname = user.getNickname();
-            Long userId = user.getId();
+    private SignInDto.Response getSignInResponse(UserStatusDto userStatus) {
+        User user = userStatus.user();
+        String username = user.getUsername();
+        String nickname = user.getNickname();
+        Long userId = user.getId();
 
-            TokenDto token = jwtService.generateToken(username, nickname, userId);
-
-            return SignInDto.Response.builder()
-                    .token(token)
-                    .shouldSignup(userStatus.shouldSignUp())
-                    .build();
-        }
+        TokenDto token = jwtService.generateToken(username, nickname, userId);
 
         return SignInDto.Response.builder()
+                .token(token)
                 .shouldSignup(userStatus.shouldSignUp())
                 .build();
+
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -1,7 +1,10 @@
 package kr.co.yeogiga.application.auth.service;
 
+import kr.co.yeogiga.application.auth.dto.SignInDto;
+import kr.co.yeogiga.application.auth.dto.TokenDto;
 import kr.co.yeogiga.application.auth.dto.UserInfoDto;
 import kr.co.yeogiga.application.auth.dto.UserStatusDto;
+import kr.co.yeogiga.common.jwt.JwtHelper;
 import kr.co.yeogiga.domain.oauth.entity.OAuth;
 import kr.co.yeogiga.domain.oauth.service.OAuthService;
 import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
@@ -18,10 +21,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class OAuthManagementService {
     private final OAuthClientFactory oAuthClientFactory;
     private final OAuthService oAuthService;
+    private final JwtHelper jwtHelper;
     private final UserService userService;
 
     @Transactional
-    public void signIn(OAuthPlatform platform, String code) {
+    public SignInDto.Response signIn(OAuthPlatform platform, String code) {
         OAuthClient oAuthClient = oAuthClientFactory.getOAuthClient(platform);
 
         String accessToken = oAuthClient.fetchAccessToken(code);
@@ -29,9 +33,8 @@ public class OAuthManagementService {
 
         UserStatusDto userStatus = getUserStatus(platform, userInfo);
 
-        // HACK: JWT 적용 시 로직 추가
+        return getSignInDto(userStatus);
     }
-
 
     private UserStatusDto getUserStatus(OAuthPlatform platform, UserInfoDto userInfo) {
         return userService.readByPlatformAndPlatformId(platform, userInfo.platformId())
@@ -55,5 +58,26 @@ public class OAuthManagementService {
         oAuthService.save(oauth);
 
         return user;
+    }
+
+    private SignInDto.Response getSignInDto(UserStatusDto userStatus) {
+        if (!userStatus.shouldSignUp()) {
+            User user = userStatus.user();
+            String username = user.getUsername();
+            String nickname = user.getNickname();
+            Long userId = user.getId();
+
+            String accessToken = jwtHelper.generateAccessToken(username, nickname, userId);
+            String refreshToken = jwtHelper.generateRefreshToken(username, nickname, userId);
+
+            return SignInDto.Response.builder()
+                    .token(TokenDto.of(accessToken, refreshToken))
+                    .shouldSignup(userStatus.shouldSignUp())
+                    .build();
+        }
+
+        return SignInDto.Response.builder()
+                .shouldSignup(userStatus.shouldSignUp())
+                .build();
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/type/Device.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/type/Device.java
@@ -1,0 +1,13 @@
+package kr.co.yeogiga.application.auth.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Device {
+    MOBILE("MOBILE"),
+    WEB("WEB");
+
+    private final String value;
+}

--- a/src/main/java/kr/co/yeogiga/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/yeogiga/common/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,6 +39,14 @@ public class GlobalExceptionHandler {
                 .code(CommonErrorType.VALIDATION_ERROR.getCode())
                 .errors(errors)
                 .build());
+    }
+
+    /* Path Variable 예외 처리 */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<?> handleValidationException(final MethodArgumentTypeMismatchException e) {
+        log.error("[Error Occurred] {}", e.getMessage());
+        BaseErrorType error = CommonErrorType.PATH_VARIABLE_VALIDATION_ERROR;
+        return ResponseEntity.status(error.getHttpStatus()).body(ErrorResponse.from(error));
     }
 
     /* 일반 예외 처리 */

--- a/src/main/java/kr/co/yeogiga/common/jwt/JwtHelper.java
+++ b/src/main/java/kr/co/yeogiga/common/jwt/JwtHelper.java
@@ -1,0 +1,41 @@
+package kr.co.yeogiga.common.jwt;
+
+import io.jsonwebtoken.Claims;
+import kr.co.yeogiga.common.jwt.dto.JwtClaims;
+import kr.co.yeogiga.infrastructure.properties.JwtProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class JwtHelper {
+    private final TokenBuilder tokenBuilder;
+    private final TokenParser tokenParser;
+    private final JwtProperties jwtProperties;
+
+    public String generateAccessToken(String username, String nickname, Long userId) {
+        return tokenBuilder.build(username, generateClaims(nickname, userId), jwtProperties.getAccessTokenExpiration());
+    }
+
+    public String generateRefreshToken(String username, String nickname, Long userId) {
+        return tokenBuilder.build(username, generateClaims(nickname, userId), jwtProperties.getRefreshTokenExpiration());
+    }
+
+    public JwtClaims parseClaims(String token) {
+        Claims claims = tokenParser.parseClaims(token);
+
+        return JwtClaims.builder()
+                .nickname(claims.get("nickname", String.class))
+                .username(claims.get("username", String.class))
+                .userId(claims.get("userId", Long.class))
+                .build();
+    }
+
+    private Map<String, Object> generateClaims(String nickname, Long userId) {
+        return Map.of("nickname", nickname,
+                      "userId", userId);
+
+    }
+}

--- a/src/main/java/kr/co/yeogiga/common/jwt/TokenBuilder.java
+++ b/src/main/java/kr/co/yeogiga/common/jwt/TokenBuilder.java
@@ -1,0 +1,32 @@
+package kr.co.yeogiga.common.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Encoder;
+import kr.co.yeogiga.common.jwt.base64.CustomBase64UrlEncoder;
+import kr.co.yeogiga.infrastructure.properties.JwtProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.io.OutputStream;
+import java.util.Date;
+import java.util.Map;
+
+
+@Component
+@RequiredArgsConstructor
+public class TokenBuilder {
+    private final Encoder<OutputStream, OutputStream> base64UrlEncoder = new CustomBase64UrlEncoder();
+    private final JwtProperties jwtProperties;
+
+    public String build(String subject, Map<String, Object> claims, long expiration) {
+        return Jwts.builder()
+                .subject(subject)
+                .claims(claims)
+                .b64Url(base64UrlEncoder)
+                .issuer(jwtProperties.getIssuer())
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(jwtProperties.getSecretKey())
+                .compact();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/common/jwt/TokenParser.java
+++ b/src/main/java/kr/co/yeogiga/common/jwt/TokenParser.java
@@ -1,0 +1,31 @@
+package kr.co.yeogiga.common.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoder;
+import kr.co.yeogiga.common.jwt.base64.CustomBase64UrlDecoder;
+import kr.co.yeogiga.infrastructure.properties.JwtProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.InputStream;
+
+@Component
+public class TokenParser {
+    private final JwtParser jwtParser;
+
+    @Autowired
+    public TokenParser(JwtProperties jwtProperties) {
+        Decoder<InputStream, InputStream> base54UrlDecoder = new CustomBase64UrlDecoder();
+        this.jwtParser = Jwts.parser()
+                .verifyWith(jwtProperties.getSecretKey())
+                .b64Url(base54UrlDecoder)
+                .build();
+    }
+
+    public Claims parseClaims(String token) {
+        return jwtParser.parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/common/jwt/base64/CustomBase64UrlDecoder.java
+++ b/src/main/java/kr/co/yeogiga/common/jwt/base64/CustomBase64UrlDecoder.java
@@ -1,0 +1,21 @@
+package kr.co.yeogiga.common.jwt.base64;
+
+import io.jsonwebtoken.io.Decoder;
+import io.jsonwebtoken.io.DecodingException;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Base64;
+
+public class CustomBase64UrlDecoder implements Decoder<InputStream, InputStream> {
+    @Override
+    public InputStream decode(InputStream inputStream) throws DecodingException {
+        try {
+            byte[] bytes = inputStream.readAllBytes();
+            byte[] decodedBytes = Base64.getUrlDecoder().decode(bytes);
+            return new ByteArrayInputStream(decodedBytes);
+        } catch (Exception e) {
+            throw new RuntimeException("Decoding failed", e);
+        }
+    }
+}

--- a/src/main/java/kr/co/yeogiga/common/jwt/base64/CustomBase64UrlEncoder.java
+++ b/src/main/java/kr/co/yeogiga/common/jwt/base64/CustomBase64UrlEncoder.java
@@ -1,0 +1,14 @@
+package kr.co.yeogiga.common.jwt.base64;
+
+import io.jsonwebtoken.io.Encoder;
+
+import java.io.OutputStream;
+import java.util.Base64;
+
+public class CustomBase64UrlEncoder implements Encoder<OutputStream, OutputStream> {
+    @Override
+    public OutputStream encode(OutputStream outputStream) {
+        Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+        return encoder.wrap(outputStream);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/common/jwt/dto/JwtClaims.java
+++ b/src/main/java/kr/co/yeogiga/common/jwt/dto/JwtClaims.java
@@ -1,0 +1,11 @@
+package kr.co.yeogiga.common.jwt.dto;
+
+import lombok.Builder;
+
+@Builder
+public record JwtClaims(
+        String username,
+        String nickname,
+        Long userId
+) {
+}

--- a/src/main/java/kr/co/yeogiga/common/response/error/type/CommonErrorType.java
+++ b/src/main/java/kr/co/yeogiga/common/response/error/type/CommonErrorType.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum CommonErrorType implements BaseErrorType {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G001", "서버 내부 에러입니다."),
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "G002", "유효성 검증에 실패하였습니다."),
+    PATH_VARIABLE_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "G003", "지원하지 않는 Path Variable 값입니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/kr/co/yeogiga/common/util/CookieUtil.java
+++ b/src/main/java/kr/co/yeogiga/common/util/CookieUtil.java
@@ -1,0 +1,15 @@
+package kr.co.yeogiga.common.util;
+
+import org.springframework.http.ResponseCookie;
+
+public class CookieUtil {
+    public static ResponseCookie createCookie(String key, String value, long maxAge) {
+        return ResponseCookie.from(key, value)
+                .path("/")
+                .httpOnly(true)
+                .maxAge(maxAge)
+                .secure(true)
+                .sameSite("None")
+                .build();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
@@ -33,6 +34,10 @@ public class User extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String nickname;
+
+    @ColumnDefault("false")
+    @Column(name = "signed_up", nullable = false)
+    private boolean signedUp;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -31,6 +31,7 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private String email;
 
+    @Column(nullable = false)
     private String nickname;
 
     @Column(nullable = false)

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -23,6 +23,7 @@ public class User extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private String username;
 
     private String password;
@@ -30,7 +31,6 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private String email;
 
-    @Column(nullable = false)
     private String nickname;
 
     @Column(nullable = false)

--- a/src/main/java/kr/co/yeogiga/domain/user/type/Role.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/type/Role.java
@@ -1,5 +1,5 @@
 package kr.co.yeogiga.domain.user.type;
 
 public enum Role {
-    USER, ADMIN
+    USER, GUEST, ADMIN
 }

--- a/src/main/java/kr/co/yeogiga/infrastructure/properties/JwtProperties.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/properties/JwtProperties.java
@@ -2,7 +2,6 @@ package kr.co.yeogiga.infrastructure.properties;
 
 import io.jsonwebtoken.Jwts;
 import lombok.Getter;
-import lombok.Setter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -11,7 +10,6 @@ import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 
 @Getter
-@Setter
 @Component
 public class JwtProperties {
     @Value("${jwt.secret-key}")

--- a/src/main/java/kr/co/yeogiga/infrastructure/properties/JwtProperties.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/properties/JwtProperties.java
@@ -1,0 +1,29 @@
+package kr.co.yeogiga.infrastructure.properties;
+
+import io.jsonwebtoken.Jwts;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+
+@Getter
+@Setter
+@Component
+public class JwtProperties {
+    @Value("${jwt.secret-key}")
+    String SECRET_KEY;
+    @Value("${jwt.issuer}")
+    String issuer;
+    @Value("${jwt.expiration.access-token}")
+    long accessTokenExpiration;
+    @Value("${jwt.expiration.refresh-token}")
+    long refreshTokenExpiration;
+
+    public SecretKey getSecretKey() {
+        return new SecretKeySpec(SECRET_KEY.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
@@ -10,10 +10,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
+import kr.co.yeogiga.application.auth.type.Device;
 import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @ApiGroup(value = "[OAuth2 인증 API]")
 @Tag(name = "[OAuth2 인증 API]", description = "OAuth2 인증 관련 API")
@@ -66,5 +68,5 @@ public interface OAuthApi {
                                     """)
                     }))
     })
-    ResponseEntity<?> signUp(@PathVariable OAuthPlatform platform, @Valid @RequestBody SignInDto.OAuthRequest request);
+    ResponseEntity<?> signUp(@RequestHeader(value = "device") Device device, @PathVariable OAuthPlatform platform, @Valid @RequestBody SignInDto.OAuthRequest request);
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
@@ -1,0 +1,70 @@
+package kr.co.yeogiga.presentation.auth.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.co.yeogiga.application.auth.dto.SignInDto;
+import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@ApiGroup(value = "[OAuth2 인증 API]")
+@Tag(name = "[OAuth2 인증 API]", description = "OAuth2 인증 관련 API")
+public interface OAuthApi {
+
+    @TrackApi(description = "OAuth2 로그인")
+    @Operation(summary = "OAuth2 로그인", description = "OAuth2를 통한 로그인 API 입니다. 처음 로그인하는 사용자는 '여기가'에 유저 정보를 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "기존 회원가입된 사용자", value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": {
+                                                "token": {
+                                                    "accessToken": "xxxxx.xxxxx.xxxxx",
+                                                    "refreshToken": "xxxxx.xxxxx.xxxxx"
+                                                },
+                                                "shouldSignup": false
+                                            }
+                                        }
+                                    """),
+                            @ExampleObject(name = "첫 로그인 사용자", value = """
+                                        {
+                                             "code": 200,
+                                             "message": "요청이 성공하였습니다.",
+                                             "data": {
+                                                 "token": null,
+                                                 "shouldSignup": true
+                                             }
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "유효성 검사 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "인증 코드 유효성 검사 실패", value = """
+                                        {
+                                            "code": "G002",
+                                            "errors": {
+                                                "code": "인증 코드값은 필수입니다."
+                                            }
+                                        }
+                                    """),
+                            @ExampleObject(name = "플랫폼 유효성 검사 실패", value = """
+                                        {
+                                            "code": "G003",
+                                            "message": "지원하지 않는 Path Variable 값입니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> signUp(@PathVariable OAuthPlatform platform, @Valid @RequestBody SignInDto.OAuthRequest request);
+}

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
@@ -95,5 +95,5 @@ public interface OAuthApi {
                                     """)
                     }))
     })
-    ResponseEntity<?> signUp(@RequestHeader(value = "device") Device device, @PathVariable OAuthPlatform platform, @Valid @RequestBody SignInDto.OAuthRequest request);
+    ResponseEntity<?> signIn(@RequestHeader(value = "device") Device device, @PathVariable(name = "platform") OAuthPlatform platform, @Valid @RequestBody SignInDto.OAuthRequest request);
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
@@ -39,7 +39,20 @@ public interface OAuthApi {
                                             }
                                         }
                                     """),
-                            @ExampleObject(name = "기존 회원가입된 사용자(웹)", value = """
+                            @ExampleObject(name = "기존 회원가입되지 않은 사용자(모바일)",  description = "추가 정보 입력(회원가입) 후 토큰 갱신 필요", value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": {
+                                                "token": {
+                                                    "accessToken": "xxxxx.xxxxx.xxxxx",
+                                                    "refreshToken": "xxxxx.xxxxx.xxxxx"
+                                                },
+                                                "shouldSignup": true
+                                            }
+                                        }
+                                    """),
+                            @ExampleObject(name = "기존 회원가입된 사용자(웹)", description = "웹은 refresh token이 쿠키로 전달", value = """
                                         {
                                              "code": 200,
                                              "message": "요청이 성공하였습니다.",
@@ -51,15 +64,17 @@ public interface OAuthApi {
                                              }
                                          }
                                     """),
-                            @ExampleObject(name = "첫 로그인 사용자", value = """
+                            @ExampleObject(name = "기존 회원가입되지 않은 사용자(웹)", description = "추가 정보 입력(회원가입) 후 토큰 갱신 필요 / 웹은 refresh token이 쿠키로 전달", value = """
                                         {
                                              "code": 200,
                                              "message": "요청이 성공하였습니다.",
                                              "data": {
-                                                 "token": null,
+                                                 "token": {
+                                                     "accessToken": "xxxxx.xxxxx.xxxxx"
+                                                 },
                                                  "shouldSignup": true
                                              }
-                                        }
+                                         }
                                     """)
                     })),
             @ApiResponse(responseCode = "400", description = "유효성 검사 실패",

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
@@ -26,7 +26,7 @@ public interface OAuthApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "로그인 성공",
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name = "기존 회원가입된 사용자", value = """
+                            @ExampleObject(name = "기존 회원가입된 사용자(모바일)", value = """
                                         {
                                             "code": 200,
                                             "message": "요청이 성공하였습니다.",
@@ -38,6 +38,18 @@ public interface OAuthApi {
                                                 "shouldSignup": false
                                             }
                                         }
+                                    """),
+                            @ExampleObject(name = "기존 회원가입된 사용자(웹)", value = """
+                                        {
+                                             "code": 200,
+                                             "message": "요청이 성공하였습니다.",
+                                             "data": {
+                                                 "token": {
+                                                     "accessToken": "xxxxx.xxxxx.xxxxx"
+                                                 },
+                                                 "shouldSignup": false
+                                             }
+                                         }
                                     """),
                             @ExampleObject(name = "첫 로그인 사용자", value = """
                                         {

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.presentation.auth.controller;
 import jakarta.validation.Valid;
 import kr.co.yeogiga.application.auth.constant.AuthConstants;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
+import kr.co.yeogiga.application.auth.dto.TokenDto;
 import kr.co.yeogiga.application.auth.service.OAuthManagementService;
 import kr.co.yeogiga.application.auth.type.Device;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
@@ -31,27 +32,34 @@ public class OAuthController implements OAuthApi {
     public ResponseEntity<?> signUp(
             @RequestHeader(value = "device") Device device,
             @PathVariable OAuthPlatform platform,
-            @Valid @RequestBody SignInDto.OAuthRequest request)
-    {
+            @Valid @RequestBody SignInDto.OAuthRequest request) {
         return createSignInResponse(device, oAuthManagementService.signIn(platform, request.code()));
     }
 
     private ResponseEntity<?> createSignInResponse(Device device, SignInDto.Response response) {
-
         if (response.shouldSignup()) {
-            return ResponseEntity.ok(response);
+            return ResponseEntity.ok(SuccessResponse.from(response));
         }
 
-        return switch(device) {
+        return switch (device) {
             case MOBILE -> ResponseEntity.ok(SuccessResponse.from(response));
-            case WEB -> ResponseEntity.ok()
-                            .header(HttpHeaders.SET_COOKIE,
-                                    CookieUtil.createCookie(
-                                        AuthConstants.REFRESH_TOKEN_PREFIX.getValue(),
-                                        response.token().refreshToken(),
-                                        Duration.ofDays(7).toSeconds()
-                                    ).toString()
-                    ).body(SuccessResponse.from(SignInDto.ResponseForWeb.from(response)));
+            case WEB -> {
+                TokenDto token = TokenDto.builder()
+                        .accessToken(response.token().accessToken())
+                        .build();
+
+                String cookie = CookieUtil.createCookie(
+                        AuthConstants.REFRESH_TOKEN_PREFIX.getValue(),
+                        response.token().refreshToken(),
+                        Duration.ofDays(7).toSeconds()).toString();
+
+                yield ResponseEntity.ok()
+                        .header(HttpHeaders.SET_COOKIE, cookie)
+                        .body(SuccessResponse.from(SignInDto.Response.builder()
+                                .token(token)
+                                .build()
+                        ));
+            }
         };
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
@@ -37,6 +37,11 @@ public class OAuthController implements OAuthApi {
     }
 
     private ResponseEntity<?> createSignInResponse(Device device, SignInDto.Response response) {
+
+        if (response.shouldSignup()) {
+            return ResponseEntity.ok(response);
+        }
+
         return switch(device) {
             case MOBILE -> ResponseEntity.ok(SuccessResponse.from(response));
             case WEB -> ResponseEntity.ok()
@@ -46,7 +51,7 @@ public class OAuthController implements OAuthApi {
                                         response.token().refreshToken(),
                                         Duration.ofDays(7).toSeconds()
                                     ).toString()
-                    ).body(SuccessResponse.from(SignInDto.ResponseToWeb.from(response)));
+                    ).body(SuccessResponse.from(SignInDto.ResponseForWeb.from(response)));
         };
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
@@ -3,7 +3,6 @@ package kr.co.yeogiga.presentation.auth.controller;
 import jakarta.validation.Valid;
 import kr.co.yeogiga.application.auth.constant.AuthConstants;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
-import kr.co.yeogiga.application.auth.dto.TokenDto;
 import kr.co.yeogiga.application.auth.service.OAuthManagementService;
 import kr.co.yeogiga.application.auth.type.Device;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
@@ -37,29 +36,14 @@ public class OAuthController implements OAuthApi {
     }
 
     private ResponseEntity<?> createSignInResponse(Device device, SignInDto.Response response) {
-        if (response.shouldSignup()) {
-            return ResponseEntity.ok(SuccessResponse.from(response));
-        }
-
         return switch (device) {
             case MOBILE -> ResponseEntity.ok(SuccessResponse.from(response));
-            case WEB -> {
-                TokenDto token = TokenDto.builder()
-                        .accessToken(response.token().accessToken())
-                        .build();
-
-                String cookie = CookieUtil.createCookie(
-                        AuthConstants.REFRESH_TOKEN_PREFIX.getValue(),
-                        response.token().refreshToken(),
-                        Duration.ofDays(7).toSeconds()).toString();
-
-                yield ResponseEntity.ok()
-                        .header(HttpHeaders.SET_COOKIE, cookie)
-                        .body(SuccessResponse.from(SignInDto.Response.builder()
-                                .token(token)
-                                .build()
-                        ));
-            }
+            case WEB -> ResponseEntity.ok()
+                        .header(HttpHeaders.SET_COOKIE, CookieUtil.createCookie(
+                                AuthConstants.REFRESH_TOKEN_PREFIX.getValue(),
+                                response.token().refreshToken(),
+                                Duration.ofDays(7).toSeconds()).toString())
+                        .body(SuccessResponse.from(response.toWebResponse()));
         };
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
@@ -1,26 +1,28 @@
 package kr.co.yeogiga.presentation.auth.controller;
 
-import kr.co.yeogiga.application.auth.dto.OAuthSignInDto;
+import jakarta.validation.Valid;
+import kr.co.yeogiga.application.auth.dto.SignInDto;
 import kr.co.yeogiga.application.auth.service.OAuthManagementService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
+import kr.co.yeogiga.presentation.auth.api.OAuthApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth/oauth")
-public class OAuthController {
+public class OAuthController implements OAuthApi {
     private final OAuthManagementService oAuthManagementService;
 
     @PostMapping("/sign-in/{platform}")
-    public ResponseEntity<?> signUp(@PathVariable OAuthPlatform platform, @RequestBody OAuthSignInDto.Request request) {
+    public ResponseEntity<?> signUp(@PathVariable OAuthPlatform platform, @Valid @RequestBody SignInDto.OAuthRequest request) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessResponse.from(oAuthManagementService.signIn(platform, request.code())));
     }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
@@ -28,9 +28,9 @@ public class OAuthController implements OAuthApi {
     private final OAuthManagementService oAuthManagementService;
 
     @PostMapping("/sign-in/{platform}")
-    public ResponseEntity<?> signUp(
+    public ResponseEntity<?> signIn(
             @RequestHeader(value = "device") Device device,
-            @PathVariable OAuthPlatform platform,
+            @PathVariable(name = "platform") OAuthPlatform platform,
             @Valid @RequestBody SignInDto.OAuthRequest request) {
         return createSignInResponse(device, oAuthManagementService.signIn(platform, request.code()));
     }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
@@ -2,8 +2,10 @@ package kr.co.yeogiga.presentation.auth.controller;
 
 import kr.co.yeogiga.application.auth.dto.OAuthSignInDto;
 import kr.co.yeogiga.application.auth.service.OAuthManagementService;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,10 +21,8 @@ public class OAuthController {
 
     @PostMapping("/sign-in/{platform}")
     public ResponseEntity<?> signUp(@PathVariable OAuthPlatform platform, @RequestBody OAuthSignInDto.Request request) {
-        oAuthManagementService.signIn(platform, request.code());
-
-        // HACK: JWT 적용 시 응답 수정
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponse.from(oAuthManagementService.signIn(platform, request.code())));
     }
 }
 

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
@@ -1,19 +1,25 @@
 package kr.co.yeogiga.presentation.auth.controller;
 
 import jakarta.validation.Valid;
+import kr.co.yeogiga.application.auth.constant.AuthConstants;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
 import kr.co.yeogiga.application.auth.service.OAuthManagementService;
+import kr.co.yeogiga.application.auth.type.Device;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.common.util.CookieUtil;
 import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
 import kr.co.yeogiga.presentation.auth.api.OAuthApi;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Duration;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,9 +28,26 @@ public class OAuthController implements OAuthApi {
     private final OAuthManagementService oAuthManagementService;
 
     @PostMapping("/sign-in/{platform}")
-    public ResponseEntity<?> signUp(@PathVariable OAuthPlatform platform, @Valid @RequestBody SignInDto.OAuthRequest request) {
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(SuccessResponse.from(oAuthManagementService.signIn(platform, request.code())));
+    public ResponseEntity<?> signUp(
+            @RequestHeader(value = "device") Device device,
+            @PathVariable OAuthPlatform platform,
+            @Valid @RequestBody SignInDto.OAuthRequest request)
+    {
+        return createSignInResponse(device, oAuthManagementService.signIn(platform, request.code()));
+    }
+
+    private ResponseEntity<?> createSignInResponse(Device device, SignInDto.Response response) {
+        return switch(device) {
+            case MOBILE -> ResponseEntity.ok(SuccessResponse.from(response));
+            case WEB -> ResponseEntity.ok()
+                            .header(HttpHeaders.SET_COOKIE,
+                                    CookieUtil.createCookie(
+                                        AuthConstants.REFRESH_TOKEN_PREFIX.getValue(),
+                                        response.token().refreshToken(),
+                                        Duration.ofDays(7).toSeconds()
+                                    ).toString()
+                    ).body(SuccessResponse.from(SignInDto.ResponseToWeb.from(response)));
+        };
     }
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,11 @@ oauth2:
     redirect-uri: ${KAKAO_REDIRECT_URI}
     token-uri: ${KAKAO_TOKEN_URI}
     user-info-uri: ${KAKAO_USER_INFO_URI}
+
+--- # jwt
+jwt:
+  secret-key: ${JWT_KEY:exampleSecretKeyForIlmansaSystemAccessSecretKeyTestForPadding}
+  issuer: ${JWT_ISSUER:ilmansa}
+  expiration:
+    access-token: ${JWT_AT_EXPIRATION:1800000}
+    refresh-token: ${JWT_RT_EXPIRATION:86400000}

--- a/src/test/java/kr/co/yeogiga/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/kr/co/yeogiga/domain/user/repository/UserRepositoryTest.java
@@ -54,6 +54,7 @@ public class UserRepositoryTest {
         // given
         User relatedUser = User.builder()
                 .email("fromPlatformt@test.com")
+                .username("fromPlatform")
                 .nickname("tempNickname")
                 .role(Role.USER)
                 .build();

--- a/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthControllerTest.java
@@ -1,0 +1,241 @@
+package kr.co.yeogiga.presentation.oauth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.application.auth.dto.SignInDto;
+import kr.co.yeogiga.application.auth.dto.TokenDto;
+import kr.co.yeogiga.application.auth.service.OAuthManagementService;
+import kr.co.yeogiga.application.auth.type.Device;
+import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
+import kr.co.yeogiga.presentation.auth.controller.OAuthController;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(OAuthController.class)
+public class OAuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private OAuthManagementService oAuthManagementService;
+
+    private Device device;
+    private OAuthPlatform oAuthPlatform;
+    private SignInDto.OAuthRequest request;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .alwaysDo(print())
+                .build();
+
+        request = SignInDto.OAuthRequest.builder()
+                .code("testCode")
+                .build();
+    }
+
+    void setSignInMethod(boolean shouldSignup) {
+        when(oAuthManagementService.signIn(any(), any())).thenReturn(
+                SignInDto.Response.builder()
+                        .token(TokenDto.builder()
+                                .accessToken("test_access_token")
+                                .refreshToken("test_refresh_token")
+                                .build())
+                        .shouldSignup(shouldSignup)
+                        .build()
+        );
+    }
+
+    @Test
+    @DisplayName("처음 로그인한 사용자 (웹)")
+    void signInFirstFromWeb() throws Exception {
+        // given
+        device = Device.WEB;
+        oAuthPlatform = OAuthPlatform.NAVER;
+        setSignInMethod(true);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/auth/oauth/sign-in/{platform}", oAuthPlatform)
+                        .header("device", device.name())
+                        .content(objectMapper.writeValueAsBytes(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("refreshToken"))
+                .andExpect(jsonPath("$.data.token.accessToken").exists())
+                .andExpect(jsonPath("$.data.shouldSignup").value(true));
+    }
+
+    @Test
+    @DisplayName("처음 로그인한 사용자 (모바일)")
+    void signInFirstFormMobile() throws Exception {
+        // given
+        device = Device.MOBILE;
+        oAuthPlatform = OAuthPlatform.NAVER;
+        setSignInMethod(true);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/auth/oauth/sign-in/{platform}", oAuthPlatform)
+                        .header("device", device.name())
+                        .content(objectMapper.writeValueAsBytes(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(cookie().doesNotExist("refreshToken"))
+                .andExpect(jsonPath("$.data.token.accessToken").exists())
+                .andExpect(jsonPath("$.data.token.refreshToken").exists())
+                .andExpect(jsonPath("$.data.shouldSignup").value(true));
+    }
+
+    @Test
+    @DisplayName("이미 회원가입한 사용자 (웹)")
+    void signInFromWeb() throws Exception {
+        // given
+        device = Device.WEB;
+        oAuthPlatform = OAuthPlatform.NAVER;
+        setSignInMethod(false);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/auth/oauth/sign-in/{platform}", oAuthPlatform)
+                        .header("device", device.name())
+                        .content(objectMapper.writeValueAsBytes(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("refreshToken"))
+                .andExpect(jsonPath("$.data.token.accessToken").exists())
+                .andExpect(jsonPath("$.data.shouldSignup").value(false));
+    }
+
+    @Test
+    @DisplayName("이미 회원가입한 사용자 (모바일)")
+    void signInFormMobile() throws Exception {
+        // given
+        device = Device.MOBILE;
+        oAuthPlatform = OAuthPlatform.NAVER;
+        setSignInMethod(false);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/auth/oauth/sign-in/{platform}", oAuthPlatform)
+                        .header("device", device.name())
+                        .content(objectMapper.writeValueAsBytes(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(cookie().doesNotExist("refreshToken"))
+                .andExpect(jsonPath("$.data.token.accessToken").exists())
+                .andExpect(jsonPath("$.data.token.refreshToken").exists())
+                .andExpect(jsonPath("$.data.shouldSignup").value(false));
+    }
+
+    @Test
+    @DisplayName("OAuth 인증 코드 누락")
+    void missOAuthCode() throws Exception {
+        // given
+        device = Device.MOBILE;
+        oAuthPlatform = OAuthPlatform.NAVER;
+        SignInDto.OAuthRequest req = SignInDto.OAuthRequest.builder()
+                        .build();
+
+
+        setSignInMethod(false);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/auth/oauth/sign-in/{platform}", oAuthPlatform)
+                        .header("device", device.name())
+                        .content(objectMapper.writeValueAsBytes(req))
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().is(400))
+                .andExpect(jsonPath("$.code").value("G002"));
+    }
+
+    @Test
+    @DisplayName("OAuth 인증 코드 공백값")
+    void emptyOAuthCode() throws Exception {
+        // given
+        device = Device.MOBILE;
+        oAuthPlatform = OAuthPlatform.NAVER;
+        SignInDto.OAuthRequest req = SignInDto.OAuthRequest.builder()
+                .code("   ")
+                .build();
+
+
+        setSignInMethod(false);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/auth/oauth/sign-in/{platform}", oAuthPlatform)
+                        .header("device", device.name())
+                        .content(objectMapper.writeValueAsBytes(req))
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().is(400))
+                .andExpect(jsonPath("$.code").value("G002"));
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 플랫폼")
+    void unsupportedPlatform() throws Exception {
+        // given
+        device = Device.MOBILE;
+        setSignInMethod(false);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/auth/oauth/sign-in/{platform}", "MISS_VALUE")
+                        .header("device", device.name())
+                        .content(objectMapper.writeValueAsBytes(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().is(400))
+                .andExpect(jsonPath("$.code").value("G003"));
+    }
+}


### PR DESCRIPTION
## 배경
- JWT를 통한 사용자 인증 필요
- JWT 도입 후 OAuth 로그인 응답값 변경

## 작업 사항
- JWT 추가
   - jjwt 디펜던시를 참고하여 Builder와 Parser 클래스를 분리하여 구성하였습니다. 
   - `JwtHelper`에서 `TokenBuilder`와 `TokenParser`를 주입받아 사용합니다.
   - subject: `username` / claims: `nickname`, `userId`
      - 이에 따른 username 값 not null 제약 추가
- User 엔티티 컬럼 변경
    - `signed_up` 컬럼 추가 

- JWT 추가 후 OAuth 소셜 로그인 응답값 변경
- 사용자 접속 디바이스(MOBILE/WEB) 별 응답값 분리 
    - 모바일 환경 Cookie 전달 시 httpOnly 미적용되는 현상으로 인한 분리
```
// 기존 회원가입된 사용자(모바일)가 로그인한 경우
{
    "code": 200,
    "message": "요청이 성공하였습니다.",
    "data": {
        "token": {
            "accessToken": "xxxxx.xxxxx.xxxxx",
            "refreshToken": "xxxxx.xxxxx.xxxxx"
        },
        "shouldSignup": false
    }
}
```

```
// 기존 회원가입된 사용자(웹)가 로그인한 경우 - refresh token은 쿠키로 전달
{
    "code": 200,
    "message": "요청이 성공하였습니다.",
    "data": {
        "token": {
            "accessToken": "xxxxx.xxxxx.xxxxx",
        },
        "shouldSignup": false
    }
}
```

```
// 첫 로그인 사용자가 로그인한 경우
{
  "code": 200,
  "message": "요청이 성공하였습니다.",
  "data": {
    "token": null,
    "shouldSignup": true
  }
}
```

- 스웨거 문서 최신화
- PathVariable로 전달되는 OAuthPlatform 불일치 글로벌 예외처리 추가 - (2e26d93476e8264a2bac2cbfc6fc5e04c9b3b539)
## 추가 논의

- 차후 JwtAuthenticationFilter 적용
- 데이터베이스 스키마 변경으로 인한 DB 테이블 삭제 예정