### PR TITLE
Feature(IL-42): Spring Security 도입 및 JWT를 통한 인증 로직

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,9 @@ dependencies {
     /* MongoDB */
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
-//    implementation 'org.springframework.boot:spring-boot-starter-security'
-//    testImplementation 'org.springframework.security:spring-security-test'
+    /* Spring Security */
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/co/yeogiga/application/auth/constant/AuthConstants.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/constant/AuthConstants.java
@@ -1,7 +1,8 @@
 package kr.co.yeogiga.application.auth.constant;
 
 public final class AuthConstants {
-    private AuthConstants() {}
+    private AuthConstants() { }
 
+    public static final String TOKEN_TYPE = "Bearer";
     public static final String REFRESH_TOKEN_PREFIX = "refreshToken";
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/constant/AuthConstants.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/constant/AuthConstants.java
@@ -1,13 +1,7 @@
 package kr.co.yeogiga.application.auth.constant;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+public final class AuthConstants {
+    private AuthConstants() {}
 
-@Getter
-@RequiredArgsConstructor
-public enum AuthConstants {
-    REFRESH_TOKEN_PREFIX("refreshToken");
-
-    private final String value;
-
+    public static final String REFRESH_TOKEN_PREFIX = "refreshToken";
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/service/JwtService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/JwtService.java
@@ -15,4 +15,9 @@ public class JwtService {
                 jwtHelper.generateAccessToken(username, nickname, userId),
                 jwtHelper.generateRefreshToken(username, nickname, userId));
     }
+
+    public Long extractUserId(String token) {
+        return jwtHelper.parseClaims(token)
+                .userId();
+    }
 }

--- a/src/main/java/kr/co/yeogiga/common/jwt/JwtHelper.java
+++ b/src/main/java/kr/co/yeogiga/common/jwt/JwtHelper.java
@@ -8,12 +8,18 @@ import org.springframework.stereotype.Component;
 
 import java.util.Map;
 
+import static kr.co.yeogiga.application.auth.constant.AuthConstants.TOKEN_TYPE;
+
 @Component
 @RequiredArgsConstructor
 public class JwtHelper {
     private final TokenBuilder tokenBuilder;
     private final TokenParser tokenParser;
     private final JwtProperties jwtProperties;
+
+    public static String resolveToken(String token) {
+        return token.replace(TOKEN_TYPE, "").trim();
+    }
 
     public String generateAccessToken(String username, String nickname, Long userId) {
         return tokenBuilder.build(username, generateClaims(nickname, userId), jwtProperties.getAccessTokenExpiration());

--- a/src/main/java/kr/co/yeogiga/common/jwt/JwtHelper.java
+++ b/src/main/java/kr/co/yeogiga/common/jwt/JwtHelper.java
@@ -8,18 +8,12 @@ import org.springframework.stereotype.Component;
 
 import java.util.Map;
 
-import static kr.co.yeogiga.application.auth.constant.AuthConstants.TOKEN_TYPE;
-
 @Component
 @RequiredArgsConstructor
 public class JwtHelper {
     private final TokenBuilder tokenBuilder;
     private final TokenParser tokenParser;
     private final JwtProperties jwtProperties;
-
-    public static String resolveToken(String token) {
-        return token.replace(TOKEN_TYPE, "").trim();
-    }
 
     public String generateAccessToken(String username, String nickname, Long userId) {
         return tokenBuilder.build(username, generateClaims(nickname, userId), jwtProperties.getAccessTokenExpiration());

--- a/src/main/java/kr/co/yeogiga/common/jwt/JwtUtil.java
+++ b/src/main/java/kr/co/yeogiga/common/jwt/JwtUtil.java
@@ -1,0 +1,9 @@
+package kr.co.yeogiga.common.jwt;
+
+import static kr.co.yeogiga.application.auth.constant.AuthConstants.TOKEN_TYPE;
+
+public class JwtUtil {
+    public static String resolveToken(String token) {
+        return token.replace(TOKEN_TYPE, "").trim();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/common/response/error/type/CommonErrorType.java
+++ b/src/main/java/kr/co/yeogiga/common/response/error/type/CommonErrorType.java
@@ -11,11 +11,6 @@ public enum CommonErrorType implements BaseErrorType {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G001", "서버 내부 에러입니다."),
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "G002", "유효성 검증에 실패하였습니다."),
     PATH_VARIABLE_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "G003", "지원하지 않는 Path Variable 값입니다."),
-
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "G004", "만료된 토큰입니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "G005", "잘못된 토큰입니다."),
-    INVALID_TOKEN_SIGNATURE(HttpStatus.UNAUTHORIZED, "G006", "토큰 서명이 잘못되었습니다."),
-    UNKNOWN_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, "G007", "토큰 인증 과정 중 에러가 발생하였습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/kr/co/yeogiga/common/response/error/type/CommonErrorType.java
+++ b/src/main/java/kr/co/yeogiga/common/response/error/type/CommonErrorType.java
@@ -3,11 +3,19 @@ package kr.co.yeogiga.common.response.error.type;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+/**
+ * Common ErrorCode: Gxxx
+ */
 @RequiredArgsConstructor
 public enum CommonErrorType implements BaseErrorType {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G001", "서버 내부 에러입니다."),
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "G002", "유효성 검증에 실패하였습니다."),
-    PATH_VARIABLE_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "G003", "지원하지 않는 Path Variable 값입니다.")
+    PATH_VARIABLE_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "G003", "지원하지 않는 Path Variable 값입니다."),
+
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "G004", "만료된 토큰입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "G005", "잘못된 토큰입니다."),
+    INVALID_TOKEN_SIGNATURE(HttpStatus.UNAUTHORIZED, "G006", "토큰 서명이 잘못되었습니다."),
+    UNKNOWN_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, "G007", "토큰 인증 과정 중 에러가 발생하였습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/kr/co/yeogiga/common/security/auth/CustomUserDetails.java
+++ b/src/main/java/kr/co/yeogiga/common/security/auth/CustomUserDetails.java
@@ -1,0 +1,8 @@
+package kr.co.yeogiga.common.security.auth;
+
+import kr.co.yeogiga.domain.user.type.Role;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public interface CustomUserDetails extends UserDetails {
+    public Role getRole();
+}

--- a/src/main/java/kr/co/yeogiga/common/security/auth/CustomUserDetails.java
+++ b/src/main/java/kr/co/yeogiga/common/security/auth/CustomUserDetails.java
@@ -4,5 +4,6 @@ import kr.co.yeogiga.domain.user.type.Role;
 import org.springframework.security.core.userdetails.UserDetails;
 
 public interface CustomUserDetails extends UserDetails {
-    public Role getRole();
+    Role getRole();
+    Long getUserId();
 }

--- a/src/main/java/kr/co/yeogiga/common/security/auth/CustomUserDetailsImpl.java
+++ b/src/main/java/kr/co/yeogiga/common/security/auth/CustomUserDetailsImpl.java
@@ -21,6 +21,11 @@ public class CustomUserDetailsImpl implements CustomUserDetails {
     }
 
     @Override
+    public Long getUserId() {
+        return user.getId();
+    }
+
+    @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> authorities = new ArrayList<>();
         authorities.add(new SimpleGrantedAuthority(user.getRole().name()));
@@ -29,7 +34,7 @@ public class CustomUserDetailsImpl implements CustomUserDetails {
 
     @Override
     public String getPassword() {
-        return user.getPassword();
+        return null;
     }
 
     @Override

--- a/src/main/java/kr/co/yeogiga/common/security/auth/CustomUserDetailsImpl.java
+++ b/src/main/java/kr/co/yeogiga/common/security/auth/CustomUserDetailsImpl.java
@@ -1,0 +1,39 @@
+package kr.co.yeogiga.common.security.auth;
+
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.type.Role;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetailsImpl implements CustomUserDetails {
+    private final User user;
+
+    @Override
+    public Role getRole() {
+        return user.getRole();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(user.getRole().name()));
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/common/security/auth/UserDetailsServiceImpl.java
+++ b/src/main/java/kr/co/yeogiga/common/security/auth/UserDetailsServiceImpl.java
@@ -1,0 +1,21 @@
+package kr.co.yeogiga.common.security.auth;
+
+import kr.co.yeogiga.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+    private final UserService userService;
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        return userService.readById(Long.parseLong(userId))
+                .map(CustomUserDetailsImpl::new)
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 사용자입니다."));
+    }
+}

--- a/src/main/java/kr/co/yeogiga/common/security/filter/AccessDeniedHandlerImpl.java
+++ b/src/main/java/kr/co/yeogiga/common/security/filter/AccessDeniedHandlerImpl.java
@@ -1,0 +1,44 @@
+package kr.co.yeogiga.common.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.yeogiga.common.response.error.ErrorResponse;
+import kr.co.yeogiga.common.response.error.type.BaseErrorType;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
+import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
+import kr.co.yeogiga.domain.user.type.Role;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class AccessDeniedHandlerImpl implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetailsImpl userDetails = (CustomUserDetailsImpl) authentication.getPrincipal();
+
+        BaseErrorType error = userDetails.getRole() == Role.GUEST
+                ? AuthErrorType.UN_REGISTERED_USER
+                : AuthErrorType.FORBIDDEN;
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.from(error)));
+    }
+
+}

--- a/src/main/java/kr/co/yeogiga/common/security/filter/AccessDeniedHandlerImpl.java
+++ b/src/main/java/kr/co/yeogiga/common/security/filter/AccessDeniedHandlerImpl.java
@@ -10,7 +10,6 @@ import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
 import kr.co.yeogiga.domain.user.type.Role;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/kr/co/yeogiga/common/security/filter/AuthenticationEntryPointImpl.java
+++ b/src/main/java/kr/co/yeogiga/common/security/filter/AuthenticationEntryPointImpl.java
@@ -1,0 +1,33 @@
+package kr.co.yeogiga.common.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.yeogiga.common.response.error.ErrorResponse;
+import kr.co.yeogiga.common.response.error.type.BaseErrorType;
+import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, org.springframework.security.core.AuthenticationException authException) throws IOException, ServletException {
+        BaseErrorType error = AuthErrorType.NOT_AUTHORIZATION;
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.from(error)));
+    }
+}

