### PR TITLE
Feature(IL-51): 게스트 사용자 권한 승격을 위한 회원 등록

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/auth/dto/SignUpDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/SignUpDto.java
@@ -42,6 +42,7 @@ public class SignUpDto {
     }
 
     public record Register(
+            @Schema(name = "닉네임", example = "testnick")
             @NotBlank(message = "닉네임은 필수 입력값입니다.")
             String nickname
     ) {

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/SignUpDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/SignUpDto.java
@@ -40,4 +40,10 @@ public class SignUpDto {
                     .build();
         }
     }
+
+    public record Register(
+            @NotBlank(message = "닉네임은 필수 입력값입니다.")
+            String nickname
+    ) {
+    }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -1,13 +1,16 @@
 package kr.co.yeogiga.application.auth.service;
 
 import kr.co.yeogiga.application.auth.dto.SignInDto;
+import kr.co.yeogiga.application.auth.dto.SignUpDto;
 import kr.co.yeogiga.application.auth.dto.TokenDto;
 import kr.co.yeogiga.application.auth.dto.UserInfoDto;
 import kr.co.yeogiga.application.auth.dto.UserStatusDto;
+import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.oauth.entity.OAuth;
 import kr.co.yeogiga.domain.oauth.service.OAuthService;
 import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
 import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.exception.UserErrorType;
 import kr.co.yeogiga.domain.user.service.UserService;
 import kr.co.yeogiga.domain.user.type.Role;
 import kr.co.yeogiga.infrastructure.oauth.OAuthClient;
@@ -21,7 +24,6 @@ public class OAuthManagementService {
     private final OAuthClientFactory oAuthClientFactory;
     private final OAuthService oAuthService;
     private final JwtService jwtService;
-    private final RefreshTokenService refreshTokenService;
     private final UserService userService;
 
     /**
@@ -41,6 +43,15 @@ public class OAuthManagementService {
         UserStatusDto userStatus = getUserStatus(platform, userInfo);
 
         return getSignInResponse(userStatus);
+    }
+
+    @Transactional
+    public void register(Long userId, SignUpDto.Register request) {
+        User user = userService.readById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
+
+        user.updateNickname(request.nickname());
+        user.upgradeRoleToUser();
     }
 
     /**
@@ -104,6 +115,5 @@ public class OAuthManagementService {
                 .token(token)
                 .shouldSignup(userStatus.shouldSignUp())
                 .build();
-
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -45,6 +45,12 @@ public class OAuthManagementService {
         return getSignInResponse(userStatus);
     }
 
+    /**
+     * GUEST 사용자의 권한 승격을 위한 회원 등록 메서드
+     *
+     * @param userId        사용자 ID
+     * @param request       회원 등록 요청 dto (nickname)
+     */
     @Transactional
     public void register(Long userId, SignUpDto.Register request) {
         User user = userService.readById(userId)

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -59,4 +59,8 @@ public class User extends BaseTimeEntity {
         signedUp = true;
         role = Role.USER;
     }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/security/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
                         authorize
                                 .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
                                 .requestMatchers(USER_ENDPOINTS).hasAuthority(Role.USER.name())
+                                .requestMatchers(GUEST_ENDPOINTS).hasAuthority(Role.GUEST.name())
                                 .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
@@ -6,10 +6,14 @@ public final class EndpointConstants {
     public static final String[] PUBLIC_ENDPOINTS = {
             "/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**",
             "/webjars/**", "/error", "/api-checker/**", "/v1/api/link/checker/**",
-            "/api/v1/auth/**"
+            "/api/v1/auth/**", "/api/v1/oauth/sign-in/**"
     };
 
     public static final String[] USER_ENDPOINTS = {
             "/api/v1/trip/**",
+    };
+
+    public static final String[] GUEST_ENDPOINTS = {
+            "/api/v1/oauth/register"
     };
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
@@ -10,9 +10,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
+import kr.co.yeogiga.application.auth.dto.SignUpDto;
 import kr.co.yeogiga.application.auth.type.Device;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -96,4 +99,40 @@ public interface OAuthApi {
                     }))
     })
     ResponseEntity<?> signIn(@RequestHeader(value = "device") Device device, @PathVariable(name = "platform") OAuthPlatform platform, @Valid @RequestBody SignInDto.OAuthRequest request);
