### PR TITLE
Feature(IL-45): 여행 준비 단계 중, 목적지 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
     /* Spring Security */
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    /* Redis */
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripPlaceDto.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripPlaceDto.java
@@ -1,0 +1,33 @@
+package kr.co.yeogiga.application.trip.dto;
+
+import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
+
+import java.util.UUID;
+
+public class TripPlaceDto {
+
+    public record Request(
+            String name,
+            double latitude,
+            double longitude,
+            String placeType
+    ) {
+        public StoredFormat toStoredFormat() {
+            return new StoredFormat(
+                    UUID.randomUUID().toString(),
+                    name,
+                    latitude,
+                    longitude,
+                    PlaceCategory.fromLabel(placeType)
+            );
+        }
+    }
+
+    public record StoredFormat(
+            String id,
+            String name,
+            double latitude,
+            double longitude,
+            PlaceCategory placeCategory
+    ) { }
+}

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripPlaceDto.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripPlaceDto.java
@@ -1,15 +1,21 @@
 package kr.co.yeogiga.application.trip.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
 
 import java.util.UUID;
 
 public class TripPlaceDto {
 
+    @Schema(name = "TripPlaceDto.Request", description = "여행 목적지 추가 DTO")
     public record Request(
+            @Schema(description = "목적지 이름", example = "광화문")
             String name,
+            @Schema(description = "목적지 위도", example = "33.33")
             double latitude,
+            @Schema(description = "목적지 경도", example = "123.123")
             double longitude,
+            @Schema(description = "목적지 타입(카테고리)", example = "관광명소")
             String placeType
     ) {
         public StoredFormat toStoredFormat() {

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripPlaceDto.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripPlaceDto.java
@@ -24,7 +24,7 @@ public class TripPlaceDto {
                     name,
                     latitude,
                     longitude,
-                    PlaceCategory.fromLabel(placeType)
+                    PlaceCategory.fromLabel(placeType).getGroupName()
             );
         }
     }
@@ -34,6 +34,6 @@ public class TripPlaceDto {
             String name,
             double latitude,
             double longitude,
-            PlaceCategory placeCategory
+            String placeCategory
     ) { }
 }

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingService.java
@@ -1,0 +1,122 @@
+package kr.co.yeogiga.application.trip.service;
+
+import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import kr.co.yeogiga.infrastructure.redis.constant.PlaceConstant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 여행 생성 단계에서 사용자들이 선택한 "목적지"들을 임시 저장하고 관리하는 서비스 클래스.
+ * - 아직 확정되지 않은 여행 목적지 편집(추가, 삭제, 수정, 조회) 수행
+ * - Redis를 임시 저장소로 사용
+ */
+@Service
+@RequiredArgsConstructor
+public class TripPlaceEditingService {
+    private final RedisRepository redisRepository;
+
+    /**
+     * 특정 여행(tripId)과 일차(day)에 저장된 목적지 리스트를 조회하는 메서드
+     *
+     * @param tripId : 여행 ID
+     * @param day    : 여행 일차 (1일차, 2일차 등)
+     * @return : 저장된 TripPlaceDto.StoredFormat 리스트
+     */
+    public List<TripPlaceDto.StoredFormat> getPlacesInEditing(Long tripId, int day) {
+        String listKey = PlaceConstant.listKey(tripId, day);
+        return redisRepository.getList(listKey, TripPlaceDto.StoredFormat.class);
+    }
+
+    /**
+     * 편집 중인 여행 일정에 새로운 목적지를 추가하는 메서드
+     * - Set을 통해 이미 추가된 장소인지 확인
+     * - 중복이 없다면 List & Set에 추가 (저장 포맷에 맞게 변환 후 저장)
+     *
+     * @param tripId : 여행 ID
+     * @param day    : 여행 일차
+     * @param place  : 추가할 TripPlaceDto.Request 객체
+     * @throws CustomException ALREADY_ADDED_PLACE : 이미 목적지를 추가한 경우
+     */
+    public void addPlaceInEditing(Long tripId, int day, TripPlaceDto.Request place) {
+        String listKey = PlaceConstant.listKey(tripId, day);
+        String setKey = PlaceConstant.setKey(tripId, day);
+
+        String placeUniqueKey = makeUniqueKey(place.name(), place.latitude(), place.longitude());
+        if (redisRepository.existsInSet(setKey, placeUniqueKey)) {
+            throw new CustomException(TripErrorType.ALREADY_ADDED_PLACE);
+        }
+
+        redisRepository.setList(listKey, place.toStoredFormat());
+        redisRepository.addToSet(setKey, placeUniqueKey);
+    }
+
+    /**
+     * 편집 중인 여행 일정에서 특정 목적지를 삭제하는 메서드
+     * - List에서 id에 해당하는 목적지 조회
+     * - 찾은 경우 List & Set에 삭제
+     *
+     * @param tripId  : 여행 ID
+     * @param day     : 여행 일차
+     * @param placeId : 삭제할 목적지 ID
+     */
+    public void deletePlaceInEditing(Long tripId, int day, String placeId) {
+        String listKey = PlaceConstant.listKey(tripId, day);
+        String setKey = PlaceConstant.setKey(tripId, day);
+
+        List<TripPlaceDto.StoredFormat> places = redisRepository.getList(listKey, TripPlaceDto.StoredFormat.class);
+
+        TripPlaceDto.StoredFormat target = places.stream()
+                .filter(p -> placeId.equals(p.id()))
+                .findFirst()
+                .orElse(null);
+
+        if (target == null) {
+            return;
+        }
+
+        redisRepository.removeFromList(listKey, target);
+
+        String placeUniqueKey = makeUniqueKey(target.name(), target.latitude(), target.longitude());
+        redisRepository.removeFromSet(setKey, placeUniqueKey);
+    }
+
+    /**
+     * 편집 중인 여행 일정의 목적지를 수정하는 메서드 (목적지의 새로운 순서로 덮어쓰기 등)
+     * - 기존 List & Set 모두 삭제
+     * - 새로운 순서대로 List & Set에 저장
+     *
+     * @param tripId : 여행 ID
+     * @param day    : 여행 일차
+     * @param places : 새로운 순서의 TripPlaceDto.Request 리스트
+     */
+    public void updatePlacesInEditing(Long tripId, int day, List<TripPlaceDto.Request> places) {
+        String listKey = PlaceConstant.listKey(tripId, day);
+        String setKey = PlaceConstant.setKey(tripId, day);
+
+        redisRepository.del(listKey);
+        redisRepository.del(setKey);
+
+        for (TripPlaceDto.Request place : places) {
+            redisRepository.setList(listKey, place.toStoredFormat());
+            String placeUniqueKey = makeUniqueKey(place.name(), place.latitude(), place.longitude());
+            redisRepository.addToSet(setKey, placeUniqueKey);
+        }
+    }
+
+    /**
+     * 목적지의 고유 식별 키를 생성하는 메서드 (장소명 + 위도 + 경도 조합)
+     *
+     * @param name      : 목적지 이름
+     * @param latitude  : 목적지 위도
+     * @param longitude : 목적지 경도
+     * @return : unique key
+     */
+    private String makeUniqueKey(String name, double latitude, double longitude) {
+        return name + ":" + latitude + ":" + longitude;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingService.java
@@ -27,7 +27,7 @@ public class TripPlaceEditingService {
      * @param day    : 여행 일차 (1일차, 2일차 등)
      * @return : 저장된 TripPlaceDto.StoredFormat 리스트
      */
-    public List<TripPlaceDto.StoredFormat> getPlacesInEditing(Long tripId, int day) {
+    public List<TripPlaceDto.StoredFormat> getPlaces(Long tripId, int day) {
         String listKey = PlaceConstant.listKey(tripId, day);
         return redisRepository.getList(listKey, TripPlaceDto.StoredFormat.class);
     }
@@ -42,7 +42,7 @@ public class TripPlaceEditingService {
      * @param place  : 추가할 TripPlaceDto.Request 객체
      * @throws CustomException ALREADY_ADDED_PLACE : 이미 목적지를 추가한 경우
      */
-    public void addPlaceInEditing(Long tripId, int day, TripPlaceDto.Request place) {
+    public void addPlace(Long tripId, int day, TripPlaceDto.Request place) {
         String listKey = PlaceConstant.listKey(tripId, day);
         String setKey = PlaceConstant.setKey(tripId, day);
 
@@ -64,7 +64,7 @@ public class TripPlaceEditingService {
      * @param day     : 여행 일차
      * @param placeId : 삭제할 목적지 ID
      */
-    public void deletePlaceInEditing(Long tripId, int day, String placeId) {
+    public void deletePlace(Long tripId, int day, String placeId) {
         String listKey = PlaceConstant.listKey(tripId, day);
         String setKey = PlaceConstant.setKey(tripId, day);
 
@@ -94,7 +94,7 @@ public class TripPlaceEditingService {
      * @param day    : 여행 일차
      * @param places : 새로운 순서의 TripPlaceDto.Request 리스트
      */
-    public void updatePlacesInEditing(Long tripId, int day, List<TripPlaceDto.Request> places) {
+    public void updatePlaces(Long tripId, int day, List<TripPlaceDto.Request> places) {
         String listKey = PlaceConstant.listKey(tripId, day);
         String setKey = PlaceConstant.setKey(tripId, day);
 

--- a/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 public enum TripErrorType implements BaseErrorType {
 
     INVALID_PLACE(HttpStatus.BAD_REQUEST, "T001", "지원하지 않는 카테고리입니다."),
+    ALREADY_ADDED_PLACE(HttpStatus.CONFLICT, "T002", "이미 추가된 장소입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/RedisConfig.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/RedisConfig.java
@@ -1,0 +1,48 @@
+package kr.co.yeogiga.infrastructure.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.util.StringUtils;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String pass;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(host, port);
+
+        if (StringUtils.hasText(pass)) {
+            redisStandaloneConfiguration.setPassword(pass);
+        }
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/redis/RedisRepository.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/redis/RedisRepository.java
@@ -1,0 +1,68 @@
+package kr.co.yeogiga.infrastructure.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisRepository {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public Object get(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void set(String key, Object value, Duration duration) {
+        redisTemplate.opsForValue().set(key, value, duration);
+    }
+
+    public void del(String key) {
+        redisTemplate.delete(key);
+    }
+
+    public boolean existed(String key) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    public void setList(String key, Object value) {
+        redisTemplate.opsForList().rightPush(key, value);
+    }
+
+    public <T> List<T> getList(String key, Class<T> clazz) {
+        List<Object> objects = redisTemplate.opsForList().range(key, 0, -1);
+        if (objects == null || objects.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return objects.stream()
+                .map(clazz::cast)
+                .collect(Collectors.toList());
+    }
+
+    public void removeFromList(String key, Object value) {
+        redisTemplate.opsForList().remove(key, 1, value);
+    }
+
+    public void addToSet(String key, Object value) {
+        redisTemplate.opsForSet().add(key, value);
+    }
+
+    public Set<Object> getSetMembers(String key) {
+        return redisTemplate.opsForSet().members(key);
+    }
+
+    public void removeFromSet(String key, Object value) {
+        redisTemplate.opsForSet().remove(key, value);
+    }
+
+    public boolean existsInSet(String key, Object value) {
+        return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(key, value));
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/redis/constant/PlaceConstant.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/redis/constant/PlaceConstant.java
@@ -1,0 +1,17 @@
+package kr.co.yeogiga.infrastructure.redis.constant;
+
+public final class PlaceConstant {
+
+    private PlaceConstant() { }
+
+    private static final String LIST_KEY_FORMAT = "trip:%d:day:%d:places";
+    private static final String SET_KEY_FORMAT = "trip:%d:day:%d:places:set";
+
+    public static String listKey(Long tripId, int day) {
+        return String.format(LIST_KEY_FORMAT, tripId, day);
+    }
+
+    public static String setKey(Long tripId, int day) {
+        return String.format(SET_KEY_FORMAT, tripId, day);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
@@ -22,7 +22,7 @@ public interface TripPlaceEditingApi {
     @TrackApi(description = "목적지 추가")
     @Operation(summary = "목적지 추가", description = "목적지 추가하는 API입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "목적지 추가 성공",
+            @ApiResponse(responseCode = "201", description = "목적지 추가 성공",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                         {

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
@@ -1,0 +1,112 @@
+package kr.co.yeogiga.presentation.trip.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@ApiGroup(value = "[여행 생성 단계에서의 목적지 API]")
+@Tag(name = "[여행 생성 단계에서의 목적지 API]", description = "여행 목적지 관련 API")
+public interface TripPlaceEditingApi {
+
+    @TrackApi(description = "목적지 추가")
+    @Operation(summary = "목적지 추가", description = "목적지 추가하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "목적지 추가 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "409", description = "이미 추가 되어 있는 목적지",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": "T002",
+                                            "message": "이미 추가된 장소입니다."
+                                        }
+                                    """)
+                    })),
+    })
+    ResponseEntity<?> addPlace(@PathVariable Long tripId,
+                               @PathVariable int day,
+                               @RequestBody TripPlaceDto.Request request);
+
+    @TrackApi(description = "일자별 목적지 조회")
+    @Operation(summary = "일자별 목적지 조회", description = "일자별 목적지 조회하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "일자별 목적지 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": [
+                                                {
+                                                    "id": "place-id1",
+                                                    "name": "목적지1",
+                                                    "latitude": 32.33,
+                                                    "longitude": 87.123,
+                                                    "placeCategory": "RESTAURANT"
+                                                },
+                                                {
+                                                    "id": "place-id2",
+                                                    "name": "목적지2",
+                                                    "latitude": 132.33,
+                                                    "longitude": 287.123,
+                                                    "placeCategory": "RESTAURANT"
+                                                }
+                                            ]
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getPlaces(@PathVariable Long tripId, @PathVariable int day);
+
+    @TrackApi(description = "목적지 수정")
+    @Operation(summary = "목적지 수정", description = "목적지 수정하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "목적지 수정 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> updatePlaces(@PathVariable Long tripId,
+                                   @PathVariable int day,
+                                   @RequestBody List<TripPlaceDto.Request> requests);
+
+    @TrackApi(description = "목적지 삭제")
+    @Operation(summary = "목적지 삭제", description = "목적지 삭제하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "목적지 삭제 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> deletePlace(@PathVariable Long tripId,
+                                  @PathVariable int day,
+                                  @PathVariable String placeId);
+}

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
@@ -60,14 +60,14 @@ public interface TripPlaceEditingApi {
                                                     "name": "목적지1",
                                                     "latitude": 32.33,
                                                     "longitude": 87.123,
-                                                    "placeCategory": "RESTAURANT"
+                                                    "placeCategory": "관광지"
                                                 },
                                                 {
                                                     "id": "place-id2",
                                                     "name": "목적지2",
                                                     "latitude": 132.33,
                                                     "longitude": 287.123,
-                                                    "placeCategory": "RESTAURANT"
+                                                    "placeCategory": "식당"
                                                 }
                                             ]
                                         }

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.presentation.trip.controller;
 import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
 import kr.co.yeogiga.application.trip.service.TripPlaceEditingService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.presentation.trip.api.TripPlaceEditingApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -19,9 +20,10 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/trip")
 @RequiredArgsConstructor
-public class TripPlaceEditingController {
+public class TripPlaceEditingController implements TripPlaceEditingApi {
     private final TripPlaceEditingService tripPlaceEditingService;
 
+    @Override
     @PostMapping("/{tripId}/days/{day}/places")
     public ResponseEntity<?> addPlace(@PathVariable Long tripId,
                                       @PathVariable int day,
@@ -31,7 +33,7 @@ public class TripPlaceEditingController {
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 
-
+    @Override
     @GetMapping("/{tripId}/days/{day}/places")
     public ResponseEntity<?> getPlaces(@PathVariable Long tripId, @PathVariable int day) {
         return ResponseEntity.ok(
@@ -39,6 +41,7 @@ public class TripPlaceEditingController {
         );
     }
 
+    @Override
     @PutMapping("/{tripId}/days/{day}/places")
     public ResponseEntity<?> updatePlaces(@PathVariable Long tripId,
                                           @PathVariable int day,
@@ -48,6 +51,7 @@ public class TripPlaceEditingController {
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 
+    @Override
     @DeleteMapping("/{tripId}/days/{day}/places/{placeId}")
     public ResponseEntity<?> deletePlace(@PathVariable Long tripId,
                                          @PathVariable int day,

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
@@ -5,6 +5,7 @@ import kr.co.yeogiga.application.trip.service.TripPlaceEditingService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.presentation.trip.api.TripPlaceEditingApi;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,7 +31,7 @@ public class TripPlaceEditingController implements TripPlaceEditingApi {
                                       @RequestBody TripPlaceDto.Request request) {
 
         tripPlaceEditingService.addPlaceInEditing(tripId, day, request);
-        return ResponseEntity.ok(SuccessResponse.ok());
+        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.ok());
     }
 
     @Override

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
@@ -1,0 +1,59 @@
+package kr.co.yeogiga.presentation.trip.controller;
+
+import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.application.trip.service.TripPlaceEditingService;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/trip")
+@RequiredArgsConstructor
+public class TripPlaceEditingController {
+    private final TripPlaceEditingService tripPlaceEditingService;
+
+    @PostMapping("/{tripId}/days/{day}/places")
+    public ResponseEntity<?> addPlace(@PathVariable Long tripId,
+                                      @PathVariable int day,
+                                      @RequestBody TripPlaceDto.Request request) {
+
+        tripPlaceEditingService.addPlaceInEditing(tripId, day, request);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+
+
+    @GetMapping("/{tripId}/days/{day}/places")
+    public ResponseEntity<?> getPlaces(@PathVariable Long tripId, @PathVariable int day) {
+        return ResponseEntity.ok(
+                SuccessResponse.from(tripPlaceEditingService.getPlacesInEditing(tripId, day))
+        );
+    }
+
+    @PutMapping("/{tripId}/days/{day}/places")
+    public ResponseEntity<?> updatePlaces(@PathVariable Long tripId,
+                                          @PathVariable int day,
+                                          @RequestBody List<TripPlaceDto.Request> requests) {
+
+        tripPlaceEditingService.updatePlacesInEditing(tripId, day, requests);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+
+    @DeleteMapping("/{tripId}/days/{day}/places/{placeId}")
+    public ResponseEntity<?> deletePlace(@PathVariable Long tripId,
+                                         @PathVariable int day,
+                                         @PathVariable String placeId) {
+
+        tripPlaceEditingService.deletePlaceInEditing(tripId, day, placeId);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
@@ -30,7 +30,7 @@ public class TripPlaceEditingController implements TripPlaceEditingApi {
                                       @PathVariable int day,
                                       @RequestBody TripPlaceDto.Request request) {
 
-        tripPlaceEditingService.addPlaceInEditing(tripId, day, request);
+        tripPlaceEditingService.addPlace(tripId, day, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.ok());
     }
 
@@ -38,7 +38,7 @@ public class TripPlaceEditingController implements TripPlaceEditingApi {
     @GetMapping("/{tripId}/days/{day}/places")
     public ResponseEntity<?> getPlaces(@PathVariable Long tripId, @PathVariable int day) {
         return ResponseEntity.ok(
-                SuccessResponse.from(tripPlaceEditingService.getPlacesInEditing(tripId, day))
+                SuccessResponse.from(tripPlaceEditingService.getPlaces(tripId, day))
         );
     }
 
@@ -48,7 +48,7 @@ public class TripPlaceEditingController implements TripPlaceEditingApi {
                                           @PathVariable int day,
                                           @RequestBody List<TripPlaceDto.Request> requests) {
 
-        tripPlaceEditingService.updatePlacesInEditing(tripId, day, requests);
+        tripPlaceEditingService.updatePlaces(tripId, day, requests);
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 
@@ -58,7 +58,7 @@ public class TripPlaceEditingController implements TripPlaceEditingApi {
                                          @PathVariable int day,
                                          @PathVariable String placeId) {
 
-        tripPlaceEditingService.deletePlaceInEditing(tripId, day, placeId);
+        tripPlaceEditingService.deletePlace(tripId, day, placeId);
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 }

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -21,3 +21,8 @@ spring:
       database: ${MONGODB_DATABASE:test}
       username: ${MONGODB_USERNAME:root}
       password: ${MONGODB_PASSWORD:password}
+
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASS:}

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -25,4 +25,4 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
-      password: ${REDIS_PASS:}
+      password: ${REDIS_PASS}

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingServiceTest.java
@@ -83,12 +83,13 @@ public class TripPlaceEditingServiceTest {
     class DeletePlaceTest {
 
         private final String placeId = "place-id";
+
         @Test
         @DisplayName("목적지 삭제 성공")
         void deletePlaceInEditingSuccess() {
             // given
             TripPlaceDto.StoredFormat place = new TripPlaceDto.StoredFormat(
-                    placeId, "목적지1", 33.123, 126.456, PlaceCategory.RESTAURANT
+                    placeId, "목적지1", 33.123, 126.456, PlaceCategory.RESTAURANT.getGroupName()
             );
 
             given(redisRepository.getList(anyString(), eq(TripPlaceDto.StoredFormat.class)))
@@ -143,7 +144,7 @@ public class TripPlaceEditingServiceTest {
     void getPlacesInEditingSuccess() {
         // given
         List<TripPlaceDto.StoredFormat> mockPlaces = List.of(
-                new TripPlaceDto.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.CAFE)
+                new TripPlaceDto.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.CAFE.getGroupName())
         );
 
         given(redisRepository.getList(anyString(), eq(TripPlaceDto.StoredFormat.class))).willReturn(mockPlaces);
@@ -154,6 +155,6 @@ public class TripPlaceEditingServiceTest {
         // then
         assertEquals(1, result.size());
         assertEquals("목적지1", result.get(0).name());
-        assertEquals(PlaceCategory.CAFE, result.get(0).placeCategory());
+        assertEquals(PlaceCategory.CAFE.getGroupName(), result.get(0).placeCategory());
     }
 }

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingServiceTest.java
@@ -54,7 +54,7 @@ public class TripPlaceEditingServiceTest {
             given(redisRepository.existsInSet(eq(setKey), anyString())).willReturn(false);
 
             // when
-            tripPlaceEditingService.addPlaceInEditing(tripId, day, place);
+            tripPlaceEditingService.addPlace(tripId, day, place);
 
             // then
             verify(redisRepository, times(1)).setList(anyString(), any(TripPlaceDto.StoredFormat.class));
@@ -70,7 +70,7 @@ public class TripPlaceEditingServiceTest {
 
             // when
             CustomException exception = assertThrows(CustomException.class, () ->
-                    tripPlaceEditingService.addPlaceInEditing(tripId, day, place)
+                    tripPlaceEditingService.addPlace(tripId, day, place)
             );
 
             // then
@@ -95,7 +95,7 @@ public class TripPlaceEditingServiceTest {
                     .willReturn(List.of(place));
 
             // when
-            tripPlaceEditingService.deletePlaceInEditing(tripId, day, placeId);
+            tripPlaceEditingService.deletePlace(tripId, day, placeId);
 
             // then
             verify(redisRepository, times(1)).removeFromList(anyString(), eq(place));
@@ -110,7 +110,7 @@ public class TripPlaceEditingServiceTest {
                     .willReturn(List.of());
 
             // when
-            assertDoesNotThrow(() -> tripPlaceEditingService.deletePlaceInEditing(tripId, day, placeId));
+            assertDoesNotThrow(() -> tripPlaceEditingService.deletePlace(tripId, day, placeId));
 
             // then
             verify(redisRepository, never()).removeFromList(anyString(), any());
@@ -130,7 +130,7 @@ public class TripPlaceEditingServiceTest {
         List<TripPlaceDto.Request> newPlaces = List.of(place2, place1);
 
         // when
-        tripPlaceEditingService.updatePlacesInEditing(tripId, day, newPlaces);
+        tripPlaceEditingService.updatePlaces(tripId, day, newPlaces);
 
         // then
         verify(redisRepository, times(2)).del(anyString());
@@ -149,7 +149,7 @@ public class TripPlaceEditingServiceTest {
         given(redisRepository.getList(anyString(), eq(TripPlaceDto.StoredFormat.class))).willReturn(mockPlaces);
 
         // when
-        List<TripPlaceDto.StoredFormat> result = tripPlaceEditingService.getPlacesInEditing(tripId, day);
+        List<TripPlaceDto.StoredFormat> result = tripPlaceEditingService.getPlaces(tripId, day);
 
         // then
         assertEquals(1, result.size());

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingServiceTest.java
@@ -1,0 +1,159 @@
+package kr.co.yeogiga.application.trip.service;
+
+import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import kr.co.yeogiga.infrastructure.redis.constant.PlaceConstant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class TripPlaceEditingServiceTest {
+
+    @Mock
+    private RedisRepository redisRepository;
+
+    @InjectMocks
+    private TripPlaceEditingService tripPlaceEditingService;
+
+    private final Long tripId = 1L;
+    private final int day = 1;
+
+    @Nested
+    @DisplayName("목적지 추가 테스트")
+    class AddPlaceTest {
+
+        private final TripPlaceDto.Request place =
+                new TripPlaceDto.Request("목적지1", 33.1234, 126.5678, "카페");
+
+        @Test
+        @DisplayName("성공")
+        void addPlaceInEditingSuccess() {
+            // given
+            String setKey = PlaceConstant.setKey(tripId, day);
+            given(redisRepository.existsInSet(eq(setKey), anyString())).willReturn(false);
+
+            // when
+            tripPlaceEditingService.addPlaceInEditing(tripId, day, place);
+
+            // then
+            verify(redisRepository, times(1)).setList(anyString(), any(TripPlaceDto.StoredFormat.class));
+            verify(redisRepository, times(1)).addToSet(eq(setKey), anyString());
+        }
+
+        @Test
+        @DisplayName("실패 - 중복")
+        void addPlaceInEditingFailAlreadyAdded() {
+            // given
+            String setKey = PlaceConstant.setKey(tripId, day);
+            given(redisRepository.existsInSet(eq(setKey), anyString())).willReturn(true);
+
+            // when
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    tripPlaceEditingService.addPlaceInEditing(tripId, day, place)
+            );
+
+            // then
+            assertEquals(TripErrorType.ALREADY_ADDED_PLACE, exception.getErrorType());
+        }
+    }
+
+    @Nested
+    @DisplayName("목적지 삭제 테스트")
+    class DeletePlaceTest {
+
+        private final String placeId = "place-id";
+        @Test
+        @DisplayName("목적지 삭제 성공")
+        void deletePlaceInEditingSuccess() {
+            // given
+            TripPlaceDto.StoredFormat place = new TripPlaceDto.StoredFormat(
+                    placeId, "목적지1", 33.123, 126.456, PlaceCategory.RESTAURANT
+            );
+
+            given(redisRepository.getList(anyString(), eq(TripPlaceDto.StoredFormat.class)))
+                    .willReturn(List.of(place));
+
+            // when
+            tripPlaceEditingService.deletePlaceInEditing(tripId, day, placeId);
+
+            // then
+            verify(redisRepository, times(1)).removeFromList(anyString(), eq(place));
+            verify(redisRepository, times(1)).removeFromSet(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("목적지 삭제 실패 - 존재하지 않음")
+        void deletePlaceInEditingNotFound() {
+            // given
+            given(redisRepository.getList(anyString(), eq(TripPlaceDto.StoredFormat.class)))
+                    .willReturn(List.of());
+
+            // when
+            assertDoesNotThrow(() -> tripPlaceEditingService.deletePlaceInEditing(tripId, day, placeId));
+
+            // then
+            verify(redisRepository, never()).removeFromList(anyString(), any());
+            verify(redisRepository, never()).removeFromSet(anyString(), anyString());
+        }
+    }
+
+    @Test
+    @DisplayName("목적지 순서 수정 성공")
+    void updatePlacesInEditingSuccess() {
+        // given
+        TripPlaceDto.Request place1 =
+                new TripPlaceDto.Request("목적지1", 33.123, 126.456, "카페");
+        TripPlaceDto.Request place2 =
+                new TripPlaceDto.Request("목적지2", 33.789, 126.987, "관광명소");
+
+        List<TripPlaceDto.Request> newPlaces = List.of(place2, place1);
+
+        // when
+        tripPlaceEditingService.updatePlacesInEditing(tripId, day, newPlaces);
+
+        // then
+        verify(redisRepository, times(2)).del(anyString());
+        verify(redisRepository, times(2)).setList(anyString(), any(TripPlaceDto.StoredFormat.class));
+        verify(redisRepository, times(2)).addToSet(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("편집 중인 여행 일정 조회 성공")
+    void getPlacesInEditingSuccess() {
+        // given
+        List<TripPlaceDto.StoredFormat> mockPlaces = List.of(
+                new TripPlaceDto.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.CAFE)
+        );
+
+        given(redisRepository.getList(anyString(), eq(TripPlaceDto.StoredFormat.class))).willReturn(mockPlaces);
+
+        // when
+        List<TripPlaceDto.StoredFormat> result = tripPlaceEditingService.getPlacesInEditing(tripId, day);
+
+        // then
+        assertEquals(1, result.size());
+        assertEquals("목적지1", result.get(0).name());
+        assertEquals(PlaceCategory.CAFE, result.get(0).placeCategory());
+    }
+}

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingControllerTest.java
@@ -1,0 +1,184 @@
+package kr.co.yeogiga.presentation.trip.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.application.trip.service.TripPlaceEditingService;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
+import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = TripPlaceEditingController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthenticationFilter.class})
+        }
+)
+public class TripPlaceEditingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private TripPlaceEditingService tripPlaceEditingService;
+
+    private final Long tripId = 1L;
+    private final int day = 1;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("목적지 추가 테스트")
+    class AddPlaceTest {
+
+        private final TripPlaceDto.Request request =
+                new TripPlaceDto.Request("목적지1", 33.1234, 126.5678, "카페");
+
+        @Test
+        @DisplayName("성공")
+        void addPlaceSuccess() throws Exception {
+            // given
+            doNothing().when(tripPlaceEditingService).addPlaceInEditing(anyLong(), anyInt(), any());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/trip/{tripId}/days/{day}/places", tripId, day)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            // then
+            resultActions
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 존재하는 장소")
+        void addPlaceFailAlreadyAdded() throws Exception {
+            // given
+            doThrow(new CustomException(TripErrorType.ALREADY_ADDED_PLACE))
+                    .when(tripPlaceEditingService).addPlaceInEditing(anyLong(), anyInt(), any());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/trip/{tripId}/days/{day}/places", tripId, day)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            // then
+            resultActions
+                    .andDo(print())
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value(TripErrorType.ALREADY_ADDED_PLACE.getCode()))
+                    .andExpect(jsonPath("$.message").value(TripErrorType.ALREADY_ADDED_PLACE.getMessage()));
+        }
+    }
+
+    @Test
+    @DisplayName("목적지 수정 성공")
+    void updatePlacesSuccess() throws Exception {
+        // given
+        List<TripPlaceDto.Request> requests = List.of(
+                new TripPlaceDto.Request("목적지1", 33.4567, 126.7890, "관광명소"),
+                new TripPlaceDto.Request("목적지2", 33.1234, 126.5678, "카페")
+        );
+
+        doNothing().when(tripPlaceEditingService).updatePlacesInEditing(anyLong(), anyInt(), Mockito.anyList());
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                put("/api/v1/trip/{tripId}/days/{day}/places", tripId, day)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requests))
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
+    }
+
+    @Test
+    @DisplayName("목적지 삭제 성공")
+    void deletePlaceSuccess() throws Exception {
+        // given
+        doNothing().when(tripPlaceEditingService).deletePlaceInEditing(anyLong(), anyInt(), Mockito.anyString());
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                delete("/api/v1/trip/{tripId}/days/{day}/places/{placeId}", tripId, day, "place-id")
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
+    }
+
+    @Test
+    @DisplayName("목적지 조회 성공")
+    void getPlacesSuccess() throws Exception {
+        // given
+        List<TripPlaceDto.StoredFormat> mockPlaces = List.of(
+                new TripPlaceDto.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.CAFE)
+        );
+        given(tripPlaceEditingService.getPlacesInEditing(tripId, day)).willReturn(mockPlaces);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/trip/{tripId}/days/{day}/places", tripId, day)
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].name").value("목적지1"))
+                .andExpect(jsonPath("$.data[0].placeCategory").value("CAFE"));
+    }
+}

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingControllerTest.java
@@ -165,7 +165,7 @@ public class TripPlaceEditingControllerTest {
     void getPlacesSuccess() throws Exception {
         // given
         List<TripPlaceDto.StoredFormat> mockPlaces = List.of(
-                new TripPlaceDto.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.CAFE)
+                new TripPlaceDto.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.CAFE.getGroupName())
         );
         given(tripPlaceEditingService.getPlaces(tripId, day)).willReturn(mockPlaces);
 
@@ -179,6 +179,6 @@ public class TripPlaceEditingControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data[0].name").value("목적지1"))
-                .andExpect(jsonPath("$.data[0].placeCategory").value("CAFE"));
+                .andExpect(jsonPath("$.data[0].placeCategory").value("식당"));
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingControllerTest.java
@@ -78,7 +78,7 @@ public class TripPlaceEditingControllerTest {
         @DisplayName("성공")
         void addPlaceSuccess() throws Exception {
             // given
-            doNothing().when(tripPlaceEditingService).addPlaceInEditing(anyLong(), anyInt(), any());
+            doNothing().when(tripPlaceEditingService).addPlace(anyLong(), anyInt(), any());
 
             // when
             ResultActions resultActions = mockMvc.perform(
@@ -90,7 +90,7 @@ public class TripPlaceEditingControllerTest {
             // then
             resultActions
                     .andDo(print())
-                    .andExpect(status().isOk())
+                    .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
         }
 
@@ -99,7 +99,7 @@ public class TripPlaceEditingControllerTest {
         void addPlaceFailAlreadyAdded() throws Exception {
             // given
             doThrow(new CustomException(TripErrorType.ALREADY_ADDED_PLACE))
-                    .when(tripPlaceEditingService).addPlaceInEditing(anyLong(), anyInt(), any());
+                    .when(tripPlaceEditingService).addPlace(anyLong(), anyInt(), any());
 
             // when
             ResultActions resultActions = mockMvc.perform(
@@ -126,7 +126,7 @@ public class TripPlaceEditingControllerTest {
                 new TripPlaceDto.Request("목적지2", 33.1234, 126.5678, "카페")
         );
 
-        doNothing().when(tripPlaceEditingService).updatePlacesInEditing(anyLong(), anyInt(), Mockito.anyList());
+        doNothing().when(tripPlaceEditingService).updatePlaces(anyLong(), anyInt(), Mockito.anyList());
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -146,7 +146,7 @@ public class TripPlaceEditingControllerTest {
     @DisplayName("목적지 삭제 성공")
     void deletePlaceSuccess() throws Exception {
         // given
-        doNothing().when(tripPlaceEditingService).deletePlaceInEditing(anyLong(), anyInt(), Mockito.anyString());
+        doNothing().when(tripPlaceEditingService).deletePlace(anyLong(), anyInt(), Mockito.anyString());
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -167,7 +167,7 @@ public class TripPlaceEditingControllerTest {
         List<TripPlaceDto.StoredFormat> mockPlaces = List.of(
                 new TripPlaceDto.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.CAFE)
         );
-        given(tripPlaceEditingService.getPlacesInEditing(tripId, day)).willReturn(mockPlaces);
+        given(tripPlaceEditingService.getPlaces(tripId, day)).willReturn(mockPlaces);
 
         // when
         ResultActions resultActions = mockMvc.perform(


### PR DESCRIPTION
## 배경
여행 준비 단계에서의 임시 목적지 저장 로직이 필요.

## 작업 사항

### 1. Redis 설정
- 이전 프로젝트에서 얘기를 나눴던 Redis의 보안성을 위한 비밀번호 설정을 하였습니다.
- 아래의 로직을 통해서 비밀번호 존재여부에 따라 설정을 처리하였습니다.
``` java
         if (StringUtils.hasText(pass)) {
             redisStandaloneConfiguration.setPassword(pass);
         }
```

### 2. 여행 준비 단계에서의 목적지 처리 로직
- 최종 목적지가 아니기에 Redis를 이용하여 저장했습니다.
- 저장 과정에서 임의의 UUID로 id를 설정한 것은, 이후에 목적지 관리의 편리성을 위함입니다.
- 현재는 전체 일정에 대한 조회 로직은 없습니다. 이후에 논의 후 추가를 해야할 것 같습니다.

## 추가 논의
이전에 말했듯이 회의를 통해 UI상 어떻게 처리해야할지 정확히 얘기를 나누고, 변화될 로직이 있다면 수정하겠습니다.

## 테스트
- Redis 저장 내역을 보여주고자 했지만, 한글 인코딩 문제로 Postman을 통한 테스트 화면을 가져왔습니다.
- 내용이 많아져 `생성 - 조회` & `수정 - 조회`만 넣었습니다.

| ![image](https://github.com/user-attachments/assets/7389617f-6872-41ce-aeff-b681ed22ef6b) | ![image](https://github.com/user-attachments/assets/d6743f72-b8df-41e5-b1bb-8dafb58a4c33) |
|:---|:---|
| 목적지 추가 과정 | 목적지 조회 (추가 결과) |
| ![image](https://github.com/user-attachments/assets/daea8925-7dbc-4216-8031-e6ba4f163604) | ![image](https://github.com/user-attachments/assets/07a48f7c-0ed5-47d2-b761-b998f6d12ff7) |
| 목적지 수정 과정 | 목적지 조회 (수정 결과) |

 