--- a/src/main/java/kr/co/yeogiga/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/co/yeogiga/common/security/filter/JwtAuthenticationFilter.java
@@ -5,7 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import kr.co.yeogiga.application.auth.service.JwtService;
-import kr.co.yeogiga.common.jwt.JwtHelper;
+import kr.co.yeogiga.common.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.apache.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -31,7 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String authToken = request.getHeader(HttpHeaders.AUTHORIZATION);
 
         if (isValidToken(authToken)) {
-            String accessToken = JwtHelper.resolveToken(authToken);
+            String accessToken = JwtUtil.resolveToken(authToken);
             Authentication authentication = getAuthentication(accessToken);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/src/main/java/kr/co/yeogiga/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/co/yeogiga/common/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,52 @@
+package kr.co.yeogiga.common.security.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.yeogiga.application.auth.service.JwtService;
+import kr.co.yeogiga.common.jwt.JwtHelper;
+import lombok.RequiredArgsConstructor;
+import org.apache.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static kr.co.yeogiga.application.auth.constant.AuthConstants.TOKEN_TYPE;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final UserDetailsService userDetailsService;
+    private final JwtService jwtService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (isValidToken(authToken)) {
+            String accessToken = JwtHelper.resolveToken(authToken);
+            Authentication authentication = getAuthentication(accessToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isValidToken(String authToken) {
+        return authToken != null && authToken.startsWith(TOKEN_TYPE);
+    }
+
+    private Authentication getAuthentication(String token) {
+        Long userId = jwtService.extractUserId(token);
+
+        UserDetails userDetails = userDetailsService.loadUserByUsername(String.valueOf(userId));
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+}

--- a/src/main/java/kr/co/yeogiga/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/co/yeogiga/common/security/filter/JwtAuthenticationFilter.java
@@ -39,10 +39,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
+    /**
+     * 토큰 유효성 검사 메서드
+     *
+     * @param authToken     사용자가 보낸 토큰
+     * @return              토큰 유효 여부
+     */
     private boolean isValidToken(String authToken) {
         return authToken != null && authToken.startsWith(TOKEN_TYPE);
     }
 
+    /**
+     * 토큰에서 추출한 사용자 정보를 통해 Authentication 구현체를 반환하는 메서드
+     *
+     * @param token         사용자가 보낸 토큰
+     * @return              Authentication 구현체 - UsernamePasswordAuthenticationToken
+     */
     private Authentication getAuthentication(String token) {
         Long userId = jwtService.extractUserId(token);
 

--- a/src/main/java/kr/co/yeogiga/common/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/kr/co/yeogiga/common/security/filter/JwtExceptionFilter.java
@@ -11,7 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import kr.co.yeogiga.common.response.error.ErrorResponse;
 import kr.co.yeogiga.common.response.error.type.BaseErrorType;
-import kr.co.yeogiga.common.response.error.type.CommonErrorType;
+import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -31,13 +31,13 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, response);
         } catch (ExpiredJwtException e) {
-            setJwtExceptionResponse(response, CommonErrorType.TOKEN_EXPIRED);
+            setJwtExceptionResponse(response, AuthErrorType.TOKEN_EXPIRED);
         } catch (MalformedJwtException e) {
-            setJwtExceptionResponse(response, CommonErrorType.INVALID_TOKEN);
+            setJwtExceptionResponse(response, AuthErrorType.INVALID_TOKEN);
         } catch (SignatureException e) {
-            setJwtExceptionResponse(response, CommonErrorType.INVALID_TOKEN_SIGNATURE);
+            setJwtExceptionResponse(response, AuthErrorType.INVALID_TOKEN_SIGNATURE);
         } catch (JwtException e) {
-            setJwtExceptionResponse(response, CommonErrorType.UNKNOWN_TOKEN_ERROR);
+            setJwtExceptionResponse(response, AuthErrorType.UNKNOWN_TOKEN_ERROR);
         }
     }
 

--- a/src/main/java/kr/co/yeogiga/common/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/kr/co/yeogiga/common/security/filter/JwtExceptionFilter.java
@@ -41,6 +41,12 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         }
     }
 