+
+    @TrackApi(description = "게스트 회원 등록")
+    @Operation(summary = "게스트 회원 등록", description = "게스트 사용자 회원 등록을 위한 API 입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원 등록 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "회원 등록 성공", value = """
+                                        {
+                                             "code": 200,
+                                             "message": "요청이 성공하였습니다."
+                                         }
+                                    """),
+                    })),
+            @ApiResponse(responseCode = "400", description = "유효성 검증 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "유효성 검증 실패", value = """
+                                        {
+                                            "code": "G002",
+                                            "errors": {
+                                                "nickname": "닉네임은 필수 입력값입니다."
+                                            }
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "접근 권한 오류",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "접근 권한 오류", value = """
+                                        {
+                                             "code": "A000",
+                                             "message": "접근 권한이 없습니다."
+                                        }
+                                    """)
+                    }))
+
+    })
+    ResponseEntity<?> register(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody SignUpDto.Register request);
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
@@ -40,11 +40,11 @@ public class OAuthController implements OAuthApi {
         return createSignInResponse(device, oAuthManagementService.signIn(platform, request.code()));
     }
 
-
+    @Override
     @PutMapping("/register")
     public ResponseEntity<?> register(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody SignUpDto.Register request) {
+            @Valid @RequestBody SignUpDto.Register request) {
         oAuthManagementService.register(userDetails.getUserId(), request);
         return ResponseEntity.ok(SuccessResponse.ok());
     }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
@@ -2,17 +2,21 @@ package kr.co.yeogiga.presentation.auth.controller;
 
 import jakarta.validation.Valid;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
