### PR TITLE
Feature(IL-41): 이미지의 위도/경도를 통해 목적지에 삽입 로직 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceImageService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceImageService.java
@@ -1,0 +1,104 @@
+package kr.co.yeogiga.application.trip.service;
+
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.tripplace.entity.Image;
+import kr.co.yeogiga.domain.tripplace.entity.Place;
+import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
+import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+
+@Service
+@RequiredArgsConstructor
+public class TripPlaceImageService {
+    private final TripDayPlaceService tripDayPlaceService;
+
+    /**
+     * 주어진 이미지 메타데이터 통해 해당 TripDayPlace에 할당하는 메서드
+     * - 위도/경도가 있을 경우 가장 가까운 목적지(Place)에 연결
+     * - 위도/경도가 없거나 목적지가 없을 경우 기타(unmatchedImages)로 분류
+     *
+     * @param tripDayPlaceId TripDayPlace의 ID
+     * @param image          GPS 정보와 시간 정보를 가진 이미지 객체
+     */
+    public void assignImageToTripDayPlace(String tripDayPlaceId, Image image) {
+        TripDayPlace tripDayPlace = tripDayPlaceService.readById(tripDayPlaceId)
+                .orElseThrow(() -> new CustomException(TripErrorType.DAY_PLACE_NOT_FOUND));
+
+        // 위도 경도 없는 경우
+        if (!hasGpsInfo(image)) {
+            assignToUnmatched(tripDayPlace, image);
+            return;
+        }
+
+        Place nearestPlace = findNearestPlace(tripDayPlace, image);
+
+        if (nearestPlace != null) {     // 담겨진 목적지가 없는 경우
+            nearestPlace.addImage(image);
+        } else {
+            assignToUnmatched(tripDayPlace, image);
+        }
+
+        tripDayPlaceService.save(tripDayPlace);
+    }
+
+    /**
+     * 이미지에 위도·경도 정보가 존재하는지 확인하는 메서드
+     *
+     * @param image 확인할 이미지 객체
+     * @return 위도와 경도가 모두 존재하면 true, 아니면 false
+     */
+    private boolean hasGpsInfo(Image image) {
+        return image.getLatitude() != null && image.getLongitude() != null;
+    }
+
+    /**
+     * GPS 정보가 없거나 적절한 목적지를 찾지 못한 이미지를 기타 목록에 추가하는 메서드
+     *
+     * @param tripDayPlace 이미지가 속한 TripDayPlace
+     * @param image        기타로 분류할 이미지
+     */
+    private void assignToUnmatched(TripDayPlace tripDayPlace, Image image) {
+        tripDayPlace.addUnmatchedImage(image);
+        tripDayPlaceService.save(tripDayPlace);
+    }
+
+    /**
+     * 이미지와 가장 가까운 위치에 있는 목적지를 TripDayPlace 내에서 탐색하는 메서드
+     * - Haversine 공식을 기반으로 계산된 거리 기준
+     *
+     * @param tripDayPlace 비교 대상이 되는 장소 리스트
+     * @param image        위치 기준이 될 이미지
+     * @return 가장 가까운 Place 객체, 없으면 null
+     */
+    private Place findNearestPlace(TripDayPlace tripDayPlace, Image image) {
+        return tripDayPlace.getPlaces().stream()
+                .min(Comparator.comparingDouble(place ->
+                        calculateDistance(image.getLatitude(), image.getLongitude(),
+                                place.getLatitude(), place.getLongitude())))
+                .orElse(null);
+    }
+
+    /**
+     * 두 GPS 좌표 간의 지구 표면 거리(km)를 Haversine 공식으로 계산하는 메서드
+     *
+     * @param lat1 첫 번째 위도
+     * @param lon1 첫 번째 경도
+     * @param lat2 두 번째 위도
+     * @param lon2 두 번째 경도
+     * @return 두 지점 간 거리 (단위: km)
+     */
+    private double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        final int R = 6371;
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return R * c;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Image.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Image.java
@@ -1,0 +1,25 @@
+package kr.co.yeogiga.domain.tripplace.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+public class Image {
+    private String id;
+    private String url;
+    private Double latitude;
+    private Double longitude;
+    private LocalDateTime date;
+
+    @Builder
+    public Image(String url, Double latitude, Double longitude, LocalDateTime date) {
+        this.id = UUID.randomUUID().toString();
+        this.url = url;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.date = date;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
@@ -4,6 +4,8 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 public class Place {
@@ -14,6 +16,7 @@ public class Place {
     private String placeType;
     private double order;
     private LocalDateTime visitedAt;
+    private List<Image> images;
 
     @Builder
     public Place(String id, String name, double latitude, double longitude,
@@ -25,9 +28,14 @@ public class Place {
         this.placeType = placeType;
         this.order = order;
         this.visitedAt = visitedAt;
+        this.images = new ArrayList<>();
     }
 
     public void updateOrder(double order) {
         this.order = order;
+    }
+
+    public void addImage(Image image) {
+        this.images.add(image);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/TripDayPlace.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/TripDayPlace.java
@@ -8,6 +8,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -20,6 +21,7 @@ public class TripDayPlace {
     private int day;
     private LocalDate date;
     private List<Place> places;
+    private List<Image> unmatchedImages;
 
     @Builder
     public TripDayPlace(Long tripId, int day, LocalDate date, List<Place> places) {
@@ -27,9 +29,14 @@ public class TripDayPlace {
         this.day = day;
         this.date = date;
         this.places = places;
+        this.unmatchedImages = new ArrayList<>();
     }
 
     public void updatePlaces(List<Place> places) {
         this.places = places;
+    }
+
+    public void addUnmatchedImage(Image image) {
+        this.unmatchedImages.add(image);
     }
 }


### PR DESCRIPTION
## 배경
본 서비스의 주요 기능인 이미지를 목적지에 자동으로 배치해주는 로직 구현이 필요

## 작업 사항
- 이미지 객체 생성 (e79dbc11aafc01273d5301f22527ad839d7a10aa)
- 이미지의 위도/경도 메타데이터를 통해 적절한 목적지에 할당 (2e35c24a5df5e7e416814f2fc10f955ce51f2ca5)
    - 위도 경도를 기반으로 거리를 계산하는 `calculateDistance`메서드는 `Haversine`공식 이용 ([참고 블로그](https://kayuse88.github.io/haversine/))

## 기타
1. 추후 즐겨찾기를 위한 필드 추가 필요
2. 방장 루트 받아오는 로직이 생기면, 사진에 위도/경도가 없을떄 방장 루트의 시간데이터로 위도/경도 값 받아오는 것이 필요. (시간도 없으면 기타로 감)
3. 이미지 목적지 변경 로직 필요 (사용자 지정)
4. 추후 이미지 저장 로직 변경 (미리 이미지를 넣어두고, 버튼을 누르면 정렬하는 과정으로 서비스가 동작하기 때문)

## 테스트

| <img width="948" alt="스크린샷 2025-05-01 오후 6 10 19" src="https://github.com/user-attachments/assets/a06fbd65-cc87-4b77-ae6c-3d23092c5c62" /> |
|---|
| 가장 위부터, 영남대, 경북대, 서울역 을 기반으로 거리 계산 후 사진 매핑 |