+    /**
+     * 예외 발생 시 응답값 설정 메서드
+     *
+     * @param response          HttpServletResponse
+     * @param errorType         발생한 에러 타입
+     */
     private void setJwtExceptionResponse(HttpServletResponse response, BaseErrorType errorType) throws IOException {
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/kr/co/yeogiga/common/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/kr/co/yeogiga/common/security/filter/JwtExceptionFilter.java
@@ -1,0 +1,50 @@
+package kr.co.yeogiga.common.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.yeogiga.common.response.error.ErrorResponse;
+import kr.co.yeogiga.common.response.error.type.BaseErrorType;
+import kr.co.yeogiga.common.response.error.type.CommonErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            setJwtExceptionResponse(response, CommonErrorType.TOKEN_EXPIRED);
+        } catch (MalformedJwtException e) {
+            setJwtExceptionResponse(response, CommonErrorType.INVALID_TOKEN);
+        } catch (SignatureException e) {
+            setJwtExceptionResponse(response, CommonErrorType.INVALID_TOKEN_SIGNATURE);
+        } catch (JwtException e) {
+            setJwtExceptionResponse(response, CommonErrorType.UNKNOWN_TOKEN_ERROR);
+        }
+    }
+
+    private void setJwtExceptionResponse(HttpServletResponse response, BaseErrorType errorType) throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.from(errorType)));
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
@@ -11,7 +11,12 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorType implements BaseErrorType {
     FORBIDDEN(HttpStatus.FORBIDDEN, "A000", "접근 권한이 없습니다."),
     UN_REGISTERED_USER(HttpStatus.FORBIDDEN, "A001", "회원가입이 필요한 사용자 입니다."),
-    NOT_AUTHORIZATION(HttpStatus.UNAUTHORIZED, "A003", "인증이 필요합니다."),
+    NOT_AUTHORIZATION(HttpStatus.UNAUTHORIZED, "A003", "인증에 실패하였습니다. 토큰을 확인해주세요."),
+
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "A004", "만료된 토큰입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A005", "잘못된 토큰입니다."),
+    INVALID_TOKEN_SIGNATURE(HttpStatus.UNAUTHORIZED, "A006", "토큰 서명이 잘못되었습니다."),
+    UNKNOWN_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, "A007", "토큰 인증 과정 중 에러가 발생하였습니다."),
     ;
 
 

