### PR TITLE
Feature(IL-50): 여행 목적지 읽기 연산 로직 구현 및 불필요 필드 삭제

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripPlaceReq.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripPlaceReq.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 import java.util.List;
 import java.util.UUID;
 
-public class TripPlaceDto {
+public class TripPlaceReq {
 
     @Builder
     @Schema(name = "TripPlaceDto.Request", description = "여행 목적지 추가 DTO")

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripPlaceRes.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripPlaceRes.java
@@ -1,0 +1,48 @@
+package kr.co.yeogiga.application.trip.dto;
+
+import kr.co.yeogiga.domain.tripplace.entity.Place;
+import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
+
+import java.util.List;
+
+public class TripPlaceRes {
+
+    public record TripDayPlaceInfo(
+            String id,
+            int day,
+            List<PlaceSummary> places
+    ) {
+        public static TripDayPlaceInfo from(TripDayPlace tripDayPlace) {
+            List<PlaceSummary> summaries = tripDayPlace.getPlaces().stream()
+                    .map(PlaceSummary::from)
+                    .toList();
+
+            return new TripDayPlaceInfo(tripDayPlace.getId(), tripDayPlace.getDay(), summaries);
+        }
+    }
+
+    public record PlaceSummary(
+            String id,
+            String name,
+            String placeType,
+            double order
+    ) {
+        public static PlaceSummary from(Place place) {
+            return new PlaceSummary(place.getId(), place.getName(), place.getPlaceType(), place.getOrder());
+        }
+    }
+
+    public record PlaceDetails(
+            String id,
+            String name,
+            double latitude,
+            double longitude,
+            String placeType,
+            double order
+    ) {
+        public static PlaceDetails from(Place place) {
+            return new PlaceDetails(place.getId(), place.getName(), place.getLatitude(),
+                    place.getLongitude(), place.getPlaceType(), place.getOrder());
+        }
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceCommandService.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.application.trip.service;
 
-import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
@@ -27,7 +27,7 @@ public class TripPlaceCommandService {
      * @param tripPlaceId   여행 일차(TripDayPlace)의 ID
      * @param insertRequest 삽입할 장소 정보 및 위치 기준 정보
      */
-    public void addNewPlace(String tripPlaceId, TripPlaceDto.InsertRequest insertRequest) {
+    public void addNewPlace(String tripPlaceId, TripPlaceReq.InsertRequest insertRequest) {
         Double prevPlaceOrder = getPlaceOrder(tripPlaceId, insertRequest.prevPlaceId());
         Double nextPlaceOrder = getPlaceOrder(tripPlaceId, insertRequest.nextPlaceId());
 
@@ -66,7 +66,7 @@ public class TripPlaceCommandService {
      * @param nextPlaceOrder 다음 목적지의 order 값 (nullable)
      * @return 생성된 Place 객체
      */
-    private Place createPlace(TripPlaceDto.InsertRequest insertRequest, Double prevPlaceOrder, Double nextPlaceOrder) {
+    private Place createPlace(TripPlaceReq.InsertRequest insertRequest, Double prevPlaceOrder, Double nextPlaceOrder) {
         if (prevPlaceOrder == null && nextPlaceOrder == null) {
             return insertRequest.toEntity(10.0);
         }
@@ -89,7 +89,7 @@ public class TripPlaceCommandService {
      * @param tripDayPlaceId 여행 일차(TripDayPlace)의 ID
      * @param reorderRequest 재정렬할 목적지 ID 리스트
      */
-    public void reorderPlaces(String tripDayPlaceId, TripPlaceDto.ReorderRequest reorderRequest) {
+    public void reorderPlaces(String tripDayPlaceId, TripPlaceReq.ReorderRequest reorderRequest) {
         TripDayPlace tripDayPlace = tripDayPlaceService.readById(tripDayPlaceId)
                 .orElseThrow(() -> new CustomException(TripErrorType.DAY_PLACE_NOT_FOUND));
 

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingService.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.application.trip.service;
 
-import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.infrastructure.redis.RedisRepository;
@@ -27,9 +27,9 @@ public class TripPlaceEditingService {
      * @param day    : 여행 일차 (1일차, 2일차 등)
      * @return : 저장된 TripPlaceDto.StoredFormat 리스트
      */
-    public List<TripPlaceDto.StoredFormat> getPlaces(Long tripId, int day) {
+    public List<TripPlaceReq.StoredFormat> getPlaces(Long tripId, int day) {
         String listKey = PlaceConstant.listKey(tripId, day);
-        return redisRepository.getList(listKey, TripPlaceDto.StoredFormat.class);
+        return redisRepository.getList(listKey, TripPlaceReq.StoredFormat.class);
     }
 
     /**
@@ -42,7 +42,7 @@ public class TripPlaceEditingService {
      * @param place  : 추가할 TripPlaceDto.Request 객체
      * @throws CustomException ALREADY_ADDED_PLACE : 이미 목적지를 추가한 경우
      */
-    public void addPlace(Long tripId, int day, TripPlaceDto.Request place) {
+    public void addPlace(Long tripId, int day, TripPlaceReq.Request place) {
         String listKey = PlaceConstant.listKey(tripId, day);
         String setKey = PlaceConstant.setKey(tripId, day);
 
@@ -68,9 +68,9 @@ public class TripPlaceEditingService {
         String listKey = PlaceConstant.listKey(tripId, day);
         String setKey = PlaceConstant.setKey(tripId, day);
 
-        List<TripPlaceDto.StoredFormat> places = redisRepository.getList(listKey, TripPlaceDto.StoredFormat.class);
+        List<TripPlaceReq.StoredFormat> places = redisRepository.getList(listKey, TripPlaceReq.StoredFormat.class);
 
-        TripPlaceDto.StoredFormat target = places.stream()
+        TripPlaceReq.StoredFormat target = places.stream()
                 .filter(p -> placeId.equals(p.id()))
                 .findFirst()
                 .orElse(null);
@@ -94,14 +94,14 @@ public class TripPlaceEditingService {
      * @param day    : 여행 일차
      * @param places : 새로운 순서의 TripPlaceDto.Request 리스트
      */
-    public void updatePlaces(Long tripId, int day, List<TripPlaceDto.Request> places) {
+    public void updatePlaces(Long tripId, int day, List<TripPlaceReq.Request> places) {
         String listKey = PlaceConstant.listKey(tripId, day);
         String setKey = PlaceConstant.setKey(tripId, day);
 
         redisRepository.del(listKey);
         redisRepository.del(setKey);
 
-        for (TripPlaceDto.Request place : places) {
+        for (TripPlaceReq.Request place : places) {
             redisRepository.setList(listKey, place.toStoredFormat());
             String placeUniqueKey = makeUniqueKey(place.name(), place.latitude(), place.longitude());
             redisRepository.addToSet(setKey, placeUniqueKey);

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceQueryService.java
@@ -1,0 +1,48 @@
+package kr.co.yeogiga.application.trip.service;
+
+import kr.co.yeogiga.application.trip.dto.TripPlaceRes;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
+import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TripPlaceQueryService {
+    private final TripDayPlaceService tripDayPlaceService;
+
+    /**
+     * 특정 여행(tripId)에 포함된 모든 여행 일차(TripDayPlace)에 대한 요약 정보 조회 메서드
+     * - 각 일차의 id, day, 포함된 place 요약 리스트를 반환
+     *
+     * @param tripId 조회할 여행 ID
+     * @return TripDayPlace 요약 정보 리스트
+     */
+    public List<TripPlaceRes.TripDayPlaceInfo> getTripDayPlacesInfo(Long tripId) {
+        List<TripDayPlace> tripDayPlaces = tripDayPlaceService.readByTripId(tripId);
+
+        return tripDayPlaces.stream()
+                .map(TripPlaceRes.TripDayPlaceInfo::from)
+                .toList();
+    }
+
+    /**
+     * 특정 여행 일차(TripDayPlace)에 포함된 모든 목적지의 상세 정보 조회 메서드
+     * - 각 place의 좌표, 타입, 순서등을 포함한 상세 정보를 반환
+     *
+     * @param tripDayPlaceId 조회할 여행 일차 ID
+     * @return 목적지 상세 정보 리스트
+     */
+    public List<TripPlaceRes.PlaceDetails> getPlaceDetailsInfo(String tripDayPlaceId) {
+        TripDayPlace tripDayPlace = tripDayPlaceService.readById(tripDayPlaceId)
+                .orElseThrow(() -> new CustomException(TripErrorType.DAY_PLACE_NOT_FOUND));
+
+        return tripDayPlace.getPlaces().stream()
+                .map(TripPlaceRes.PlaceDetails::from)
+                .toList();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceSavingService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceSavingService.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.application.trip.service;
 
-import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
@@ -50,12 +50,12 @@ public class TripPlaceSavingService {
      */
     private TripDayPlace createTripDayPlace(Long tripId, int day) {
         String listKey = PlaceConstant.listKey(tripId, day);
-        List<TripPlaceDto.StoredFormat> storedPlaces
-                = redisRepository.getList(listKey, TripPlaceDto.StoredFormat.class);
+        List<TripPlaceReq.StoredFormat> storedPlaces
+                = redisRepository.getList(listKey, TripPlaceReq.StoredFormat.class);
 
         List<Place> places = new ArrayList<>();
         for (int i = 0; i < storedPlaces.size(); i++) {
-            TripPlaceDto.StoredFormat stored = storedPlaces.get(i);
+            TripPlaceReq.StoredFormat stored = storedPlaces.get(i);
             places.add(convertToPlace(stored, i));
         }
 
@@ -74,7 +74,7 @@ public class TripPlaceSavingService {
      * @param index  : 리스트 내 순서
      * @return : Place 변환 객체
      */
-    private Place convertToPlace(TripPlaceDto.StoredFormat stored, int index) {
+    private Place convertToPlace(TripPlaceReq.StoredFormat stored, int index) {
         return Place.builder()
                 .id(stored.id())
                 .name(stored.name())

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
@@ -3,8 +3,6 @@ package kr.co.yeogiga.domain.tripplace.entity;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
-
 @Getter
 public class Place {
     private String id;
@@ -13,18 +11,16 @@ public class Place {
     private double longitude;
     private String placeType;
     private double order;
-    private LocalDateTime visitedAt;
 
     @Builder
-    public Place(String id, String name, double latitude, double longitude,
-                 String placeType, double order, LocalDateTime visitedAt) {
+    public Place(String id, String name, double latitude,
+                 double longitude, String placeType, double order) {
         this.id = id;
         this.name = name;
         this.latitude = latitude;
         this.longitude = longitude;
         this.placeType = placeType;
         this.order = order;
-        this.visitedAt = visitedAt;
     }
 
     public void updateOrder(double order) {

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/TripDayPlace.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/TripDayPlace.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Getter
@@ -18,14 +17,12 @@ public class TripDayPlace {
     private String id;
     private Long tripId;
     private int day;
-    private LocalDate date;
     private List<Place> places;
 
     @Builder
-    public TripDayPlace(Long tripId, int day, LocalDate date, List<Place> places) {
+    public TripDayPlace(Long tripId, int day, List<Place> places) {
         this.tripId = tripId;
         this.day = day;
-        this.date = date;
         this.places = places;
     }
 

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
@@ -1,9 +1,15 @@
 package kr.co.yeogiga.domain.tripplace.repository;
 
 import kr.co.yeogiga.domain.tripplace.entity.Place;
+import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface CustomTripDayPlaceRepository {
     void savePlace(String id, Place place);
     void deletePlace(String id, String placeId);
     Double findOrderByIdAndPlaceId(String id, String placeId);
+    Optional<TripDayPlace> findByIdSorted(String id);
+    List<TripDayPlace> findByTripIdSorted(Long tripId);
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
@@ -3,10 +3,16 @@ package kr.co.yeogiga.domain.tripplace.repository;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
+
+import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class CustomTripDayPlaceRepositoryImpl implements CustomTripDayPlaceRepository {
@@ -42,5 +48,43 @@ public class CustomTripDayPlaceRepositoryImpl implements CustomTripDayPlaceRepos
 
         return result.getPlaces().get(0).getOrder();
     }
+
+    @Override
+    public Optional<TripDayPlace> findByIdSorted(String id) {
+        Aggregation aggregation = Aggregation.newAggregation(
+                Aggregation.match(Criteria.where("_id").is(id)),
+                Aggregation.unwind("places"),
+                Aggregation.sort(Sort.by(Sort.Direction.ASC, "places.order")),
+                Aggregation.group("_id")
+                        .first("tripId").as("tripId")
+                        .first("day").as("day")
+                        .push("places").as("places")
+        );
+
+        AggregationResults<TripDayPlace> results =
+                mongoTemplate.aggregate(aggregation, "trip_day_place", TripDayPlace.class);
+
+        return results.getMappedResults().stream().findFirst();
+    }
+
+
+    @Override
+    public List<TripDayPlace> findByTripIdSorted(Long tripId) {
+        Aggregation aggregation = Aggregation.newAggregation(
+                Aggregation.match(Criteria.where("tripId").is(tripId)),
+                Aggregation.unwind("places"),
+                Aggregation.sort(Sort.by(Sort.Direction.ASC, "places.order")),
+                Aggregation.group("_id")
+                        .first("tripId").as("tripId")
+                        .first("day").as("day")
+                        .push("places").as("places")
+        );
+
+        AggregationResults<TripDayPlace> results =
+                mongoTemplate.aggregate(aggregation, "trip_day_place", TripDayPlace.class);
+
+        return results.getMappedResults();
+    }
+
 
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/TripDayPlaceRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/TripDayPlaceRepository.java
@@ -3,5 +3,8 @@ package kr.co.yeogiga.domain.tripplace.repository;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.List;
+
 public interface TripDayPlaceRepository extends MongoRepository<TripDayPlace, String>, CustomTripDayPlaceRepository {
+    List<TripDayPlace> findByTripId(Long tripId);
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
@@ -30,6 +30,10 @@ public class TripDayPlaceService {
         return tripDayPlaceRepository.findById(id);
     }
 
+    public List<TripDayPlace> readByTripId(Long tripId) {
+        return tripDayPlaceRepository.findByTripId(tripId);
+    }
+
     public Double readOrderByIdAndPlaceId(String id, String placeId) {
         return tripDayPlaceRepository.findOrderByIdAndPlaceId(id, placeId);
     }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
@@ -27,11 +27,11 @@ public class TripDayPlaceService {
     }
 
     public Optional<TripDayPlace> readById(String id) {
-        return tripDayPlaceRepository.findById(id);
+        return tripDayPlaceRepository.findByIdSorted(id);
     }
 
     public List<TripDayPlace> readByTripId(Long tripId) {
-        return tripDayPlaceRepository.findByTripId(tripId);
+        return tripDayPlaceRepository.findByTripIdSorted(tripId);
     }
 
     public Double readOrderByIdAndPlaceId(String id, String placeId) {

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
@@ -6,7 +6,7 @@ public final class EndpointConstants {
     public static final String[] PUBLIC_ENDPOINTS = {
             "/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**",
             "/webjars/**", "/error", "/api-checker/**", "/v1/api/link/checker/**",
-            "/api/v1/auth/oauth/**", "/api/v1/auth/reissue",
+            "/api/v1/auth/oauth/**", "/api/v1/auth/reissue", "**"
     };
 
     public static final String[] USER_ENDPOINTS = {

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
@@ -6,7 +6,7 @@ public final class EndpointConstants {
     public static final String[] PUBLIC_ENDPOINTS = {
             "/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**",
             "/webjars/**", "/error", "/api-checker/**", "/v1/api/link/checker/**",
-            "/api/v1/auth/oauth/**", "/api/v1/auth/reissue", "**"
+            "/api/v1/auth/oauth/**", "/api/v1/auth/reissue"
     };
 
     public static final String[] USER_ENDPOINTS = {

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceApi.java
@@ -50,6 +50,90 @@ public interface TripPlaceApi {
                                   @PathVariable String tripDayPlaceId,
                                   @RequestBody TripPlaceReq.InsertRequest insertRequest);
 
+    @TrackApi(description = "여행 일정 정보 불러오기")
+    @Operation(summary = "여행 일정 정보 불러오기", description = "여행 일정 정보를 불러오는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "여행 일정 정보 불러오기",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": [
+                                                    {
+                                                        "id": "tripDayPlace1-id",
+                                                        "day": 1,
+                                                        "places": [
+                                                            {
+                                                                "id": "place1-id",
+                                                                "name": "목적지1",
+                                                                "placeType": "식당",
+                                                                "order": 0.0
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "tripDayPlace2-id",
+                                                        "day": 2,
+                                                        "places": [
+                                                            {
+                                                                "id": "place2-id",
+                                                                "name": "목적지2",
+                                                                "placeType": "식당",
+                                                                "order": 10.0
+                                                            }
+                                                        ]
+                                                    }
+                                            ]
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getTripDayPlacesInfo(@PathVariable Long tripId);
+
+    @TrackApi(description = "목적지 상세 정보 불러오기")
+    @Operation(summary = "목적지 상세 정보 불러오기", description = "여행 목적지 상세 정보를 불러오는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "여행 목적지 상세 정보 불러오기",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": [
+                                                    {
+                                                        "id": "place1-id",
+                                                        "name": "목적지1",
+                                                        "latitude": 11.22,
+                                                        "longitude": 33.44,
+                                                        "placeType": "식당",
+                                                        "order": 10.0
+                                                    },
+                                                    {
+                                                        "id": "place2-id",
+                                                        "name": "목적지 2",
+                                                        "latitude": 55.66,
+                                                        "longitude": 77.88,
+                                                        "placeType": "식당",
+                                                        "order": 15.0
+                                                    }
+                                                ]
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "여행 일차 존재하지 않음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": "T003",
+                                            "message": "해당 여행 일차 정보가 존재하지 않습니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getPlaceDetailsInfo(@PathVariable Long tripId,
+                                          @PathVariable String tripDayPlaceId);
+
     @TrackApi(description = "여행 목적지 순서 변경")
     @Operation(summary = "여행 목적지 순서 변경", description = "여행 목적지 순서를 변경하는 API입니다.")
     @ApiResponses({

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceApi.java
@@ -46,7 +46,7 @@ public interface TripPlaceApi {
                                     """)
                     }))
     })
-    ResponseEntity<?> addNewPlace(@PathVariable String tripId,
+    ResponseEntity<?> addNewPlace(@PathVariable Long tripId,
                                   @PathVariable String tripDayPlaceId,
                                   @RequestBody TripPlaceReq.InsertRequest insertRequest);
 
@@ -72,7 +72,7 @@ public interface TripPlaceApi {
                                     """)
                     }))
     })
-    ResponseEntity<?> reorderPlaces(@PathVariable String tripId,
+    ResponseEntity<?> reorderPlaces(@PathVariable Long tripId,
                                     @PathVariable String tripDayPlaceId,
                                     @RequestBody TripPlaceReq.ReorderRequest reorderRequest);
 
@@ -89,7 +89,7 @@ public interface TripPlaceApi {
                                     """)
                     }))
     })
-    ResponseEntity<?> deletePlace(@PathVariable String tripId,
+    ResponseEntity<?> deletePlace(@PathVariable Long tripId,
                                   @PathVariable String tripDayPlaceId,
                                   @PathVariable String placeId);
 }

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceApi.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,7 +31,7 @@ public interface TripPlaceApi {
                     }))
     })
     ResponseEntity<?> completeTrip(@PathVariable Long tripId,
-                                   @RequestBody TripPlaceDto.CompleteRequest request);
+                                   @RequestBody TripPlaceReq.CompleteRequest request);
 
     @TrackApi(description = "여행 목적지 추가")
     @Operation(summary = "여행 목적지 추가", description = "여행 목적지를 추가하는 API입니다.")
@@ -48,7 +48,7 @@ public interface TripPlaceApi {
     })
     ResponseEntity<?> addNewPlace(@PathVariable String tripId,
                                   @PathVariable String tripDayPlaceId,
-                                  @RequestBody TripPlaceDto.InsertRequest insertRequest);
+                                  @RequestBody TripPlaceReq.InsertRequest insertRequest);
 
     @TrackApi(description = "여행 목적지 순서 변경")
     @Operation(summary = "여행 목적지 순서 변경", description = "여행 목적지 순서를 변경하는 API입니다.")
@@ -74,7 +74,7 @@ public interface TripPlaceApi {
     })
     ResponseEntity<?> reorderPlaces(@PathVariable String tripId,
                                     @PathVariable String tripDayPlaceId,
-                                    @RequestBody TripPlaceDto.ReorderRequest reorderRequest);
+                                    @RequestBody TripPlaceReq.ReorderRequest reorderRequest);
 
     @TrackApi(description = "여행 목적지 삭제")
     @Operation(summary = "여행 목적지 삭제", description = "여행 목적지를 삭제하는 API입니다.")

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -43,7 +43,7 @@ public interface TripPlaceEditingApi {
     })
     ResponseEntity<?> addPlace(@PathVariable Long tripId,
                                @PathVariable int day,
-                               @RequestBody TripPlaceDto.Request request);
+                               @RequestBody TripPlaceReq.Request request);
 
     @TrackApi(description = "일자별 목적지 조회")
     @Operation(summary = "일자별 목적지 조회", description = "일자별 목적지 조회하는 API입니다.")
@@ -91,7 +91,7 @@ public interface TripPlaceEditingApi {
     })
     ResponseEntity<?> updatePlaces(@PathVariable Long tripId,
                                    @PathVariable int day,
-                                   @RequestBody List<TripPlaceDto.Request> requests);
+                                   @RequestBody List<TripPlaceReq.Request> requests);
 
     @TrackApi(description = "목적지 삭제")
     @Operation(summary = "목적지 삭제", description = "목적지 삭제하는 API입니다.")

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceController.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.presentation.trip.controller;
 
-import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
 import kr.co.yeogiga.application.trip.service.TripPlaceCommandService;
 import kr.co.yeogiga.application.trip.service.TripPlaceSavingService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
@@ -26,7 +26,7 @@ public class TripPlaceController implements TripPlaceApi {
     @Override
     @PostMapping("/{tripId}/complete")
     public ResponseEntity<?> completeTrip(@PathVariable Long tripId,
-                                          @RequestBody TripPlaceDto.CompleteRequest request) {
+                                          @RequestBody TripPlaceReq.CompleteRequest request) {
 
         tripPlaceSavingService.completeTrip(tripId, request.lastDay());
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
@@ -36,7 +36,7 @@ public class TripPlaceController implements TripPlaceApi {
     @PostMapping("/{tripId}/day-place/{tripDayPlaceId}/places")
     public ResponseEntity<?> addNewPlace(@PathVariable String tripId,
                                          @PathVariable String tripDayPlaceId,
-                                         @RequestBody TripPlaceDto.InsertRequest insertRequest) {
+                                         @RequestBody TripPlaceReq.InsertRequest insertRequest) {
 
         tripPlaceCommandService.addNewPlace(tripDayPlaceId, insertRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
@@ -46,7 +46,7 @@ public class TripPlaceController implements TripPlaceApi {
     @PutMapping("/{tripId}/day-place/{tripDayPlaceId}/places/order")
     public ResponseEntity<?> reorderPlaces(@PathVariable String tripId,
                                            @PathVariable String tripDayPlaceId,
-                                           @RequestBody TripPlaceDto.ReorderRequest reorderRequest) {
+                                           @RequestBody TripPlaceReq.ReorderRequest reorderRequest) {
         tripPlaceCommandService.reorderPlaces(tripDayPlaceId, reorderRequest);
         return ResponseEntity.ok(SuccessResponse.ok());
     }

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceController.java
@@ -45,6 +45,7 @@ public class TripPlaceController implements TripPlaceApi {
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
     }
 
+    @Override
     @GetMapping("/{tripId}/day-place/places")
     public ResponseEntity<?> getTripDayPlacesInfo(@PathVariable Long tripId) {
         return ResponseEntity.ok(
@@ -52,6 +53,7 @@ public class TripPlaceController implements TripPlaceApi {
         );
     }
 
+    @Override
     @GetMapping("/{tripId}/day-place/{tripDayPlaceId}/places")
     public ResponseEntity<?> getPlaceDetailsInfo(@PathVariable Long tripId,
                                                  @PathVariable String tripDayPlaceId) {

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceController.java
@@ -2,6 +2,7 @@ package kr.co.yeogiga.presentation.trip.controller;
 
 import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
 import kr.co.yeogiga.application.trip.service.TripPlaceCommandService;
+import kr.co.yeogiga.application.trip.service.TripPlaceQueryService;
 import kr.co.yeogiga.application.trip.service.TripPlaceSavingService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.presentation.trip.api.TripPlaceApi;
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TripPlaceController implements TripPlaceApi {
     private final TripPlaceSavingService tripPlaceSavingService;
     private final TripPlaceCommandService tripPlaceCommandService;
+    private final TripPlaceQueryService tripPlaceQueryService;
 
     @Override
     @PostMapping("/{tripId}/complete")
@@ -40,6 +43,22 @@ public class TripPlaceController implements TripPlaceApi {
 
         tripPlaceCommandService.addNewPlace(tripDayPlaceId, insertRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
+    }
+
+    @GetMapping("/{tripId}/day-place/places")
+    public ResponseEntity<?> getTripDayPlacesInfo(@PathVariable Long tripId) {
+        return ResponseEntity.ok(
+                SuccessResponse.from(tripPlaceQueryService.getTripDayPlacesInfo(tripId))
+        );
+    }
+
+    @GetMapping("/{tripId}/day-place/{tripDayPlaceId}/places")
+    public ResponseEntity<?> getPlaceDetailsInfo(@PathVariable Long tripId,
+                                                 @PathVariable String tripDayPlaceId) {
+
+        return ResponseEntity.ok(
+                SuccessResponse.from(tripPlaceQueryService.getPlaceDetailsInfo(tripDayPlaceId))
+        );
     }
 
     @Override

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceController.java
@@ -37,7 +37,7 @@ public class TripPlaceController implements TripPlaceApi {
 
     @Override
     @PostMapping("/{tripId}/day-place/{tripDayPlaceId}/places")
-    public ResponseEntity<?> addNewPlace(@PathVariable String tripId,
+    public ResponseEntity<?> addNewPlace(@PathVariable Long tripId,
                                          @PathVariable String tripDayPlaceId,
                                          @RequestBody TripPlaceReq.InsertRequest insertRequest) {
 
@@ -63,7 +63,7 @@ public class TripPlaceController implements TripPlaceApi {
 
     @Override
     @PutMapping("/{tripId}/day-place/{tripDayPlaceId}/places/order")
-    public ResponseEntity<?> reorderPlaces(@PathVariable String tripId,
+    public ResponseEntity<?> reorderPlaces(@PathVariable Long tripId,
                                            @PathVariable String tripDayPlaceId,
                                            @RequestBody TripPlaceReq.ReorderRequest reorderRequest) {
         tripPlaceCommandService.reorderPlaces(tripDayPlaceId, reorderRequest);
@@ -72,7 +72,7 @@ public class TripPlaceController implements TripPlaceApi {
 
     @Override
     @DeleteMapping("/{tripId}/day-place/{tripDayPlaceId}/places/{placeId}")
-    public ResponseEntity<?> deletePlace(@PathVariable String tripId,
+    public ResponseEntity<?> deletePlace(@PathVariable Long tripId,
                                          @PathVariable String tripDayPlaceId,
                                          @PathVariable String placeId) {
 

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.presentation.trip.controller;
 
-import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
 import kr.co.yeogiga.application.trip.service.TripPlaceEditingService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.presentation.trip.api.TripPlaceEditingApi;
@@ -28,7 +28,7 @@ public class TripPlaceEditingController implements TripPlaceEditingApi {
     @PostMapping("/{tripId}/days/{day}/places")
     public ResponseEntity<?> addPlace(@PathVariable Long tripId,
                                       @PathVariable int day,
-                                      @RequestBody TripPlaceDto.Request request) {
+                                      @RequestBody TripPlaceReq.Request request) {
 
         tripPlaceEditingService.addPlace(tripId, day, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
@@ -46,7 +46,7 @@ public class TripPlaceEditingController implements TripPlaceEditingApi {
     @PutMapping("/{tripId}/days/{day}/places")
     public ResponseEntity<?> updatePlaces(@PathVariable Long tripId,
                                           @PathVariable int day,
-                                          @RequestBody List<TripPlaceDto.Request> requests) {
+                                          @RequestBody List<TripPlaceReq.Request> requests) {
 
         tripPlaceEditingService.updatePlaces(tripId, day, requests);
         return ResponseEntity.ok(SuccessResponse.ok());

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceCommandServiceTest.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.application.trip.service;
 
-import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
@@ -49,7 +49,7 @@ public class TripPlaceCommandServiceTest {
         @DisplayName("가장 처음 추가되는 경우 - 기존에 목적지 없는 상태")
         void addPlaceFirst() {
             // given
-            TripPlaceDto.InsertRequest insertRequest = TripPlaceDto.InsertRequest.builder()
+            TripPlaceReq.InsertRequest insertRequest = TripPlaceReq.InsertRequest.builder()
                     .name("목적지1")
                     .latitude(0.0)
                     .longitude(0.0)
@@ -71,7 +71,7 @@ public class TripPlaceCommandServiceTest {
         void addPlaceFront() {
             // given
             given(tripDayPlaceService.readOrderByIdAndPlaceId(tripDayPlaceId, "nextId")).willReturn(20.0);
-            TripPlaceDto.InsertRequest insertRequest = TripPlaceDto.InsertRequest.builder()
+            TripPlaceReq.InsertRequest insertRequest = TripPlaceReq.InsertRequest.builder()
                     .name("목적지1")
                     .latitude(0.0)
                     .longitude(0.0)
@@ -94,7 +94,7 @@ public class TripPlaceCommandServiceTest {
         void addPlaceBack() {
             // given
             given(tripDayPlaceService.readOrderByIdAndPlaceId(tripDayPlaceId, "prevId")).willReturn(20.0);
-            TripPlaceDto.InsertRequest insertRequest = TripPlaceDto.InsertRequest.builder()
+            TripPlaceReq.InsertRequest insertRequest = TripPlaceReq.InsertRequest.builder()
                     .name("목적지1")
                     .latitude(0.0)
                     .longitude(0.0)
@@ -119,7 +119,7 @@ public class TripPlaceCommandServiceTest {
             given(tripDayPlaceService.readOrderByIdAndPlaceId(tripDayPlaceId, "prevId")).willReturn(10.0);
             given(tripDayPlaceService.readOrderByIdAndPlaceId(tripDayPlaceId, "nextId")).willReturn(30.0);
 
-            TripPlaceDto.InsertRequest insertRequest = TripPlaceDto.InsertRequest.builder()
+            TripPlaceReq.InsertRequest insertRequest = TripPlaceReq.InsertRequest.builder()
                     .name("목적지1")
                     .latitude(0.0)
                     .longitude(0.0)
@@ -154,7 +154,7 @@ public class TripPlaceCommandServiceTest {
                     Place.builder().id("id3").name("목적지3").latitude(0.0).longitude(0.0).placeType("식당").order(30.0).build()
             );
             TripDayPlace tripDayPlace = TripDayPlace.builder().day(1).places(places).build();
-            TripPlaceDto.ReorderRequest reorderRequest = new TripPlaceDto.ReorderRequest(List.of("id3", "id1", "id2"));
+            TripPlaceReq.ReorderRequest reorderRequest = new TripPlaceReq.ReorderRequest(List.of("id3", "id1", "id2"));
 
             given(tripDayPlaceService.readById(tripDayPlaceId)).willReturn(Optional.of(tripDayPlace));
 
@@ -174,7 +174,7 @@ public class TripPlaceCommandServiceTest {
             // given
             given(tripDayPlaceService.readById(tripDayPlaceId)).willReturn(Optional.empty());
 
-            TripPlaceDto.ReorderRequest reorderRequest = new TripPlaceDto.ReorderRequest(List.of("a"));
+            TripPlaceReq.ReorderRequest reorderRequest = new TripPlaceReq.ReorderRequest(List.of("a"));
 
             // when
             CustomException e = assertThrows(CustomException.class, () ->

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingServiceTest.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.application.trip.service;
 
-import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
@@ -43,7 +43,7 @@ public class TripPlaceEditingServiceTest {
     @DisplayName("목적지 추가 테스트")
     class AddPlaceTest {
 
-        private final TripPlaceDto.Request place = TripPlaceDto.Request.builder()
+        private final TripPlaceReq.Request place = TripPlaceReq.Request.builder()
                 .name("목적지1")
                 .latitude(0.0)
                 .longitude(0.0)
@@ -61,7 +61,7 @@ public class TripPlaceEditingServiceTest {
             tripPlaceEditingService.addPlace(tripId, day, place);
 
             // then
-            verify(redisRepository, times(1)).setList(anyString(), any(TripPlaceDto.StoredFormat.class));
+            verify(redisRepository, times(1)).setList(anyString(), any(TripPlaceReq.StoredFormat.class));
             verify(redisRepository, times(1)).addToSet(eq(setKey), anyString());
         }
 
@@ -92,11 +92,11 @@ public class TripPlaceEditingServiceTest {
         @DisplayName("목적지 삭제 성공")
         void deletePlaceInEditingSuccess() {
             // given
-            TripPlaceDto.StoredFormat place = new TripPlaceDto.StoredFormat(
+            TripPlaceReq.StoredFormat place = new TripPlaceReq.StoredFormat(
                     placeId, "목적지1", 33.123, 126.456, PlaceCategory.RESTAURANT.getGroupName()
             );
 
-            given(redisRepository.getList(anyString(), eq(TripPlaceDto.StoredFormat.class)))
+            given(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class)))
                     .willReturn(List.of(place));
 
             // when
@@ -111,7 +111,7 @@ public class TripPlaceEditingServiceTest {
         @DisplayName("목적지 삭제 실패 - 존재하지 않음")
         void deletePlaceInEditingNotFound() {
             // given
-            given(redisRepository.getList(anyString(), eq(TripPlaceDto.StoredFormat.class)))
+            given(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class)))
                     .willReturn(List.of());
 
             // when
@@ -127,28 +127,28 @@ public class TripPlaceEditingServiceTest {
     @DisplayName("목적지 순서 수정 성공")
     void updatePlacesInEditingSuccess() {
         // given
-        TripPlaceDto.Request place1 = TripPlaceDto.Request.builder()
+        TripPlaceReq.Request place1 = TripPlaceReq.Request.builder()
                 .name("목적지1")
                 .latitude(0.0)
                 .longitude(0.0)
                 .placeType("카페")
                 .build();
 
-        TripPlaceDto.Request place2 = TripPlaceDto.Request.builder()
+        TripPlaceReq.Request place2 = TripPlaceReq.Request.builder()
                 .name("목적지2")
                 .latitude(0.0)
                 .longitude(0.0)
                 .placeType("카페")
                 .build();
 
-        List<TripPlaceDto.Request> newPlaces = List.of(place2, place1);
+        List<TripPlaceReq.Request> newPlaces = List.of(place2, place1);
 
         // when
         tripPlaceEditingService.updatePlaces(tripId, day, newPlaces);
 
         // then
         verify(redisRepository, times(2)).del(anyString());
-        verify(redisRepository, times(2)).setList(anyString(), any(TripPlaceDto.StoredFormat.class));
+        verify(redisRepository, times(2)).setList(anyString(), any(TripPlaceReq.StoredFormat.class));
         verify(redisRepository, times(2)).addToSet(anyString(), anyString());
     }
 
@@ -156,14 +156,14 @@ public class TripPlaceEditingServiceTest {
     @DisplayName("편집 중인 여행 일정 조회 성공")
     void getPlacesInEditingSuccess() {
         // given
-        List<TripPlaceDto.StoredFormat> mockPlaces = List.of(
-                new TripPlaceDto.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.CAFE.getGroupName())
+        List<TripPlaceReq.StoredFormat> mockPlaces = List.of(
+                new TripPlaceReq.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.CAFE.getGroupName())
         );
 
-        given(redisRepository.getList(anyString(), eq(TripPlaceDto.StoredFormat.class))).willReturn(mockPlaces);
+        given(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class))).willReturn(mockPlaces);
 
         // when
-        List<TripPlaceDto.StoredFormat> result = tripPlaceEditingService.getPlaces(tripId, day);
+        List<TripPlaceReq.StoredFormat> result = tripPlaceEditingService.getPlaces(tripId, day);
 
         // then
         assertEquals(1, result.size());

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceQueryServiceTest.java
@@ -1,0 +1,103 @@
+package kr.co.yeogiga.application.trip.service;
+
+import kr.co.yeogiga.application.trip.dto.TripPlaceRes;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.tripplace.entity.Place;
+import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
+import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class TripPlaceQueryServiceTest {
+
+    @Mock
+    private TripDayPlaceService tripDayPlaceService;
+
+    @InjectMocks
+    private TripPlaceQueryService tripPlaceQueryService;
+
+    private final Place place1 = Place.builder().id("id1").name("목적지1").latitude(0.0).longitude(1.1).placeType("카페").order(10.0).build();
+    private final Place place2 = Place.builder().id("id2").name("목적지2").latitude(2.2).longitude(3.3).placeType("카페").order(20.0).build();
+
+    @Test
+    @DisplayName("여행 일정 불러오기 테스트 성공")
+    void getTripDayPlacesInfoSuccess() {
+        // given
+        Long tripId = 1L;
+
+        List<Place> places = List.of(place1, place2);
+
+        TripDayPlace tripDayPlace = TripDayPlace.builder()
+                .day(1)
+                .places(places)
+                .build();
+
+        given(tripDayPlaceService.readByTripId(tripId)).willReturn(List.of(tripDayPlace));
+
+        // when
+        List<TripPlaceRes.TripDayPlaceInfo> result = tripPlaceQueryService.getTripDayPlacesInfo(tripId);
+
+        // then
+        assertEquals(2, result.get(0).places().size());
+        assertEquals(1, result.get(0).day());
+        assertEquals(2, result.get(0).places().size());
+    }
+
+    @Nested
+    @DisplayName("목적지 정보 불러오기 테스트")
+    class GetPlaceDetailsInfo {
+
+        private final String tripDayPlaceId = "day1";
+
+        @Test
+        @DisplayName("성공")
+        void getPlaceDetailsInfoSuccess() {
+            // given
+            List<Place> places = List.of(place1, place2);
+
+            TripDayPlace tripDayPlace = TripDayPlace.builder()
+                    .day(1)
+                    .places(places)
+                    .build();
+
+            given(tripDayPlaceService.readById(tripDayPlaceId)).willReturn(Optional.of(tripDayPlace));
+
+            // when
+            List<TripPlaceRes.PlaceDetails> result = tripPlaceQueryService.getPlaceDetailsInfo(tripDayPlaceId);
+
+            // then
+            assertEquals(2, result.size());
+            assertEquals("목적지1", result.get(0).name());
+            assertEquals(0.0, result.get(0).latitude());
+            assertEquals(2.2, result.get(1).latitude());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 일차 ID")
+        void getPlaceDetailsInfoFail() {
+            // given
+            String tripDayPlaceId = "non-existent";
+            given(tripDayPlaceService.readById(tripDayPlaceId)).willReturn(Optional.empty());
+
+            // when
+            CustomException e = assertThrows(CustomException.class, () ->
+                    tripPlaceQueryService.getPlaceDetailsInfo(tripDayPlaceId));
+
+            assertEquals(TripErrorType.DAY_PLACE_NOT_FOUND, e.getErrorType());
+        }
+    }
+}

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceSavingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceSavingServiceTest.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.application.trip.service;
 
-import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import kr.co.yeogiga.infrastructure.redis.RedisRepository;
 import kr.co.yeogiga.infrastructure.redis.constant.PlaceConstant;
@@ -39,14 +39,14 @@ public class TripPlaceSavingServiceTest {
     @DisplayName("여행 생성 완료 성공")
     void completeTripSuccess() {
         // given
-        TripPlaceDto.StoredFormat place1 = new TripPlaceDto.StoredFormat(
+        TripPlaceReq.StoredFormat place1 = new TripPlaceReq.StoredFormat(
                 "id1", "장소1", 33.123, 126.456, "관광지"
         );
-        TripPlaceDto.StoredFormat place2 = new TripPlaceDto.StoredFormat(
+        TripPlaceReq.StoredFormat place2 = new TripPlaceReq.StoredFormat(
                 "id2", "장소2", 33.789, 126.987, "식당"
         );
 
-        when(redisRepository.getList(anyString(), eq(TripPlaceDto.StoredFormat.class)))
+        when(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class)))
                 .thenReturn(List.of(place1))
                 .thenReturn(List.of(place2));
 
@@ -54,7 +54,7 @@ public class TripPlaceSavingServiceTest {
         tripPlaceSavingService.completeTrip(tripId, lastDay);
 
         // then
-        verify(redisRepository, times(2)).getList(anyString(), eq(TripPlaceDto.StoredFormat.class));
+        verify(redisRepository, times(2)).getList(anyString(), eq(TripPlaceReq.StoredFormat.class));
         verify(tripDayPlaceService, times(1)).saveAll(any());
         verify(redisRepository, times(1)).del(PlaceConstant.listKey(tripId, 1));
         verify(redisRepository, times(1)).del(PlaceConstant.setKey(tripId, 1));

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceControllerTest.java
@@ -1,7 +1,7 @@
 package kr.co.yeogiga.presentation.trip.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
 import kr.co.yeogiga.application.trip.service.TripPlaceCommandService;
 import kr.co.yeogiga.application.trip.service.TripPlaceSavingService;
 import kr.co.yeogiga.common.exception.CustomException;
@@ -68,7 +68,7 @@ public class TripPlaceControllerTest {
     @DisplayName("여행 목적지 확정 완료")
     void completeTripSuccess() throws Exception {
         // given
-        TripPlaceDto.CompleteRequest completeRequest = new TripPlaceDto.CompleteRequest(2);
+        TripPlaceReq.CompleteRequest completeRequest = new TripPlaceReq.CompleteRequest(2);
         doNothing().when(tripPlaceSavingService).completeTrip(tripId, completeRequest.lastDay());
 
         // when
@@ -89,7 +89,7 @@ public class TripPlaceControllerTest {
     @DisplayName("목적지 추가 성공")
     void addNewPlaceSuccess() throws Exception {
         // given
-        TripPlaceDto.InsertRequest insertRequest = TripPlaceDto.InsertRequest.builder()
+        TripPlaceReq.InsertRequest insertRequest = TripPlaceReq.InsertRequest.builder()
                 .name("목적지1")
                 .latitude(0.0)
                 .longitude(0.0)
@@ -117,7 +117,7 @@ public class TripPlaceControllerTest {
     @DisplayName("목적지 정렬 성공")
     void reorderPlacesSuccess() throws Exception {
         // given
-        TripPlaceDto.ReorderRequest reorderRequest = new TripPlaceDto.ReorderRequest(List.of("id1", "id2", "id3"));
+        TripPlaceReq.ReorderRequest reorderRequest = new TripPlaceReq.ReorderRequest(List.of("id1", "id2", "id3"));
         doNothing().when(tripPlaceCommandService).reorderPlaces(tripDayPlaceId, reorderRequest);
 
         // when
@@ -138,7 +138,7 @@ public class TripPlaceControllerTest {
     @DisplayName("목적지 정렬 실패 - 일차가 존재하지 않음")
     void reorderPlacesFailDayPlaceNotFound() throws Exception {
         // given
-        TripPlaceDto.ReorderRequest reorderRequest = new TripPlaceDto.ReorderRequest(List.of("id1", "id2"));
+        TripPlaceReq.ReorderRequest reorderRequest = new TripPlaceReq.ReorderRequest(List.of("id1", "id2"));
         doThrow(new CustomException(TripErrorType.DAY_PLACE_NOT_FOUND))
                 .when(tripPlaceCommandService).reorderPlaces(tripDayPlaceId, reorderRequest);
 

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceControllerTest.java
@@ -2,7 +2,9 @@ package kr.co.yeogiga.presentation.trip.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
+import kr.co.yeogiga.application.trip.dto.TripPlaceRes;
 import kr.co.yeogiga.application.trip.service.TripPlaceCommandService;
+import kr.co.yeogiga.application.trip.service.TripPlaceQueryService;
 import kr.co.yeogiga.application.trip.service.TripPlaceSavingService;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
@@ -24,9 +26,11 @@ import org.springframework.web.context.WebApplicationContext;
 
 import java.util.List;
 
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -52,6 +56,9 @@ public class TripPlaceControllerTest {
 
     @MockBean
     private TripPlaceCommandService tripPlaceCommandService;
+
+    @MockBean
+    private TripPlaceQueryService tripPlaceQueryService;
 
     private final Long tripId = 1L;
     private final String tripDayPlaceId = "dayId";
@@ -112,6 +119,46 @@ public class TripPlaceControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
     }
+
+    @Test
+    @DisplayName("여행 일차별 목적지 요약 정보 조회 성공")
+    void getTripDayPlacesInfoSuccess() throws Exception {
+        // given
+        TripPlaceRes.TripDayPlaceInfo info = new TripPlaceRes.TripDayPlaceInfo("day1", 1, List.of());
+        given(tripPlaceQueryService.getTripDayPlacesInfo(tripId)).willReturn(List.of(info));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/trip/{tripId}/day-place/places", tripId)
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
+    }
+
+    @Test
+    @DisplayName("여행 일차 목적지 상세 정보 조회 성공")
+    void getPlaceDetailsInfoSuccess() throws Exception {
+        // given
+        TripPlaceRes.PlaceDetails details =
+                new TripPlaceRes.PlaceDetails("place1", "목적지1", 0.0, 0.0, "카페", 10.0);
+        given(tripPlaceQueryService.getPlaceDetailsInfo(tripDayPlaceId)).willReturn(List.of(details));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/trip/{tripId}/day-place/{tripDayPlaceId}/places", tripId, tripDayPlaceId)
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
+    }
+
 
     @Test
     @DisplayName("목적지 정렬 성공")

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingControllerTest.java
@@ -1,7 +1,7 @@
 package kr.co.yeogiga.presentation.trip.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.co.yeogiga.application.trip.dto.TripPlaceDto;
+import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
 import kr.co.yeogiga.application.trip.service.TripPlaceEditingService;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
@@ -71,7 +71,7 @@ public class TripPlaceEditingControllerTest {
     @DisplayName("목적지 추가 테스트")
     class AddPlaceTest {
 
-        private final TripPlaceDto.Request request = TripPlaceDto.Request.builder()
+        private final TripPlaceReq.Request request = TripPlaceReq.Request.builder()
                 .name("목적지1")
                 .latitude(0.0)
                 .longitude(0.0)
@@ -125,9 +125,9 @@ public class TripPlaceEditingControllerTest {
     @DisplayName("목적지 수정 성공")
     void updatePlacesSuccess() throws Exception {
         // given
-        List<TripPlaceDto.Request> requests = List.of(
-                TripPlaceDto.Request.builder().name("목적지1").latitude(0.0).longitude(0.0).placeType("관광명소").build(),
-                TripPlaceDto.Request.builder().name("목적지2").latitude(0.0).longitude(0.0).placeType("카페").build()
+        List<TripPlaceReq.Request> requests = List.of(
+                TripPlaceReq.Request.builder().name("목적지1").latitude(0.0).longitude(0.0).placeType("관광명소").build(),
+                TripPlaceReq.Request.builder().name("목적지2").latitude(0.0).longitude(0.0).placeType("카페").build()
         );
 
         doNothing().when(tripPlaceEditingService).updatePlaces(anyLong(), anyInt(), Mockito.anyList());
@@ -168,8 +168,8 @@ public class TripPlaceEditingControllerTest {
     @DisplayName("목적지 조회 성공")
     void getPlacesSuccess() throws Exception {
         // given
-        List<TripPlaceDto.StoredFormat> mockPlaces = List.of(
-                new TripPlaceDto.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.CAFE.getGroupName())
+        List<TripPlaceReq.StoredFormat> mockPlaces = List.of(
+                new TripPlaceReq.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.CAFE.getGroupName())
         );
         given(tripPlaceEditingService.getPlaces(tripId, day)).willReturn(mockPlaces);
 


### PR DESCRIPTION
## 배경
여행의 전체 일정별 목적지 조회 및 특정 일정의 자세한 목적지 정보 조회 로직이 필요.
이전 PR에서 언급한 불필요 필드 제거

## 작업 사항
- 불필요 필드 제거 (fc052211a3f7ee34907bc83de6dc26255e8cbbc3)
- TripPlace 읽기 연산 로직 구현 (e90a371ec4884d733cc8b11de7736ddf602ecb96)
- Place order 기반 정렬 후 조회 (1d660f1810c635a88140df673669268280df9364)
      - 빠른 조회를 위해 애플리케이션 단에서 정렬하는 것이 아닌, MongoDB 내에서 order기반으로 정렬 후 조회하는 로직으로 구현 

## 추가 논의
- 추후 이미지 저장 로직 구현 후, 현재 조회 로직 과정 중 db로부터 image를 제외하고 불러오는 로직으로 수정이 필요
     - 현재 로직은 목적지에 대한 정보를 보여주는 것이기에 image에 대한 정보를 모두 들고오면 메모리 낭비 발생하기 때문