### PR TITLE
Feature(IL-40): 목적지 저장을 위한 MongoDB Document 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/domain/oauth/exception/OAuthErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/oauth/exception/OAuthErrorType.java
@@ -19,16 +19,16 @@ public enum OAuthErrorType implements BaseErrorType {
 
     @Override
     public HttpStatus getHttpStatus() {
-        return null;
+        return httpStatus;
     }
 
     @Override
     public String getCode() {
-        return "";
+        return code;
     }
 
     @Override
     public String getMessage() {
-        return "";
+        return message;
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/oauth/exception/OAuthErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/oauth/exception/OAuthErrorType.java
@@ -4,11 +4,14 @@ import kr.co.yeogiga.common.response.error.type.BaseErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+/**
+ * OAuth ErrorCode: Oxxx
+ */
 @RequiredArgsConstructor
 public enum OAuthErrorType implements BaseErrorType {
 
     OAUTH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "O001", "소셜 로그인 과정에서 에러가 발생하였습니다. 관리자에게 문의하세요."),
-    UNSUPPORTED_PLATFORM(HttpStatus.BAD_REQUEST, "O0002", "지원하지 않는 소셜 로그인 플랫폼입니다.");
+    UNSUPPORTED_PLATFORM(HttpStatus.BAD_REQUEST, "O002", "지원하지 않는 소셜 로그인 플랫폼입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
@@ -19,16 +19,16 @@ public enum TripErrorType implements BaseErrorType {
 
     @Override
     public HttpStatus getHttpStatus() {
-        return null;
+        return httpStatus;
     }
 
     @Override
     public String getCode() {
-        return "";
+        return code;
     }
 
     @Override
     public String getMessage() {
-        return "";
+        return message;
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
@@ -1,0 +1,34 @@
+package kr.co.yeogiga.domain.trip.exception;
+
+import kr.co.yeogiga.common.response.error.type.BaseErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Trip ErrorCode: Txxx
+ */
+@RequiredArgsConstructor
+public enum TripErrorType implements BaseErrorType {
+
+    INVALID_PLACE(HttpStatus.BAD_REQUEST, "T001", "지원하지 않는 카테고리입니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return null;
+    }
+
+    @Override
+    public String getCode() {
+        return "";
+    }
+
+    @Override
+    public String getMessage() {
+        return "";
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
@@ -1,16 +1,13 @@
 package kr.co.yeogiga.domain.tripplace.entity;
 
 import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Place {
     private String id;
     private String name;

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
@@ -1,0 +1,33 @@
+package kr.co.yeogiga.domain.tripplace.entity;
+
+import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Place {
+    private String id;
+    private String name;
+    private double latitude;
+    private double longitude;
+    private PlaceCategory type;
+    private double order;
+    private LocalDateTime visitedAt;
+
+    @Builder
+    public Place(String name, double latitude, double longitude, PlaceCategory type, double order, LocalDateTime visitedAt) {
+        this.id = UUID.randomUUID().toString();
+        this.name = name;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.type = type;
+        this.order = order;
+        this.visitedAt = visitedAt;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/TripDayPlace.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/TripDayPlace.java
@@ -1,0 +1,31 @@
+package kr.co.yeogiga.domain.tripplace.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collation = "trip_day_place")
+public class TripDayPlace {
+    @Id
+    private String id;
+    private Long tripId;
+    private int day;
+    private LocalDate date;
+    private List<Place> places;
+
+    @Builder
+    public TripDayPlace(Long tripId, int day, LocalDate date, List<Place> places) {
+        this.tripId = tripId;
+        this.day = day;
+        this.date = date;
+        this.places = places;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/TripDayPlace.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/TripDayPlace.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Document(collation = "trip_day_place")
+@Document(collection = "trip_day_place")
 public class TripDayPlace {
     @Id
     private String id;

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/type/PlaceCategory.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/type/PlaceCategory.java
@@ -1,0 +1,60 @@
+package kr.co.yeogiga.domain.tripplace.type;
+
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@RequiredArgsConstructor
+public enum PlaceCategory {
+
+    RESTAURANT("음식점", CategoryGroup.식당),
+    CAFE("카페", CategoryGroup.식당),
+
+    TOURIST_SPOT("관광명소", CategoryGroup.관광지),
+    CULTURE_FACILITY("문화시설", CategoryGroup.관광지),
+
+    LODGING("숙박", CategoryGroup.숙소),
+
+    ETC("기타", CategoryGroup.기타)
+    ;
+
+    private final String label;
+    private final CategoryGroup group;
+
+    private static final Map<String, PlaceCategory> LABEL_MAP = new HashMap<>();
+
+    static {
+        for (PlaceCategory type : values()) {
+            LABEL_MAP.put(type.label, type);
+        }
+    }
+
+    /**
+     * 전달된 문자열 라벨에 해당하는 PlaceCategory enum을 반환
+     *
+     * @param label : 클라이언트가 전달한 키워드 문자열
+     * @return : 해당 키워드에 대응하는 PlaceCategory enum
+     * @throws CustomException INVALID_PLACE : 유효하지 않은 장소일 경우 예외 발생
+     */
+    public static PlaceCategory fromLabel(String label) {
+        PlaceCategory placeCategory = LABEL_MAP.get(label);
+        if (placeCategory == null) {
+            throw new CustomException(TripErrorType.INVALID_PLACE);
+        }
+        return placeCategory;
+    }
+
+    public String getGroupName() {
+        return group.name();
+    }
+
+    enum CategoryGroup {
+        식당, 관광지, 숙소, 기타
+    }
+}
+


### PR DESCRIPTION
## 배경
여행 목적지를 NoSQL에 저장하기 위해 Document의 필요성

## 작업 사항
- 여행 목적지 저장을 위한 Document 구현 (770ccf5a92808d3a57e0e5bec5bc78d79ebec3d2)
- 목적지 카테고리 enum 생성 (b72d26257ffabb7f8e00d0541701750b84114d58)

## 추가 논의
- `PlaceCategory` 안에 있는 `enum CategoryGroup`는 피그마에 있는 카테고리별로 설정한 것이고, `enum PlaceCategory`에 적어둔 값들은, 카카오 지도의 `category_group_name`응답을 기준으로 관련있는 값들을 가져온 것입니다.
 변경해야할 사항 있다면 말씀해주세요 (혹시몰라 아래에 카카오 그룹 내용 첨부하겠습니다.
<img width="441" alt="스크린샷 2025-04-19 오후 10 59 26" src="https://github.com/user-attachments/assets/d817fa77-de3a-48ca-836e-1330e0e4fd2f" />
<img width="562" alt="스크린샷 2025-04-19 오후 10 59 22" src="https://github.com/user-attachments/assets/568d59f6-0087-412e-a4ea-1971657892bc" />