+import kr.co.yeogiga.application.auth.dto.SignUpDto;
 import kr.co.yeogiga.application.auth.service.OAuthManagementService;
 import kr.co.yeogiga.application.auth.type.Device;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import kr.co.yeogiga.common.util.CookieUtil;
 import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
 import kr.co.yeogiga.presentation.auth.api.OAuthApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,6 +38,15 @@ public class OAuthController implements OAuthApi {
             @PathVariable(name = "platform") OAuthPlatform platform,
             @Valid @RequestBody SignInDto.OAuthRequest request) {
         return createSignInResponse(device, oAuthManagementService.signIn(platform, request.code()));
+    }
+
+
+    @PutMapping("/register")
+    public ResponseEntity<?> register(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody SignUpDto.Register request) {
+        oAuthManagementService.register(userDetails.getUserId(), request);
+        return ResponseEntity.ok().build();
     }
 
     private ResponseEntity<?> createSignInResponse(Device device, SignInDto.Response response) {

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
@@ -19,14 +19,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.Duration;
-import static kr.co.yeogiga.application.auth.constant.AuthConstants.*;
+import static kr.co.yeogiga.application.auth.constant.AuthConstants.REFRESH_TOKEN_PREFIX;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/auth/oauth")
+@RequestMapping("/api/v1/oauth")
 public class OAuthController implements OAuthApi {
     private final OAuthManagementService oAuthManagementService;
 
+    @Override
     @PostMapping("/sign-in/{platform}")
     public ResponseEntity<?> signIn(
             @RequestHeader(value = "device") Device device,

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
@@ -46,7 +46,7 @@ public class OAuthController implements OAuthApi {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody SignUpDto.Register request) {
         oAuthManagementService.register(userDetails.getUserId(), request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(SuccessResponse.ok());
     }
 
     private ResponseEntity<?> createSignInResponse(Device device, SignInDto.Response response) {

--- a/src/test/java/kr/co/yeogiga/application/oauth/service/OAuthManagementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/oauth/service/OAuthManagementServiceTest.java
@@ -1,0 +1,73 @@
+package kr.co.yeogiga.application.oauth.service;
+
+import kr.co.yeogiga.application.auth.dto.SignUpDto;
+import kr.co.yeogiga.application.auth.service.JwtService;
+import kr.co.yeogiga.application.auth.service.OAuthClientFactory;
+import kr.co.yeogiga.application.auth.service.OAuthManagementService;
+import kr.co.yeogiga.domain.oauth.service.OAuthService;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.service.UserService;
+import kr.co.yeogiga.domain.user.type.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class OAuthManagementServiceTest {
+
+    @Mock
+    private OAuthClientFactory oAuthClientFactory;
+
+    @Mock
+    private OAuthService oAuthService;
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private OAuthManagementService oAuthManagementService;
+
+    @Nested
+    @DisplayName("회원 등록 - 게스트 권한 승격")
+    class Register {
+        private User user = User.builder()
+                .username("testid")
+                .password("testpassword")
+                .nickname("KAKAO 123")
+                .email("test@test.com")
+                .role(Role.GUEST)
+                .build();
+
+        private final Long userId = 1L;
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            String updatedNickname = "newNickname";
+            SignUpDto.Register request = new SignUpDto.Register(updatedNickname);
+
+            when(userService.readById(userId)).thenReturn(Optional.of(user));
+
+            // when
+            oAuthManagementService.register(userId, request);
+
+            // then
+            assertEquals(user.getNickname(), updatedNickname);
+            assertEquals(user.getRole(), Role.USER);
+            assertEquals(user.isSignedUp(), true);
+        }
+    }
+}

--- a/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthControllerTest.java
@@ -86,7 +86,7 @@ public class OAuthControllerTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                post("/api/v1/auth/oauth/sign-in/{platform}", oAuthPlatform)
+                post("/api/v1/oauth/sign-in/{platform}", oAuthPlatform)
                         .header("device", device.name())
                         .content(objectMapper.writeValueAsBytes(request))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -110,7 +110,7 @@ public class OAuthControllerTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                post("/api/v1/auth/oauth/sign-in/{platform}", oAuthPlatform)
+                post("/api/v1/oauth/sign-in/{platform}", oAuthPlatform)
                         .header("device", device.name())
                         .content(objectMapper.writeValueAsBytes(request))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -135,7 +135,7 @@ public class OAuthControllerTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                post("/api/v1/auth/oauth/sign-in/{platform}", oAuthPlatform)
+                post("/api/v1/oauth/sign-in/{platform}", oAuthPlatform)
                         .header("device", device.name())
                         .content(objectMapper.writeValueAsBytes(request))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -159,7 +159,7 @@ public class OAuthControllerTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                post("/api/v1/auth/oauth/sign-in/{platform}", oAuthPlatform)
+                post("/api/v1/oauth/sign-in/{platform}", oAuthPlatform)
                         .header("device", device.name())
                         .content(objectMapper.writeValueAsBytes(request))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -188,7 +188,7 @@ public class OAuthControllerTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                post("/api/v1/auth/oauth/sign-in/{platform}", oAuthPlatform)
+                post("/api/v1/oauth/sign-in/{platform}", oAuthPlatform)
                         .header("device", device.name())
                         .content(objectMapper.writeValueAsBytes(req))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -215,7 +215,7 @@ public class OAuthControllerTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                post("/api/v1/auth/oauth/sign-in/{platform}", oAuthPlatform)
+                post("/api/v1/oauth/sign-in/{platform}", oAuthPlatform)
                         .header("device", device.name())
                         .content(objectMapper.writeValueAsBytes(req))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -236,7 +236,7 @@ public class OAuthControllerTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                post("/api/v1/auth/oauth/sign-in/{platform}", "MISS_VALUE")
+                post("/api/v1/oauth/sign-in/{platform}", "MISS_VALUE")
                         .header("device", device.name())
                         .content(objectMapper.writeValueAsBytes(request))
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthSecurityControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthSecurityControllerTest.java
@@ -61,8 +61,7 @@ public class OAuthSecurityControllerTest {
         this.mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)
                 .apply(springSecurity())
-                .defaultRequest(get("/**").with(csrf()))
-                .defaultRequest(post("/**").with(csrf()))
+                .defaultRequest(put("/**").with(csrf()))
                 .alwaysDo(print())
                 .build();
     }

--- a/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthSecurityControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthSecurityControllerTest.java
@@ -1,0 +1,134 @@
+package kr.co.yeogiga.presentation.oauth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.application.auth.dto.SignUpDto;
+import kr.co.yeogiga.application.auth.service.OAuthManagementService;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
+import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.type.Role;
+import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
+import kr.co.yeogiga.presentation.auth.controller.OAuthController;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = OAuthController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthenticationFilter.class})
+        }
+)
+public class OAuthSecurityControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private OAuthManagementService oAuthManagementService;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .defaultRequest(get("/**").with(csrf()))
+                .defaultRequest(post("/**").with(csrf()))
+                .alwaysDo(print())
+                .build();
+    }
+
+    @Nested
+    @DisplayName("회원 등록 - 게스트 권한 승격")
+    class Register {
+
+        private final Long userId = 1L;
+
+        private User user = User.builder()
+                .username("testuser")
+                .email("test@example.com")
+                .nickname("Tester")
+                .role(Role.GUEST)
+                .password("password")
+                .build();
+
+        private CustomUserDetails userDetails;
+
+        @BeforeEach
+        void setUp() {
+            ReflectionTestUtils.setField(user, "id", userId);
+
+            userDetails = new CustomUserDetailsImpl(user);
+        }
+
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            SignUpDto.Register request = new SignUpDto.Register("newNick");
+
+            // when
+            ResultActions resultActions = mockMvc.perform(put("/api/v1/oauth/register")
+                    .with(user(userDetails))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(request))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+
+            verify(oAuthManagementService, times(1)).register(any(), any());
+        }
+
+        @Test
+        @DisplayName("실패 - 유효성 검증 실패")
+        void failValidation() throws Exception {
+            // given
+            SignUpDto.Register request = new SignUpDto.Register(null);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    put("/api/v1/oauth/register")
+                            .with(user(userDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors").exists());
+        }
+    }
+}

