### PR TITLE
Feature(IL-47): refresh token 관리

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
@@ -1,0 +1,39 @@
+package kr.co.yeogiga.application.auth.service;
+
+import kr.co.yeogiga.application.auth.dto.TokenDto;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.exception.UserErrorType;
+import kr.co.yeogiga.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final RefreshTokenService refreshTokenService;
+    private final UserService userService;
+    private final JwtService jwtService;
+
+    public TokenDto reissueToken(String refreshToken) {
+        Long userId = jwtService.extractUserId(refreshToken);
+
+        if (!refreshTokenService.exists(userId)) {
+            throw new CustomException(AuthErrorType.REFRESH_TOKEN_EXPIRED);
+        }
+
+        User user = userService.readById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
+
+        TokenDto reissuedToken = jwtService.generateToken(user.getUsername(), user.getNickname(), user.getId());
+        refreshTokenService.save(userId, reissuedToken.refreshToken());
+
+        return reissuedToken;
+    }
+
+    public void signOut(String refreshToken) {
+        Long userId = jwtService.extractUserId(refreshToken);
+        refreshTokenService.delete(userId);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
@@ -16,6 +16,12 @@ public class AuthService {
     private final UserService userService;
     private final JwtService jwtService;
 
+    /**
+     * 토큰 재발급 메서드
+     *
+     * @param refreshToken  리프레시 토큰
+     * @return              신규 발급 토큰(accessToken, refreshToken)
+     */
     public TokenDto reissueToken(String refreshToken) {
         Long userId = jwtService.extractUserId(refreshToken);
 
@@ -32,6 +38,11 @@ public class AuthService {
         return reissuedToken;
     }
 
+    /**
+     * 로그아웃 메서드
+     *
+     * @param refreshToken  리프레시 토큰
+     */
     public void signOut(String refreshToken) {
         Long userId = jwtService.extractUserId(refreshToken);
         refreshTokenService.delete(userId);

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -21,6 +21,7 @@ public class OAuthManagementService {
     private final OAuthClientFactory oAuthClientFactory;
     private final OAuthService oAuthService;
     private final JwtService jwtService;
+    private final RefreshTokenService refreshTokenService;
     private final UserService userService;
 
     /**
@@ -86,6 +87,7 @@ public class OAuthManagementService {
 
     /**
      * 로그인 요청 응답 DTO 생성 메서드
+     * - 토큰 생성 시, 리프레시 토큰 저장
      *
      * @param userStatus    User, 추가 정보 입력 여부
      * @return              로그인 응답 정보 (JWT, 추가 정보 입력 필요 여부)
@@ -97,6 +99,7 @@ public class OAuthManagementService {
         Long userId = user.getId();
 
         TokenDto token = jwtService.generateToken(username, nickname, userId);
+        refreshTokenService.save(userId, token.refreshToken());
 
         return SignInDto.Response.builder()
                 .token(token)

--- a/src/main/java/kr/co/yeogiga/application/auth/service/RefreshTokenService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/RefreshTokenService.java
@@ -1,0 +1,32 @@
+package kr.co.yeogiga.application.auth.service;
+
+import kr.co.yeogiga.infrastructure.properties.JwtProperties;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import kr.co.yeogiga.infrastructure.redis.constant.TokenConstant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+    private final JwtProperties jwtProperties;
+    private final RedisRepository redisRepository;
+
+    public void save(Long userId, String token) {
+        redisRepository.set(
+                TokenConstant.parseRefreshTokenKey(userId),
+                token,
+                Duration.ofSeconds(jwtProperties.getRefreshTokenExpiration())
+        );
+    }
+
+    public void delete(Long userId) {
+        redisRepository.del(TokenConstant.parseRefreshTokenKey(userId));
+    }
+
+    public boolean exists(Long userId) {
+        return redisRepository.existed(TokenConstant.parseRefreshTokenKey(userId));
+    }
+}

--- a/src/main/java/kr/co/yeogiga/common/util/CookieUtil.java
+++ b/src/main/java/kr/co/yeogiga/common/util/CookieUtil.java
@@ -12,4 +12,14 @@ public class CookieUtil {
                 .sameSite("None")
                 .build();
     }
+
+    public static ResponseCookie removeCookie(String key) {
+        return ResponseCookie.from(key, "")
+                .path("/")
+                .httpOnly(true)
+                .maxAge(0)
+                .secure(true)
+                .sameSite("None")
+                .build();
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
@@ -17,6 +17,8 @@ public enum AuthErrorType implements BaseErrorType {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A005", "잘못된 토큰입니다."),
     INVALID_TOKEN_SIGNATURE(HttpStatus.UNAUTHORIZED, "A006", "토큰 서명이 잘못되었습니다."),
     UNKNOWN_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, "A007", "토큰 인증 과정 중 에러가 발생하였습니다."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.NOT_FOUND, "A008", "리프레시 토큰이 만료되었습니다. 재로그인 해주세요."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "A009", "리프레시 토큰을 찾을 수 없습니다.")
     ;
 
 

--- a/src/main/java/kr/co/yeogiga/domain/user/exception/UserErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/exception/UserErrorType.java
@@ -1,0 +1,33 @@
+package kr.co.yeogiga.domain.user.exception;
+
+import kr.co.yeogiga.common.response.error.type.BaseErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * User ErrorCode: Uxxx
+ */
+@RequiredArgsConstructor
+public enum UserErrorType implements BaseErrorType {
+    NOT_FOUND(HttpStatus.NOT_FOUND, "U000", "존재하지 않는 사용자입니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
@@ -6,10 +6,11 @@ public final class EndpointConstants {
     public static final String[] PUBLIC_ENDPOINTS = {
             "/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**",
             "/webjars/**", "/error", "/api-checker/**", "/v1/api/link/checker/**",
-            "/api/v1/auth/**"
+            "/api/v1/auth/oauth/**", "/api/v1/auth/reissue",
     };
 
     public static final String[] USER_ENDPOINTS = {
-            "/api/v1/trip/**"
+            "/api/v1/trip/**",
+            "/api/v1/auth/sign-out"
     };
 }

--- a/src/main/java/kr/co/yeogiga/infrastructure/redis/constant/TokenConstant.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/redis/constant/TokenConstant.java
@@ -1,0 +1,11 @@
+package kr.co.yeogiga.infrastructure.redis.constant;
+
+public final class TokenConstant {
+    private TokenConstant() { }
+
+    public static final String REFRESH_TOKEN_PREFIX = "refresh_token:%d";
+
+    public static String parseRefreshTokenKey(Long userId) {
+        return String.format(REFRESH_TOKEN_PREFIX, userId);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
@@ -13,7 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestHeader;
 
-@ApiGroup(value = "[OAuth2 인증 API]")
+@ApiGroup(value = "[인증 API]")
 @Tag(name = "[인증 API]", description = "인증 관련 API")
 public interface AuthApi {
 

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
@@ -40,23 +40,11 @@ public interface AuthApi {
                                                  "refreshToken": "xxxxx.xxxxx.xxxxx"
                                              }
                                         }
-                                    """),
-                            @ExampleObject(name = "기존 회원가입된 사용자(웹)", description = "웹은 refresh token이 쿠키로 전달", value = """
-                                        {
-                                             "code": 200,
-                                             "message": "요청이 성공하였습니다.",
-                                             "data": {
-                                                 "token": {
-                                                     "accessToken": "xxxxx.xxxxx.xxxxx"
-                                                 },
-                                                 "shouldSignup": false
-                                             }
-                                         }
                                     """)
                     })),
-            @ApiResponse(responseCode = "404", description = "쿠키에 리프레시 토큰이 없을 경우",
+            @ApiResponse(responseCode = "404", description = "리프레시 토큰이 없을 경우",
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name = "쿠키 내 리프레시 토큰 미포함", value = """
+                            @ExampleObject(name = "리프레시 토큰 미포함", value = """
                                         {
                                              "code": "A009",
                                              "message": "리프레시 토큰을 찾을 수 없습니다."
@@ -71,8 +59,9 @@ public interface AuthApi {
                     }))
     })
     ResponseEntity<?> reissueToken(
-            @RequestHeader(value = "device") Device device,
-            @CookieValue(name = "refreshToken", required = false) String refreshToken
+            @RequestHeader(name = "device") Device device,
+            @RequestHeader(name = "refreshToken", required = false) String refreshTokenInHeader,
+            @CookieValue(name = "refreshToken", required = false) String refreshTokenInCookie
     );
 
     @TrackApi(description = "로그아웃")
@@ -97,6 +86,10 @@ public interface AuthApi {
                                     """)
                     }))
     })
-    ResponseEntity<?> signOut(@CookieValue(name = "refreshToken", required = false) String refreshToken);
+    ResponseEntity<?> signOut(
+            @RequestHeader(name = "device") Device device,
+            @RequestHeader(name = "refreshToken", required = false) String refreshTokenInHeader,
+            @CookieValue(name = "refreshToken", required = false) String refreshTokenInCookie
+    );
 
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
@@ -1,0 +1,102 @@
+package kr.co.yeogiga.presentation.auth.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.yeogiga.application.auth.type.Device;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@ApiGroup(value = "[OAuth2 인증 API]")
+@Tag(name = "[인증 API]", description = "인증 관련 API")
+public interface AuthApi {
+
+    @TrackApi(description = "토큰 재발급")
+    @Operation(summary = "토큰 재발급", description = "토큰(access token, refresh token) 재발급 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "토큰 재발급 성공(웹)", value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": {
+                                                "accessToken": "xxxxx.xxxxx.xxxxx"
+                                            }
+                                        }
+                                    """),
+                            @ExampleObject(name = "토큰 재발급 성공(모바일)", value = """
+                                        {
+                                             "code": 200,
+                                             "message": "요청이 성공하였습니다.",
+                                             "data": {
+                                                 "accessToken": "xxxxx.xxxxx.xxxxx",
+                                                 "refreshToken": "xxxxx.xxxxx.xxxxx"
+                                             }
+                                        }
+                                    """),
+                            @ExampleObject(name = "기존 회원가입된 사용자(웹)", description = "웹은 refresh token이 쿠키로 전달", value = """
+                                        {
+                                             "code": 200,
+                                             "message": "요청이 성공하였습니다.",
+                                             "data": {
+                                                 "token": {
+                                                     "accessToken": "xxxxx.xxxxx.xxxxx"
+                                                 },
+                                                 "shouldSignup": false
+                                             }
+                                         }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "쿠키에 리프레시 토큰이 없을 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "쿠키 내 리프레시 토큰 미포함", value = """
+                                        {
+                                             "code": "A009",
+                                             "message": "리프레시 토큰을 찾을 수 없습니다."
+                                        }
+                                    """),
+                            @ExampleObject(name = "리프레시 토큰 만료", description = "리프레시 토큰이 만료되어 Redis 내에서 삭제된 경우", value = """
+                                        {
+                                            "code": "A008",
+                                            "message": "리프레시 토큰이 만료되었습니다. 재로그인 해주세요."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> reissueToken(
+            @RequestHeader(value = "device") Device device,
+            @CookieValue(name = "refreshToken", required = false) String refreshToken
+    );
+
+    @TrackApi(description = "로그아웃")
+    @Operation(summary = "로그아웃", description = "로그아웃")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "로그아웃 성공", value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "401", description = "로그아웃 실패 - 인증",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "Authorization 헤더 미포함", value = """
+                                        {
+                                            "code": "A003",
+                                            "message": "인증에 실패하였습니다. 토큰을 확인해주세요."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> signOut(@CookieValue(name = "refreshToken", required = false) String refreshToken);
+
+}

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
@@ -1,0 +1,64 @@
+package kr.co.yeogiga.presentation.auth.controller;
+
+import kr.co.yeogiga.application.auth.dto.TokenDto;
+import kr.co.yeogiga.application.auth.service.AuthService;
+import kr.co.yeogiga.application.auth.type.Device;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.common.util.CookieUtil;
+import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static kr.co.yeogiga.application.auth.constant.AuthConstants.REFRESH_TOKEN_PREFIX;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    @GetMapping("/reissue")
+    public ResponseEntity<?> reissueToken(
+            @RequestHeader(value = "device") Device device,
+            @CookieValue(name = "refreshToken", required = false) String refreshToken
+    ) {
+        if (refreshToken == null) {
+            throw new CustomException(AuthErrorType.REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        return createReissueTokenResponse(device, authService.reissueToken(refreshToken));
+    }
+
+    @GetMapping("/sign-out")
+    public ResponseEntity<?> signOut(@CookieValue(name = "refreshToken", required = false) String refreshToken) {
+        if (refreshToken != null) {
+            authService.signOut(refreshToken);
+        }
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, CookieUtil.removeCookie(REFRESH_TOKEN_PREFIX).toString())
+                .body(SuccessResponse.ok());
+    }
+
+    private ResponseEntity<?> createReissueTokenResponse(Device device, TokenDto reissuedToken) {
+        return switch (device) {
+            case MOBILE -> ResponseEntity.ok(SuccessResponse.from(reissuedToken));
+            case WEB -> ResponseEntity.ok()
+                    .header(HttpHeaders.SET_COOKIE, CookieUtil.createCookie(
+                            REFRESH_TOKEN_PREFIX,
+                            reissuedToken.refreshToken(),
+                            Duration.ofDays(7).toSeconds()).toString()
+                    ).body(SuccessResponse.from(Map.of("accessToken", reissuedToken.accessToken())));
+        };
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.util.CookieUtil;
 import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
+import kr.co.yeogiga.presentation.auth.api.AuthApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +25,7 @@ import static kr.co.yeogiga.application.auth.constant.AuthConstants.REFRESH_TOKE
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
-public class AuthController {
+public class AuthController implements AuthApi {
     private final AuthService authService;
 
     @GetMapping("/reissue")

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
@@ -51,6 +51,14 @@ public class AuthController implements AuthApi {
                 .body(SuccessResponse.ok());
     }
 
+    /**
+     * 토큰 재발급 시 HTTP 응답 생성 메서드
+     *
+     * @param device            사용자 장치(WEB, MOBILE)
+     * @param reissuedToken     신규 발급 토큰(accessToken, refreshToken)
+     * @return                  MOBILE -> accessToken(body), refreshToken(body)
+     *                          WEB    -> accessToken(body), refreshToken(cookie)
+     */
     private ResponseEntity<?> createReissueTokenResponse(Device device, TokenDto reissuedToken) {
         return switch (device) {
             case MOBILE -> ResponseEntity.ok(SuccessResponse.from(reissuedToken));

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
@@ -1,6 +1,5 @@
 package kr.co.yeogiga.presentation.auth.controller;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import kr.co.yeogiga.application.auth.dto.TokenDto;
 import kr.co.yeogiga.application.auth.service.AuthService;
 import kr.co.yeogiga.application.auth.type.Device;

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.presentation.auth.controller;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import kr.co.yeogiga.application.auth.dto.TokenDto;
 import kr.co.yeogiga.application.auth.service.AuthService;
 import kr.co.yeogiga.application.auth.type.Device;
@@ -30,20 +31,33 @@ public class AuthController implements AuthApi {
 
     @GetMapping("/reissue")
     public ResponseEntity<?> reissueToken(
-            @RequestHeader(value = "device") Device device,
-            @CookieValue(name = "refreshToken", required = false) String refreshToken
+            @RequestHeader(name = "device") Device device,
+            @RequestHeader(name = "refreshToken", required = false) String refreshTokenInHeader,
+            @CookieValue(name = "refreshToken", required = false) String refreshTokenInCookie
     ) {
-        if (refreshToken == null) {
+        if ((device.equals(Device.WEB) && refreshTokenInCookie == null)
+            || (device.equals(Device.MOBILE) && refreshTokenInHeader == null)) {
             throw new CustomException(AuthErrorType.REFRESH_TOKEN_NOT_FOUND);
         }
 
-        return createReissueTokenResponse(device, authService.reissueToken(refreshToken));
+        return switch (device) {
+            case MOBILE -> createReissueTokenResponse(device, authService.reissueToken(refreshTokenInHeader));
+            case WEB -> createReissueTokenResponse(device, authService.reissueToken(refreshTokenInCookie));
+        };
     }
 
     @GetMapping("/sign-out")
-    public ResponseEntity<?> signOut(@CookieValue(name = "refreshToken", required = false) String refreshToken) {
-        if (refreshToken != null) {
-            authService.signOut(refreshToken);
+    public ResponseEntity<?> signOut(
+            @RequestHeader(name = "device") Device device,
+            @RequestHeader(name = "refreshToken", required = false) String refreshTokenInHeader,
+            @CookieValue(name = "refreshToken", required = false) String refreshTokenInCookie
+    ) {
+        if (device.equals(Device.WEB) && refreshTokenInCookie != null) {
+            authService.signOut(refreshTokenInCookie);
+        }
+
+        if (device.equals(Device.MOBILE) && refreshTokenInHeader != null) {
+            authService.signOut(refreshTokenInHeader);
         }
 
         return ResponseEntity.ok()

--- a/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
@@ -1,0 +1,87 @@
+package kr.co.yeogiga.application.auth.service;
+
+import kr.co.yeogiga.application.auth.dto.TokenDto;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.service.UserService;
+import kr.co.yeogiga.domain.user.type.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private JwtService jwtService;
+
+    @InjectMocks
+    private AuthService authService;
+
+    private final Long userId = 1L;
+
+    private final User user = User.builder()
+            .nickname("test")
+            .username("test")
+            .password("test")
+            .email("test@test.com")
+            .role(Role.USER)
+            .build();
+
+    private final TokenDto tokenDto = TokenDto.builder()
+            .accessToken("test-access-token")
+            .refreshToken("test-refresh-token")
+            .build();
+
+    @Test
+    @DisplayName("토큰 재발급 - 성공")
+    void successReissueToken() {
+        // given
+        when(jwtService.extractUserId(any())).thenReturn(userId);
+        when(refreshTokenService.exists(userId)).thenReturn(true);
+        when(userService.readById(userId)).thenReturn(Optional.ofNullable(user));
+        when(jwtService.generateToken(any(), any(), any())).thenReturn(tokenDto);
+        doNothing().when(refreshTokenService).save(userId, tokenDto.refreshToken());
+
+        // when
+        TokenDto reissuedToken = authService.reissueToken("old-refresh-token");
+
+        // then
+        verify(refreshTokenService).save(userId, reissuedToken.refreshToken());
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 - 실패")
+    void failReissueToken() {
+        // given
+        when(jwtService.extractUserId(any())).thenReturn(userId);
+        when(refreshTokenService.exists(userId)).thenReturn(false); // refresh token 만료
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () ->
+                authService.reissueToken("old-refresh-token")
+        );
+
+        // then
+        assertEquals(AuthErrorType.REFRESH_TOKEN_EXPIRED, exception.getErrorType());
+    }
+
+}

--- a/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
@@ -69,7 +69,7 @@ public class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("토큰 재발급 - 실패")
+    @DisplayName("토큰 재발급 - 실패: 리프레시 토큰 만료")
     void failReissueToken() {
         // given
         when(jwtService.extractUserId(any())).thenReturn(userId);

--- a/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
@@ -45,7 +45,8 @@ public class AuthControllerTest {
     @MockBean
     private AuthService authService;
 
-    private final Cookie refreshTokenCookie = new Cookie("refreshToken", "test-refresh-token");
+    private final Cookie refreshTokenInCookie = new Cookie("refreshToken", "test-refresh-token");
+    private final String refreshTokenInHeader = "test-refresh-token";
 
     @BeforeEach
     void setUp(WebApplicationContext webApplicationContext) {
@@ -55,27 +56,52 @@ public class AuthControllerTest {
                 .build();
     }
 
-    @Test
+    @Nested
     @DisplayName("로그아웃")
-    void successSignOut() throws Exception {
-        // given
-        doNothing().when(authService).signOut(refreshTokenCookie.toString());
+    class  SignOut {
 
-        // when
-        ResultActions result = mockMvc.perform(get("/api/v1/auth/sign-out")
-                .cookie(refreshTokenCookie)
-        );
+        @Test
+        @DisplayName("성공 - 모바일")
+        void successSignOutInMobile() throws Exception {
+            // given
+            doNothing().when(authService).signOut(refreshTokenInHeader);
 
-        // then
-        result
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/auth/sign-out")
+                            .header("refreshToken", refreshTokenInHeader)
+                            .header("device", Device.MOBILE)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
+
+        @Test
+        @DisplayName("성공 - 웹")
+        void successSignOutInWeb() throws Exception {
+            // given
+            doNothing().when(authService).signOut(refreshTokenInCookie.getValue());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/auth/sign-out")
+                            .cookie(refreshTokenInCookie)
+                            .header("device", Device.WEB)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
     }
 
     @Nested
     @DisplayName("토큰 재발급")
     class TokenReissue {
-
         private final TokenDto tokenDto = TokenDto.builder()
                 .accessToken("test-access-token")
                 .refreshToken("test-refresh-token")
@@ -85,16 +111,17 @@ public class AuthControllerTest {
         @DisplayName("성공 - 모바일")
         void successReissueTokenInMobile() throws Exception {
             // given
-            when(authService.reissueToken(refreshTokenCookie.getValue())).thenReturn(tokenDto);
+            when(authService.reissueToken(refreshTokenInCookie.getValue())).thenReturn(tokenDto);
 
             // when
-            ResultActions result = mockMvc.perform(get("/api/v1/auth/reissue")
-                    .header("device", Device.MOBILE.toString())
-                    .cookie(refreshTokenCookie)
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/auth/reissue")
+                        .header("device", Device.MOBILE.toString())
+                        .header("refreshToken", refreshTokenInHeader)
             );
 
             // then
-            result
+            resultActions
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
                     .andExpect(jsonPath("$.data.refreshToken").isNotEmpty());
@@ -105,16 +132,17 @@ public class AuthControllerTest {
         @DisplayName("성공 - 웹")
         void successReissueTokenInWeb() throws Exception {
             // given
-            when(authService.reissueToken(refreshTokenCookie.getValue())).thenReturn(tokenDto);
+            when(authService.reissueToken(refreshTokenInCookie.getValue())).thenReturn(tokenDto);
 
             // when
-            ResultActions result = mockMvc.perform(get("/api/v1/auth/reissue")
-                    .header("device", Device.WEB.toString())
-                    .cookie(refreshTokenCookie)
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/auth/reissue")
+                        .header("device", Device.WEB.toString())
+                        .cookie(refreshTokenInCookie)
             );
 
             // then
-            result
+            resultActions
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
                     .andExpect(cookie().exists(AuthConstants.REFRESH_TOKEN_PREFIX));
@@ -122,39 +150,82 @@ public class AuthControllerTest {
         }
 
         @Test
-        @DisplayName("실패 - 쿠키 미포함")
-        void failReissueToken() throws Exception {
+        @DisplayName("실패 - 웹 리프레시 토큰 미포함")
+        void failReissueTokenInWeb() throws Exception {
             // given
-            when(authService.reissueToken(refreshTokenCookie.getValue())).thenReturn(tokenDto);
+            when(authService.reissueToken(refreshTokenInCookie.getValue())).thenReturn(tokenDto);
 
             // when
 
-            ResultActions result = mockMvc.perform(get("/api/v1/auth/reissue")
-                    .header("device", Device.WEB)
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/auth/reissue")
+                            .header("device", Device.WEB)
             );
 
             // then
-            result
+            resultActions
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.code").value("A009"));
 
         }
 
         @Test
-        @DisplayName("실패 - 리프레시 토큰 만료")
-        void failReissueTokenExpiredToken() throws Exception {
+        @DisplayName("실패 - 모바일 리프레시 토큰 미포함")
+        void failReissueTokenInMobile() throws Exception {
             // given
-            when(authService.reissueToken(refreshTokenCookie.getValue())).thenThrow(new CustomException(AuthErrorType.REFRESH_TOKEN_EXPIRED));
+            when(authService.reissueToken(refreshTokenInHeader)).thenReturn(tokenDto);
 
             // when
 
-            ResultActions result = mockMvc.perform(get("/api/v1/auth/reissue")
-                    .header("device", Device.WEB)
-                    .cookie(refreshTokenCookie)
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/auth/reissue")
+                            .header("device", Device.WEB)
             );
 
             // then
-            result
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("A009"));
+
+        }
+
+        @Test
+        @DisplayName("실패 - 웹 리프레시 토큰 만료")
+        void failReissueTokenExpiredTokenInWeb() throws Exception {
+            // given
+            when(authService.reissueToken(refreshTokenInCookie.getValue())).thenThrow(new CustomException(AuthErrorType.REFRESH_TOKEN_EXPIRED));
+
+            // when
+
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/auth/reissue")
+                        .header("device", Device.WEB)
+                        .cookie(refreshTokenInCookie)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("A008"));
+
+        }
+
+        @Test
+        @DisplayName("실패 - 모바일 리프레시 토큰 만료")
+        void failReissueTokenExpiredTokenInMobile() throws Exception {
+            // given
+            when(authService.reissueToken(refreshTokenInHeader)).thenThrow(new CustomException(AuthErrorType.REFRESH_TOKEN_EXPIRED));
+
+            // when
+
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/auth/reissue")
+                            .header("device", Device.MOBILE)
+                            .header("refreshToken", refreshTokenInHeader)
+            );
+
+            // then
+            resultActions
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.code").value("A008"));
 

--- a/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
@@ -1,0 +1,163 @@
+package kr.co.yeogiga.presentation.auth.controller;
+
+import jakarta.servlet.http.Cookie;
+import kr.co.yeogiga.application.auth.constant.AuthConstants;
+import kr.co.yeogiga.application.auth.dto.TokenDto;
+import kr.co.yeogiga.application.auth.service.AuthService;
+import kr.co.yeogiga.application.auth.type.Device;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
+import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = AuthController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthenticationFilter.class})
+        }
+)
+public class AuthControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    private final Cookie refreshTokenCookie = new Cookie("refreshToken", "test-refresh-token");
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .alwaysDo(print())
+                .build();
+    }
+
+    @Test
+    @DisplayName("로그아웃")
+    void successSignOut() throws Exception {
+        // given
+        doNothing().when(authService).signOut(refreshTokenCookie.toString());
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/v1/auth/sign-out")
+                .cookie(refreshTokenCookie)
+        );
+
+        // then
+        result
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+    }
+
+    @Nested
+    @DisplayName("토큰 재발급")
+    class TokenReissue {
+
+        private final TokenDto tokenDto = TokenDto.builder()
+                .accessToken("test-access-token")
+                .refreshToken("test-refresh-token")
+                .build();
+
+        @Test
+        @DisplayName("성공 - 모바일")
+        void successReissueTokenInMobile() throws Exception {
+            // given
+            when(authService.reissueToken(refreshTokenCookie.getValue())).thenReturn(tokenDto);
+
+            // when
+            ResultActions result = mockMvc.perform(get("/api/v1/auth/reissue")
+                    .header("device", Device.MOBILE.toString())
+                    .cookie(refreshTokenCookie)
+            );
+
+            // then
+            result
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+                    .andExpect(jsonPath("$.data.refreshToken").isNotEmpty());
+
+        }
+
+        @Test
+        @DisplayName("성공 - 웹")
+        void successReissueTokenInWeb() throws Exception {
+            // given
+            when(authService.reissueToken(refreshTokenCookie.getValue())).thenReturn(tokenDto);
+
+            // when
+            ResultActions result = mockMvc.perform(get("/api/v1/auth/reissue")
+                    .header("device", Device.WEB.toString())
+                    .cookie(refreshTokenCookie)
+            );
+
+            // then
+            result
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+                    .andExpect(cookie().exists(AuthConstants.REFRESH_TOKEN_PREFIX));
+
+        }
+
+        @Test
+        @DisplayName("실패 - 쿠키 미포함")
+        void failReissueToken() throws Exception {
+            // given
+            when(authService.reissueToken(refreshTokenCookie.getValue())).thenReturn(tokenDto);
+
+            // when
+
+            ResultActions result = mockMvc.perform(get("/api/v1/auth/reissue")
+                    .header("device", Device.WEB)
+            );
+
+            // then
+            result
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("A009"));
+
+        }
+
+        @Test
+        @DisplayName("실패 - 리프레시 토큰 만료")
+        void failReissueTokenExpiredToken() throws Exception {
+            // given
+            when(authService.reissueToken(refreshTokenCookie.getValue())).thenThrow(new CustomException(AuthErrorType.REFRESH_TOKEN_EXPIRED));
+
+            // when
+
+            ResultActions result = mockMvc.perform(get("/api/v1/auth/reissue")
+                    .header("device", Device.WEB)
+                    .cookie(refreshTokenCookie)
+            );
+
+            // then
+            result
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("A008"));
+
+        }
+    }
+}

--- a/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
@@ -58,7 +58,7 @@ public class AuthControllerTest {
 
     @Nested
     @DisplayName("로그아웃")
-    class  SignOut {
+    class SignOut {
 
         @Test
         @DisplayName("성공 - 모바일")


### PR DESCRIPTION
## 배경
- Redis 및 쿠키를 통한 리프레시 토큰 관리

## 작업 사항
- 사용자 로그인 후 토큰 발급 시, 리프레시 토큰 저장 로직 추가
- 리프레시 토큰 재발급 api 추가
   - PUBLIC 권한으로 가능하도록 설정
   - 사용자 디바이스 별 리프레시 토큰 요청 방식 분리
      - WEB: cookie
      - MOBILE: header
- 로그아웃 api 추가
   - USER 권한만 가능하도록 설정
   - 사용자 디바이스 별 리프레시 토큰 요청 방식 분리
      - WEB: cookie
      - MOBILE: header

## 테스트
<table>
	<tr>
		<td style="text-align: center;"> Redis 내 저장 리프레시 토큰 </td>
	</tr>
	<tr>
		<td>
			<img src="https://github.com/user-attachments/assets/5d02472f-64cd-44c8-857f-8eda65617feb" alt="redis" />
		</td>
	</tr>
</table>


<table>
	<tr>
		<td style="text-align: center;"> 리프레시 토큰 발급 성공 - 모바일 </td>
	</tr>
	<tr>
		<td>
			<img src="https://github.com/user-attachments/assets/9d2db80a-43ef-4900-a81b-4f6784959d08" alt="MOBILE" />
		</td>
	</tr>
	<tr>
		<td style="text-align: center;"> 리프레시 토큰 발급 성공 - 웹 </td>
	</tr>
	<tr>
		<td>
			<img src="https://github.com/user-attachments/assets/c2752135-c613-4a38-910d-ba341973af32" alt="redis" />
		</td>
	</tr>

</table>