### PR TITLE
Feature(IL-46): 여행 일정 준비 중, 목적지 확정 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,6 @@ dependencies {
 
     /* Image Metadata Extractor */
     implementation 'com.drewnoakes:metadata-extractor:2.18.0'
-    implementation 'net.coobird:thumbnailator:0.4.20'
 
     /* AWS S3 */
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripPlaceDto.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripPlaceDto.java
@@ -36,4 +36,8 @@ public class TripPlaceDto {
             double longitude,
             String placeCategory
     ) { }
+
+    public record CompleteRequest(
+            int lastDay
+    ) { }
 }

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripPlaceDto.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripPlaceDto.java
@@ -37,7 +37,9 @@ public class TripPlaceDto {
             String placeCategory
     ) { }
 
+    @Schema(name = "TripPlaceDto.CompleteRequest", description = "여행 목적지 선택 완료 요청 DTO")
     public record CompleteRequest(
+            @Schema(description = "편집 완료된 마지막 일차", example = "5")
             int lastDay
     ) { }
 }

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceSavingService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceSavingService.java
@@ -1,0 +1,87 @@
+package kr.co.yeogiga.application.trip.service;
+
+import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.domain.tripplace.TripDayPlaceService;
+import kr.co.yeogiga.domain.tripplace.entity.Place;
+import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import kr.co.yeogiga.infrastructure.redis.constant.PlaceConstant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TripPlaceSavingService {
+    private final TripDayPlaceService tripDayPlaceService;
+    private final RedisRepository redisRepository;
+
+    /**
+     * 여행 생성 완료 시, Redis에 임시 저장된 일차별 목적지들을 MongoDB에 저장하는 메서드
+     * - 1일차부터 lastDay까지 순회하며 TripDayPlace 생성
+     * - Redis에 임시 저장한 데이터 삭제 (list, set)
+     * - 생성된 TripDayPlace 리스트를 MongoDB에 일괄 저장
+     *
+     * @param tripId  : 여행 ID
+     * @param lastDay : 여행 마지막 일차
+     */
+    public void completeTrip(Long tripId, int lastDay) {
+        List<TripDayPlace> tripDayPlaces = new ArrayList<>();
+
+        for (int day = 1; day <= lastDay; day++) {
+            tripDayPlaces.add(createTripDayPlace(tripId, day));
+
+            // Redis에 임시 저장된 데이터 삭제
+            redisRepository.del(PlaceConstant.listKey(tripId, day));
+            redisRepository.del(PlaceConstant.setKey(tripId, day));
+        }
+
+        tripDayPlaceService.saveAll(tripDayPlaces);
+    }
+
+    /**
+     * 특정 일자(day)에 해당하는 TripDayPlace 객체 생성
+     *
+     * @param tripId : 여행 ID
+     * @param day    : 일차 (1일차, 2일차 ...)
+     * @return : 생성된 TripDayPlace
+     */
+    private TripDayPlace createTripDayPlace(Long tripId, int day) {
+        String listKey = PlaceConstant.listKey(tripId, day);
+        List<TripPlaceDto.StoredFormat> storedPlaces
+                = redisRepository.getList(listKey, TripPlaceDto.StoredFormat.class);
+
+        List<Place> places = new ArrayList<>();
+        for (int i = 0; i < storedPlaces.size(); i++) {
+            TripPlaceDto.StoredFormat stored = storedPlaces.get(i);
+            places.add(convertToPlace(stored, i));
+        }
+
+        return TripDayPlace.builder()
+                .tripId(tripId)
+                .day(day)
+                .places(places)
+                .build();
+    }
+
+    /**
+     * StoredFormat -> Place 변환 (순서(order) 반영)
+     * - 순서(order)는 10씩 증가. (효율적인 목적지 순서 번경을 위함)
+     *
+     * @param stored : 저장된 StoredFormat
+     * @param index  : 리스트 내 순서
+     * @return : Place 변환 객체
+     */
+    private Place convertToPlace(TripPlaceDto.StoredFormat stored, int index) {
+        return Place.builder()
+                .id(stored.id())
+                .name(stored.name())
+                .latitude(stored.latitude())
+                .longitude(stored.longitude())
+                .placeType(stored.placeCategory())
+                .order(index * 10.0)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceSavingService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceSavingService.java
@@ -81,7 +81,7 @@ public class TripPlaceSavingService {
                 .latitude(stored.latitude())
                 .longitude(stored.longitude())
                 .placeType(stored.placeCategory())
-                .order(index * 10.0)
+                .order((index + 1) * 10.0)
                 .build();
     }
 }

--- a/src/main/java/kr/co/yeogiga/common/response/success/SuccessResponse.java
+++ b/src/main/java/kr/co/yeogiga/common/response/success/SuccessResponse.java
@@ -18,6 +18,13 @@ public record SuccessResponse<T>(
                 .build();
     }
 
+    public static SuccessResponse<?> created() {
+        return SuccessResponse.builder()
+                .code(HttpStatus.CREATED.value())
+                .message("요청이 성공하였습니다.")
+                .build();
+    }
+
     public static <T> SuccessResponse<?> from(T data) {
         return SuccessResponse.builder()
                 .code(HttpStatus.OK.value())

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/TripDayPlaceRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/TripDayPlaceRepository.java
@@ -1,0 +1,7 @@
+package kr.co.yeogiga.domain.tripplace;
+
+import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface TripDayPlaceRepository extends MongoRepository<TripDayPlace, String > {
+}

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/TripDayPlaceRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/TripDayPlaceRepository.java
@@ -3,5 +3,5 @@ package kr.co.yeogiga.domain.tripplace;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface TripDayPlaceRepository extends MongoRepository<TripDayPlace, String > {
+public interface TripDayPlaceRepository extends MongoRepository<TripDayPlace, String> {
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/TripDayPlaceService.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/TripDayPlaceService.java
@@ -1,0 +1,17 @@
+package kr.co.yeogiga.domain.tripplace;
+
+import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TripDayPlaceService {
+    private final TripDayPlaceRepository tripDayPlaceRepository;
+
+    public void saveAll(List<TripDayPlace> tripDayPlaces) {
+        tripDayPlaceRepository.saveAll(tripDayPlaces);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
@@ -1,11 +1,9 @@
 package kr.co.yeogiga.domain.tripplace.entity;
 
-import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Getter
 public class Place {
@@ -13,17 +11,18 @@ public class Place {
     private String name;
     private double latitude;
     private double longitude;
-    private PlaceCategory type;
+    private String placeType;
     private double order;
     private LocalDateTime visitedAt;
 
     @Builder
-    public Place(String name, double latitude, double longitude, PlaceCategory type, double order, LocalDateTime visitedAt) {
-        this.id = UUID.randomUUID().toString();
+    public Place(String id, String name, double latitude, double longitude,
+                 String placeType, double order, LocalDateTime visitedAt) {
+        this.id = id;
         this.name = name;
         this.latitude = latitude;
         this.longitude = longitude;
-        this.type = type;
+        this.placeType = placeType;
         this.order = order;
         this.visitedAt = visitedAt;
     }

--- a/src/main/java/kr/co/yeogiga/presentation/image/api/ImageApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/image/api/ImageApi.java
@@ -24,11 +24,11 @@ public interface ImageApi {
     @TrackApi(description = "이미지 업로드")
     @Operation(summary = "이미지 업로드", description = "이미지 업로드하는 API입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "이미지 업로드 성공",
+            @ApiResponse(responseCode = "201", description = "이미지 업로드 성공",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                         {
-                                            "code": 200,
+                                            "code": 201,
                                             "message": "요청이 성공하였습니다."
                                         }
                                     """)

--- a/src/main/java/kr/co/yeogiga/presentation/image/controller/ImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/image/controller/ImageController.java
@@ -31,7 +31,7 @@ public class ImageController implements ImageApi {
     public ResponseEntity<?> uploadImages(@RequestPart(value = "images", required = false) List<MultipartFile> images,
                                           @PathVariable Long tripId) {
         imageUploadProcessor.process(images, tripId);
-        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.ok());
+        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
     }
 
     @Override

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
@@ -26,7 +26,7 @@ public interface TripPlaceEditingApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                         {
-                                            "code": 200,
+                                            "code": 201,
                                             "message": "요청이 성공하였습니다."
                                         }
                                     """)

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceSavingApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceSavingApi.java
@@ -24,7 +24,7 @@ public interface TripPlaceSavingApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                         {
-                                            "code": 200,
+                                            "code": 201,
                                             "message": "요청이 성공하였습니다."
                                         }
                                     """)

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceSavingApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceSavingApi.java
@@ -1,0 +1,35 @@
+package kr.co.yeogiga.presentation.trip.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@ApiGroup(value = "[여행 목적지 확정 API]")
+@Tag(name = "[여행 목적지 확정 API]", description = "여행 목적지 확정 관련 API")
+public interface TripPlaceSavingApi {
+
+    @TrackApi(description = "여행 목적지 확정")
+    @Operation(summary = "여행 목적지 확정", description = "여행 목적지를 확정하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "여행 목적지 확정 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> completeTrip(@PathVariable Long tripId,
+                                   @RequestBody TripPlaceDto.CompleteRequest request);
+}

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
@@ -31,7 +31,7 @@ public class TripPlaceEditingController implements TripPlaceEditingApi {
                                       @RequestBody TripPlaceDto.Request request) {
 
         tripPlaceEditingService.addPlace(tripId, day, request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.ok());
+        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
     }
 
     @Override

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceSavingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceSavingController.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.presentation.trip.controller;
 import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
 import kr.co.yeogiga.application.trip.service.TripPlaceSavingService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.presentation.trip.api.TripPlaceSavingApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,9 +16,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/trip")
 @RequiredArgsConstructor
-public class TripPlaceSavingController {
+public class TripPlaceSavingController implements TripPlaceSavingApi {
     private final TripPlaceSavingService tripPlaceSavingService;
 
+    @Override
     @PostMapping("/{tripId}/complete")
     public ResponseEntity<?> completeTrip(@PathVariable Long tripId,
                                           @RequestBody TripPlaceDto.CompleteRequest request) {

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceSavingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceSavingController.java
@@ -1,0 +1,28 @@
+package kr.co.yeogiga.presentation.trip.controller;
+
+import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.application.trip.service.TripPlaceSavingService;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/trip")
+@RequiredArgsConstructor
+public class TripPlaceSavingController {
+    private final TripPlaceSavingService tripPlaceSavingService;
+
+    @PostMapping("/{tripId}/complete")
+    public ResponseEntity<?> completeTrip(@PathVariable Long tripId,
+                                          @RequestBody TripPlaceDto.CompleteRequest request) {
+
+        tripPlaceSavingService.completeTrip(tripId, request.lastDay());
+        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.ok());
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceSavingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceSavingController.java
@@ -25,6 +25,6 @@ public class TripPlaceSavingController implements TripPlaceSavingApi {
                                           @RequestBody TripPlaceDto.CompleteRequest request) {
 
         tripPlaceSavingService.completeTrip(tripId, request.lastDay());
-        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.ok());
+        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
     }
 }

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -25,4 +25,4 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
-      password: ${REDIS_PASS}
+      password: ${REDIS_PASS:}

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceSavingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceSavingServiceTest.java
@@ -1,0 +1,64 @@
+package kr.co.yeogiga.application.trip.service;
+
+import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.domain.tripplace.TripDayPlaceService;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import kr.co.yeogiga.infrastructure.redis.constant.PlaceConstant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TripPlaceSavingServiceTest {
+
+    @Mock
+    private TripDayPlaceService tripDayPlaceService;
+
+    @Mock
+    private RedisRepository redisRepository;
+
+    @InjectMocks
+    private TripPlaceSavingService tripPlaceSavingService;
+
+    private final Long tripId = 1L;
+    private final int lastDay = 2;
+
+    @Test
+    @DisplayName("여행 생성 완료 성공")
+    void completeTripSuccess() {
+        // given
+        TripPlaceDto.StoredFormat place1 = new TripPlaceDto.StoredFormat(
+                "id1", "장소1", 33.123, 126.456, "관광지"
+        );
+        TripPlaceDto.StoredFormat place2 = new TripPlaceDto.StoredFormat(
+                "id2", "장소2", 33.789, 126.987, "식당"
+        );
+
+        when(redisRepository.getList(anyString(), eq(TripPlaceDto.StoredFormat.class)))
+                .thenReturn(List.of(place1))
+                .thenReturn(List.of(place2));
+
+        // when
+        tripPlaceSavingService.completeTrip(tripId, lastDay);
+
+        // then
+        verify(redisRepository, times(2)).getList(anyString(), eq(TripPlaceDto.StoredFormat.class));
+        verify(tripDayPlaceService, times(1)).saveAll(any());
+        verify(redisRepository, times(1)).del(PlaceConstant.listKey(tripId, 1));
+        verify(redisRepository, times(1)).del(PlaceConstant.setKey(tripId, 1));
+        verify(redisRepository, times(1)).del(PlaceConstant.listKey(tripId, 2));
+        verify(redisRepository, times(1)).del(PlaceConstant.setKey(tripId, 2));
+    }
+}

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceSavingControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceSavingControllerTest.java
@@ -1,0 +1,74 @@
+package kr.co.yeogiga.presentation.trip.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.application.trip.service.TripPlaceSavingService;
+import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = TripPlaceSavingController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthenticationFilter.class})
+        }
+)
+public class TripPlaceSavingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private TripPlaceSavingService tripPlaceSavingService;
+
+    private final Long tripId = 1L;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .build();
+    }
+
+    @Test
+    @DisplayName("여행 목적지 확정 완료")
+    void completeTripSuccess() throws Exception {
+        // given
+        TripPlaceDto.CompleteRequest completeRequest = new TripPlaceDto.CompleteRequest(2);
+        doNothing().when(tripPlaceSavingService).completeTrip(tripId, completeRequest.lastDay());
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/trip/{tripId}/complete", tripId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(completeRequest))
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
+    }
+}


### PR DESCRIPTION
## 배경
사용자가 여행 목적지를 확정하면, redis에 임시 저장한 데이터를 nosql로 이동해야함.

## 작업 사항
1. MongoDB saveAll()을 통한 batch insert (2a02dfdd6f240ec6e4f46def0c66c9c06af02854)
- MongoDB는 Mysql에서의 saveAll()동작과는 다르게 벌크 연산이 가능합기에 saveAll()을 이용
    - 이전 프로젝트(Muzusi)에서 얘기했었던 [stackoverflow](https://stackoverflow.com/questions/53996227/is-saveall-of-mongorepository-inserting-data-in-one-bulk)내용과 동일합니다!

2. 여행 목적지 확정 로직 구현 (5b6464546608d327c452b1119933281cccdb0217)
- 클라이언트로부터 마지막 날짜 (3일 여행이면, 3)를 받으면, 그 날짜를 기반으로 redis에 저장되어 있던 데이터를 Nosql로 이동시킵니다.
- 이동시킨 후, redis에서의 값은 삭제합니다.
- 저장을 할 떄, `TripPlaceSavingService. convertToPlace`에서 `.order((index + 1) * 10.0)`을 볼 수 있는데, 이전에 말한 것 처럼 목적지 순서를 변경할 떄, 편리하게 수정하기 위해 10부터 10씩 증가합니다.

## 추가 논의
- 여행 목적지 확정 로직 중, 마지막 날짜를 보내야 함을 프론트 쪽에 인지시켜야 할 것 같습니다! (Swagger에 명시하긴 함)
- `TripDayPlace`에서 `date`필드, `Place`에서 `visitedAt`는 아직 값을 넣어주지 않았고, 추후에 얘기를 나눠본 후 넣으면 될 것 같습니다

## 테스트
| <img width="553" alt="스크린샷 2025-04-28 오후 10 27 36" src="https://github.com/user-attachments/assets/4f8b2367-eb98-4dc5-81c9-16128fae2612" /> |
|---|
| 여행 목적지 확정 후, nosql에 저장된 형태 |