--- a/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthSecurityControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthSecurityControllerTest.java
@@ -33,8 +33,6 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;


### PR DESCRIPTION
## 배경
- GUEST → USER 권한 승격을 위한 회원 등록 api 필요 

## 작업 사항
- `OAuthController` 엔드포인트 접두사 변경
   - 사용자 권한 별 엔드포인트 분리 용이성을 위한 변경 `/api/v1/auth/oauth/**` → `/api/v1/oauth/**`
   - 회원 등록은 GUEST 사용자만 접근가능하도록 제한

- OAuthController 내 `/api/v1/oauth/register` api 추가

- SpringSecurity를 적용한 테스트 분리를 위한 `OAuthControllerSecurityTest` 클래스 추가

## 추가 논의

1. 테스트 코드 작성 시 `@AuthenticationPrincipal` 값 바인딩 문제로 인한 접근 권한 테스트 미실시
```java
    @Override
    @PutMapping("/register")
    public ResponseEntity<?> register(
            @AuthenticationPrincipal CustomUserDetails userDetails,
            @Valid @RequestBody SignUpDto.Register request) {
        oAuthManagementService.register(userDetails.getUserId(), request);
        return ResponseEntity.ok(SuccessResponse.ok());
    }
```
위 코드에 대한 테스트 코드 작성 시, `Captor`를 사용하여 `oAuthManagementService.register(ipCator.capture(), registerCaptor.capture())`와 같이 메서드에 인자로 사용된 값을 확인하려 하였으나 계속 null 값으로 출력되어 인자값을 확인하는 테스트는 진행하지 못하였습니다.

해당 콘트롤러 메서드 내에 `userDetails` 로그를 출력하여도 테스트에서는 `userDetails`는 null로 출력되었습니다.

또한, `userDetails 등록 시` 사용자 권한이 GUEST가 아닌 USER여도 정상적으로 통과하는 문제가 있어 접근 권한에 관한 테스트는 진행하지 못하였습니다.

기존 `OAuthController` 내 PUBLIC 엔드포인트도 mockMvc 값 할당 시 `springSecurity()`를 사용하면 userDetails를 제공하지 않아도 테스트가 정상적으로 진행되는 것이 아니라 401에러가 발생해 `OAuthSecurityControllerTest`로 분리하였습니다.

혹시라도, `@WebMvcTest`의 `excludeFilters` 속성 여부에 따라 결과가 달라질 수 있다고 생각하여 테스트 하였으나, `excludeFilters` 속성을 지우고 테스트를 진행해도 동일한 결과가 발생하였습니다.

참고로, excludeFilters 속성을 지우니, springSecurity 관련 필터와 빈을 로드하면서 JwtAuthenticationFiltler나 JwtExceptionFilter 등에 존재하는 의존성이 없어 ApplicationContext가 로드되지 않아 해당 의존성들을 MockBean 으로 등록하였습니다.

테스트 결과에서 모두 권한이 USER로 설정되어 있어도 무시되고 권한 오류는 발생하지 않았습니다.

<img width="1775" alt="image" src="https://github.com/user-attachments/assets/6c799ddf-36d1-4261-ade4-50cd5d71a058" />

따라서, 접근 권한 테스트는 미실시 하였으나, Swagger 문서 상에는 접근 권한 테스트 오류도 명시하였습니다.