--- a/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
@@ -1,0 +1,36 @@
+package kr.co.yeogiga.domain.auth.exception;
+
+import kr.co.yeogiga.common.response.error.type.BaseErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Auth ErrorCode: Axxx
+ */
+@RequiredArgsConstructor
+public enum AuthErrorType implements BaseErrorType {
+    FORBIDDEN(HttpStatus.FORBIDDEN, "A000", "접근 권한이 없습니다."),
+    UN_REGISTERED_USER(HttpStatus.FORBIDDEN, "A001", "회원가입이 필요한 사용자 입니다."),
+    NOT_AUTHORIZATION(HttpStatus.UNAUTHORIZED, "A003", "인증이 필요합니다."),
+    ;
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
@@ -17,7 +17,7 @@ public class UserService {
         return userRepository.findByPlatformAndPlatformId(platform, platformId);
     }
 
-    public Optional<User> readById(Long userId) {
-        return userRepository.findById(userId);
+    public Optional<User> readById(Long id) {
+        return userRepository.findById(id);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
@@ -16,4 +16,8 @@ public class UserService {
     public Optional<User> readByPlatformAndPlatformId(OAuthPlatform platform, String platformId) {
         return userRepository.findByPlatformAndPlatformId(platform, platformId);
     }
+
+    public Optional<User> readById(Long userId) {
+        return userRepository.findById(userId);
+    }
 }

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/security/CorsConfig.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/security/CorsConfig.java
@@ -1,0 +1,35 @@
+package kr.co.yeogiga.infrastructure.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.PATCH;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOriginPattern("*");
+        configuration.setAllowedMethods(List.of(GET.name(), POST.name(), PUT.name(), PATCH.name(), DELETE.name()));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of(HttpHeaders.AUTHORIZATION, HttpHeaders.SET_COOKIE));
+        configuration.setMaxAge(3600L);
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/security/SecurityConfig.java
@@ -1,0 +1,54 @@
+package kr.co.yeogiga.infrastructure.config.security;
+
+import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.common.security.filter.JwtExceptionFilter;
+import kr.co.yeogiga.domain.user.type.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import static kr.co.yeogiga.infrastructure.config.security.constant.EndpointConstants.*;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtExceptionFilter jwtExceptionFilter;
+    private final CorsConfigurationSource corsConfigurationSource;
+    private final AuthenticationEntryPoint authenticationEntryPoint;
+    private final AccessDeniedHandler accessDeniedHandler;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorize ->
+                        authorize
+                                .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
+                                .requestMatchers(USER_ENDPOINTS).hasAuthority(Role.USER.name())
+                                .anyRequest().authenticated())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
+                .exceptionHandling(exceptionConfig -> exceptionConfig
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
+                )
+                .build();
+    }
+
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
@@ -1,0 +1,15 @@
+package kr.co.yeogiga.infrastructure.config.security.constant;
+
+public final class EndpointConstants {
+    private EndpointConstants() {}
+
+    public static final String[] PUBLIC_ENDPOINTS = {
+            "/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**",
+            "/webjars/**", "/error", "/api-checker/**", "/v1/api/link/checker/**",
+            "/api/v1/auth/**"
+    };
+
+    public static final String[] USER_ENDPOINTS = {
+            "/api/v1/trip/**"
+    };
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/oauth/NaverClient.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/oauth/NaverClient.java
@@ -29,7 +29,6 @@ public class NaverClient extends OAuthClient {
                 .queryParam("client_id", properties.getClientId())
                 .queryParam("client_secret", properties.getClientSecret())
                 .queryParam("code", code)
-                .queryParam("state", "flase")
                 .toUriString();
 
         HttpEntity<String> request = new HttpEntity<>(new HttpHeaders());

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
@@ -1,7 +1,6 @@
 package kr.co.yeogiga.presentation.auth.controller;
 
 import jakarta.validation.Valid;
-import kr.co.yeogiga.application.auth.constant.AuthConstants;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
 import kr.co.yeogiga.application.auth.service.OAuthManagementService;
 import kr.co.yeogiga.application.auth.type.Device;
@@ -20,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.Duration;
+import static kr.co.yeogiga.application.auth.constant.AuthConstants.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,7 +40,7 @@ public class OAuthController implements OAuthApi {
             case MOBILE -> ResponseEntity.ok(SuccessResponse.from(response));
             case WEB -> ResponseEntity.ok()
                         .header(HttpHeaders.SET_COOKIE, CookieUtil.createCookie(
-                                AuthConstants.REFRESH_TOKEN_PREFIX.getValue(),
+                                REFRESH_TOKEN_PREFIX,
                                 response.token().refreshToken(),
                                 Duration.ofDays(7).toSeconds()).toString())
                         .body(SuccessResponse.from(response.toWebResponse()));

--- a/src/test/java/kr/co/yeogiga/presentation/image/controller/ImageControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/image/controller/ImageControllerTest.java
@@ -16,7 +16,6 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;

--- a/src/test/java/kr/co/yeogiga/presentation/image/controller/ImageControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/image/controller/ImageControllerTest.java
@@ -4,14 +4,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.image.dto.ImageUrlDto;
 import kr.co.yeogiga.application.image.service.ImageDeleteProcessor;
 import kr.co.yeogiga.application.image.service.ImageUploadProcessor;
+import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -25,7 +30,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(ImageController.class)
+@WebMvcTest(
+        controllers = ImageController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthenticationFilter.class})
+        }
+)
 public class ImageControllerTest {
 
     @Autowired

--- a/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthControllerTest.java
@@ -5,14 +5,19 @@ import kr.co.yeogiga.application.auth.dto.SignInDto;
 import kr.co.yeogiga.application.auth.dto.TokenDto;
 import kr.co.yeogiga.application.auth.service.OAuthManagementService;
 import kr.co.yeogiga.application.auth.type.Device;
+import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
 import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
+import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
 import kr.co.yeogiga.presentation.auth.controller.OAuthController;
+import kr.co.yeogiga.presentation.image.controller.ImageController;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -27,7 +32,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(OAuthController.class)
+@WebMvcTest(
+        controllers = OAuthController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthenticationFilter.class})
+        }
+)
 public class OAuthControllerTest {
 
     @Autowired

--- a/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthControllerTest.java
@@ -9,7 +9,6 @@ import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
 import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
 import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
 import kr.co.yeogiga.presentation.auth.controller.OAuthController;
-import kr.co.yeogiga.presentation.image.controller.ImageController;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## 배경
- JWT를 통한 인증 로직 추가

## 작업 사항
### 1. JWT 기반 인증 관련 필터 추가
- `JwtAuthenticationFilter`, `JwtExceptionFilter` 추가 - (8a5c9dc740882632197fd8d5a7420bfa4fb9166f)

### 2. 인증, 인가 관련 처리 클래스 추가
현재 정의된 사용자 역할(Role)은 다음과 같습니다.

- `GUEST`: 아직 회원가입하지 않은 사용자(최초 로그인 후 정보 수정 x) 
- `USER`:회원가입을 진행한 사용자
- `ADMIN`: 관리자

#### (1) 인가 관련 에러 처리를 위한 `AccessDeniedHandler` 구현 - (f27dd92dd98c53795601552881b3928e5cbea104)
- GUEST의 경우에는 "회원가입이 필요" 에러 문구 리턴
<img width="862" alt="image" src="https://github.com/user-attachments/assets/dd480825-2893-4880-957b-d13bff203618" />

- 그 외, USER가 ADMIN_ENDPOINT로 요청을 보낸 경우 등
<img width="867" alt="image" src="https://github.com/user-attachments/assets/a79ee4e2-f05a-4228-a47f-e5d9255697f5" />

#### (2) 인증 관련 에러 처리를 위한 'AuthenticationEntryPoint` 구현 - (b3e1f5a5d2bf24d819afecd82fe352a2e664e4a2)
- 토큰이 null 이거나, 토큰 타입이 불일치하는 경우
   - 해당 상황 관련해서, 토큰이 null 이거나, 토큰 타입 불일치 상황에 대한 에러 코드를 별개로 나누고 이를 처리하는 추가로직을 구성할까 고민하였지만, 불필요하다 생각하여 진행하지는 않았습니다.
<img width="864" alt="image" src="https://github.com/user-attachments/assets/da68733e-a953-480f-910b-fb52e8585606" />

#### (3) 기타 
- 토큰 인증 관련 에러 코드 위치 이동 : `CommonErrorType` → `AuthErrorType`

## 추가 논의
- Spring Security 적용 후 WebMvcTest 진행 시 ApplicationContext 생성 에러가 발생하였습니다.
따라서, 테스트 과정에서 시큐리티를 적용할 일은 없다고 생각하여 `excludeFilters`를 통하여 테스트 시큐리티 관련 클래스 빈이 생성 되지 않도록 하여 테스트 코드 수정하였습니다. 차후 Presentation 레이어 테스트 시 참고바랍니다.