### PR TITLE
Feature(IL-52): 임시 목적지 관련 로직 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingService.java
@@ -44,26 +44,33 @@ public class TripPlaceEditingService {
     }
 
     /**
-     * 편집 중인 여행 일정에 새로운 목적지를 추가하는 메서드
-     * - Set을 통해 이미 추가된 장소인지 확인
-     * - 중복이 없다면 List & Set에 추가 (저장 포맷에 맞게 변환 후 저장)
+     * 임시 저장소에서 장소를 꺼내와 특정 일차에 배정하는 메서드
+     * - 이미 해당 일차에 존재하는 경우 예외 발생
+     * - 배정 후 임시 저장소에서 해당 장소는 제거됨
      *
-     * @param tripId : 여행 ID
-     * @param day    : 여행 일차
-     * @param place  : 추가할 TripPlaceDto.Request 객체
-     * @throws CustomException ALREADY_ADDED_PLACE : 이미 목적지를 추가한 경우
+     * @param tripId  : 여행 ID
+     * @param day     : 배정할 일차
+     * @param placeId : 배정할 장소의 ID (임시 저장소 기준)
      */
-    public void assignPlaceToDay(Long tripId, int day, TripPlaceReq.Request place) {
-        String listKey = PlaceConstant.listKey(tripId, day);
-        String setKey = PlaceConstant.setKey(tripId, day);
+    public void assignPlaceToDay(Long tripId, int day, String placeId) {
+        String tempListKey = PlaceConstant.tempListKey(tripId);
+        String dayPlacesKey = PlaceConstant.dayPlacesKey(tripId, day);
+        String dayPlaceSetKey = PlaceConstant.dayPlaceSetKey(tripId, day);
+
+        TripPlaceReq.StoredFormat place = findPlaceInList(tempListKey, placeId);
+        if (place == null) {
+            throw new CustomException(TripErrorType.NOT_FOUND_TEMP_PLACE);
+        }
 
         String placeUniqueKey = makeUniqueKey(place.name(), place.latitude(), place.longitude());
-        if (redisRepository.existsInSet(setKey, placeUniqueKey)) {
+        if (redisRepository.existsInSet(dayPlaceSetKey, placeUniqueKey)) {
             throw new CustomException(TripErrorType.ALREADY_ADDED_PLACE);
         }
 
-        redisRepository.setList(listKey, place.toStoredFormat());
-        redisRepository.addToSet(setKey, placeUniqueKey);
+        redisRepository.setList(dayPlacesKey, place);
+        redisRepository.addToSet(dayPlaceSetKey, placeUniqueKey);
+
+        deleteTempPlace(tripId, placeId);
     }
 
     /**
@@ -74,8 +81,8 @@ public class TripPlaceEditingService {
      * @return : 저장된 TripPlaceDto.StoredFormat 리스트
      */
     public List<TripPlaceReq.StoredFormat> getAssignedPlaces(Long tripId, int day) {
-        String listKey = PlaceConstant.listKey(tripId, day);
-        return redisRepository.getList(listKey, TripPlaceReq.StoredFormat.class);
+        String dayPlacesKey = PlaceConstant.dayPlacesKey(tripId, day);
+        return redisRepository.getList(dayPlacesKey, TripPlaceReq.StoredFormat.class);
     }
 
     /**
@@ -105,18 +112,18 @@ public class TripPlaceEditingService {
      * @param placeId : 삭제할 목적지 ID
      */
     public void deleteAssignedPlace(Long tripId, int day, String placeId) {
-        String listKey = PlaceConstant.listKey(tripId, day);
-        String setKey = PlaceConstant.setKey(tripId, day);
+        String dayPlacesKey = PlaceConstant.dayPlacesKey(tripId, day);
+        String dayPlaceSetKey = PlaceConstant.dayPlaceSetKey(tripId, day);
 
-        TripPlaceReq.StoredFormat target = findPlaceInList(listKey, placeId);
+        TripPlaceReq.StoredFormat target = findPlaceInList(dayPlacesKey, placeId);
         if (target == null) {
             return;
         }
 
-        redisRepository.removeFromList(listKey, target);
+        redisRepository.removeFromList(dayPlacesKey, target);
 
         String placeUniqueKey = makeUniqueKey(target.name(), target.latitude(), target.longitude());
-        redisRepository.removeFromSet(setKey, placeUniqueKey);
+        redisRepository.removeFromSet(dayPlaceSetKey, placeUniqueKey);
     }
 
     /**
@@ -145,16 +152,16 @@ public class TripPlaceEditingService {
      * @param places : 새로운 순서의 TripPlaceDto.Request 리스트
      */
     public void updatePlaces(Long tripId, int day, List<TripPlaceReq.Request> places) {
-        String listKey = PlaceConstant.listKey(tripId, day);
-        String setKey = PlaceConstant.setKey(tripId, day);
+        String dayPlacesKey = PlaceConstant.dayPlacesKey(tripId, day);
+        String dayPlaceSetKey = PlaceConstant.dayPlaceSetKey(tripId, day);
 
-        redisRepository.del(listKey);
-        redisRepository.del(setKey);
+        redisRepository.del(dayPlacesKey);
+        redisRepository.del(dayPlaceSetKey);
 
         for (TripPlaceReq.Request place : places) {
-            redisRepository.setList(listKey, place.toStoredFormat());
+            redisRepository.setList(dayPlacesKey, place.toStoredFormat());
             String placeUniqueKey = makeUniqueKey(place.name(), place.latitude(), place.longitude());
-            redisRepository.addToSet(setKey, placeUniqueKey);
+            redisRepository.addToSet(dayPlaceSetKey, placeUniqueKey);
         }
     }
 

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingService.java
@@ -27,9 +27,9 @@ public class TripPlaceEditingService {
      * @param place  : 추가할 TripPlaceDto.Request 객체
      */
     public void addTempPlace(Long tripId, TripPlaceReq.Request place) {
-        String listKey = PlaceConstant.tempListKey(tripId);
+        String tempListKey = PlaceConstant.tempListKey(tripId);
 
-        redisRepository.setList(listKey, place.toStoredFormat());
+        redisRepository.setList(tempListKey, place.toStoredFormat());
     }
 
     /**
@@ -39,8 +39,8 @@ public class TripPlaceEditingService {
      * @return : 임시 저장된 장소 리스트
      */
     public List<TripPlaceReq.StoredFormat> getTempPlaces(Long tripId) {
-        String listKey = PlaceConstant.tempListKey(tripId);
-        return redisRepository.getList(listKey, TripPlaceReq.StoredFormat.class);
+        String tempListKey = PlaceConstant.tempListKey(tripId);
+        return redisRepository.getList(tempListKey, TripPlaceReq.StoredFormat.class);
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingService.java
@@ -20,16 +20,27 @@ import java.util.List;
 public class TripPlaceEditingService {
     private final RedisRepository redisRepository;
 
-
     /**
-     * 일정에 분배되기 전, 임시 목적지 목록에 장소를 추가하는 메서드
+     * 일정에 배정되기 전 임시 저장소에 장소를 추가하는 메서드
      *
-     * @param tripId  : 여행 ID
-     * @param place   : 추가할 장소 정보
-     * @throws CustomException ALREADY_ADDED_PLACE : 이미 추가된 장소인 경우
+     * @param tripId : 여행 ID
+     * @param place  : 추가할 TripPlaceDto.Request 객체
      */
     public void addTempPlace(Long tripId, TripPlaceReq.Request place) {
+        String listKey = PlaceConstant.tempListKey(tripId);
 
+        redisRepository.setList(listKey, place.toStoredFormat());
+    }
+
+    /**
+     * 일정에 배정되기 전 임시 저장소에 있는 장소 목록을 조회하는 메서드
+     *
+     * @param tripId : 여행 ID
+     * @return : 임시 저장된 장소 리스트
+     */
+    public List<TripPlaceReq.StoredFormat> getTempPlaces(Long tripId) {
+        String listKey = PlaceConstant.tempListKey(tripId);
+        return redisRepository.getList(listKey, TripPlaceReq.StoredFormat.class);
     }
 
     /**
@@ -68,6 +79,23 @@ public class TripPlaceEditingService {
     }
 
     /**
+     * 일정에 배정되기 전 임시 저장소에서 장소를 삭제하는 메서드
+     *
+     * @param tripId  : 여행 ID
+     * @param placeId : 삭제할 장소 ID
+     */
+    public void deleteTempPlace(Long tripId, String placeId) {
+        String listKey = PlaceConstant.tempListKey(tripId);
+
+        TripPlaceReq.StoredFormat target = findPlaceInList(listKey, placeId);
+        if (target == null) {
+            return;
+        }
+
+        redisRepository.removeFromList(listKey, target);
+    }
+
+    /**
      * 편집 중인 여행 일정에서 특정 목적지를 삭제하는 메서드
      * - List에서 id에 해당하는 목적지 조회
      * - 찾은 경우 List & Set에 삭제
@@ -80,13 +108,7 @@ public class TripPlaceEditingService {
         String listKey = PlaceConstant.listKey(tripId, day);
         String setKey = PlaceConstant.setKey(tripId, day);
 
-        List<TripPlaceReq.StoredFormat> places = redisRepository.getList(listKey, TripPlaceReq.StoredFormat.class);
-
-        TripPlaceReq.StoredFormat target = places.stream()
-                .filter(p -> placeId.equals(p.id()))
-                .findFirst()
-                .orElse(null);
-
+        TripPlaceReq.StoredFormat target = findPlaceInList(listKey, placeId);
         if (target == null) {
             return;
         }
@@ -95,6 +117,22 @@ public class TripPlaceEditingService {
 
         String placeUniqueKey = makeUniqueKey(target.name(), target.latitude(), target.longitude());
         redisRepository.removeFromSet(setKey, placeUniqueKey);
+    }
+
+    /**
+     * Redis 리스트에서 주어진 placeId에 해당하는 장소를 찾아 반환하는 메서드
+     *
+     * @param listKey  : Redis에 저장된 장소 리스트의 키
+     * @param placeId  : 조회할 장소의 ID
+     * @return         : 일치하는 장소가 존재하면 해당 객체, 없으면 null 반환
+     */
+    private TripPlaceReq.StoredFormat findPlaceInList(String listKey, String placeId) {
+        List<TripPlaceReq.StoredFormat> places = redisRepository.getList(listKey, TripPlaceReq.StoredFormat.class);
+
+        return places.stream()
+                .filter(p -> placeId.equals(p.id()))
+                .findFirst()
+                .orElse(null);
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingService.java
@@ -27,7 +27,7 @@ public class TripPlaceEditingService {
      * @param day    : 여행 일차 (1일차, 2일차 등)
      * @return : 저장된 TripPlaceDto.StoredFormat 리스트
      */
-    public List<TripPlaceReq.StoredFormat> getPlaces(Long tripId, int day) {
+    public List<TripPlaceReq.StoredFormat> getAssignedPlaces(Long tripId, int day) {
         String listKey = PlaceConstant.listKey(tripId, day);
         return redisRepository.getList(listKey, TripPlaceReq.StoredFormat.class);
     }
@@ -42,7 +42,7 @@ public class TripPlaceEditingService {
      * @param place  : 추가할 TripPlaceDto.Request 객체
      * @throws CustomException ALREADY_ADDED_PLACE : 이미 목적지를 추가한 경우
      */
-    public void addPlace(Long tripId, int day, TripPlaceReq.Request place) {
+    public void assignPlaceToDay(Long tripId, int day, TripPlaceReq.Request place) {
         String listKey = PlaceConstant.listKey(tripId, day);
         String setKey = PlaceConstant.setKey(tripId, day);
 

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingService.java
@@ -20,16 +20,16 @@ import java.util.List;
 public class TripPlaceEditingService {
     private final RedisRepository redisRepository;
 
+
     /**
-     * 특정 여행(tripId)과 일차(day)에 저장된 목적지 리스트를 조회하는 메서드
+     * 일정에 분배되기 전, 임시 목적지 목록에 장소를 추가하는 메서드
      *
-     * @param tripId : 여행 ID
-     * @param day    : 여행 일차 (1일차, 2일차 등)
-     * @return : 저장된 TripPlaceDto.StoredFormat 리스트
+     * @param tripId  : 여행 ID
+     * @param place   : 추가할 장소 정보
+     * @throws CustomException ALREADY_ADDED_PLACE : 이미 추가된 장소인 경우
      */
-    public List<TripPlaceReq.StoredFormat> getAssignedPlaces(Long tripId, int day) {
-        String listKey = PlaceConstant.listKey(tripId, day);
-        return redisRepository.getList(listKey, TripPlaceReq.StoredFormat.class);
+    public void addTempPlace(Long tripId, TripPlaceReq.Request place) {
+
     }
 
     /**
@@ -56,6 +56,18 @@ public class TripPlaceEditingService {
     }
 
     /**
+     * 특정 여행(tripId)과 일차(day)에 저장된 목적지 리스트를 조회하는 메서드
+     *
+     * @param tripId : 여행 ID
+     * @param day    : 여행 일차 (1일차, 2일차 등)
+     * @return : 저장된 TripPlaceDto.StoredFormat 리스트
+     */
+    public List<TripPlaceReq.StoredFormat> getAssignedPlaces(Long tripId, int day) {
+        String listKey = PlaceConstant.listKey(tripId, day);
+        return redisRepository.getList(listKey, TripPlaceReq.StoredFormat.class);
+    }
+
+    /**
      * 편집 중인 여행 일정에서 특정 목적지를 삭제하는 메서드
      * - List에서 id에 해당하는 목적지 조회
      * - 찾은 경우 List & Set에 삭제
@@ -64,7 +76,7 @@ public class TripPlaceEditingService {
      * @param day     : 여행 일차
      * @param placeId : 삭제할 목적지 ID
      */
-    public void deletePlace(Long tripId, int day, String placeId) {
+    public void deleteAssignedPlace(Long tripId, int day, String placeId) {
         String listKey = PlaceConstant.listKey(tripId, day);
         String setKey = PlaceConstant.setKey(tripId, day);
 

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceSavingService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceSavingService.java
@@ -34,8 +34,8 @@ public class TripPlaceSavingService {
             tripDayPlaces.add(createTripDayPlace(tripId, day));
 
             // Redis에 임시 저장된 데이터 삭제
-            redisRepository.del(PlaceConstant.listKey(tripId, day));
-            redisRepository.del(PlaceConstant.setKey(tripId, day));
+            redisRepository.del(PlaceConstant.dayPlacesKey(tripId, day));
+            redisRepository.del(PlaceConstant.dayPlaceSetKey(tripId, day));
         }
 
         tripDayPlaceService.saveAll(tripDayPlaces);
@@ -49,9 +49,9 @@ public class TripPlaceSavingService {
      * @return : 생성된 TripDayPlace
      */
     private TripDayPlace createTripDayPlace(Long tripId, int day) {
-        String listKey = PlaceConstant.listKey(tripId, day);
+        String dayPlacesKey = PlaceConstant.dayPlacesKey(tripId, day);
         List<TripPlaceReq.StoredFormat> storedPlaces
-                = redisRepository.getList(listKey, TripPlaceReq.StoredFormat.class);
+                = redisRepository.getList(dayPlacesKey, TripPlaceReq.StoredFormat.class);
 
         List<Place> places = new ArrayList<>();
         for (int i = 0; i < storedPlaces.size(); i++) {

--- a/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
@@ -12,7 +12,8 @@ public enum TripErrorType implements BaseErrorType {
 
     INVALID_PLACE(HttpStatus.BAD_REQUEST, "T001", "지원하지 않는 카테고리입니다."),
     ALREADY_ADDED_PLACE(HttpStatus.CONFLICT, "T002", "이미 추가된 장소입니다."),
-    DAY_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "T003", "해당 여행 일차 정보가 존재하지 않습니다.")
+    DAY_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "T003", "해당 여행 일차 정보가 존재하지 않습니다."),
+    NOT_FOUND_TEMP_PLACE(HttpStatus.NOT_FOUND, "T003", "임시 저장소에 해당 장소가 존재하지 않습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
@@ -13,7 +13,7 @@ public enum TripErrorType implements BaseErrorType {
     INVALID_PLACE(HttpStatus.BAD_REQUEST, "T001", "지원하지 않는 카테고리입니다."),
     ALREADY_ADDED_PLACE(HttpStatus.CONFLICT, "T002", "이미 추가된 장소입니다."),
     DAY_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "T003", "해당 여행 일차 정보가 존재하지 않습니다."),
-    NOT_FOUND_TEMP_PLACE(HttpStatus.NOT_FOUND, "T003", "임시 저장소에 해당 장소가 존재하지 않습니다.")
+    NOT_FOUND_TEMP_PLACE(HttpStatus.NOT_FOUND, "T004", "임시 저장소에 해당 장소가 존재하지 않습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/co/yeogiga/infrastructure/redis/constant/PlaceConstant.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/redis/constant/PlaceConstant.java
@@ -6,6 +6,7 @@ public final class PlaceConstant {
 
     private static final String LIST_KEY_FORMAT = "trip:%d:day:%d:places";
     private static final String SET_KEY_FORMAT = "trip:%d:day:%d:places:set";
+    private static final String TEMP_LIST_KEY_FORMAT = "trip:%d:temp:places";
 
     public static String listKey(Long tripId, int day) {
         return String.format(LIST_KEY_FORMAT, tripId, day);
@@ -13,5 +14,9 @@ public final class PlaceConstant {
 
     public static String setKey(Long tripId, int day) {
         return String.format(SET_KEY_FORMAT, tripId, day);
+    }
+
+    public static String tempListKey(Long tripId) {
+        return String.format(TEMP_LIST_KEY_FORMAT, tripId);
     }
 }

--- a/src/main/java/kr/co/yeogiga/infrastructure/redis/constant/PlaceConstant.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/redis/constant/PlaceConstant.java
@@ -4,16 +4,16 @@ public final class PlaceConstant {
 
     private PlaceConstant() { }
 
-    private static final String LIST_KEY_FORMAT = "trip:%d:day:%d:places";
-    private static final String SET_KEY_FORMAT = "trip:%d:day:%d:places:set";
+    private static final String DAY_PLACES_KEY_FORMAT = "trip:%d:day:%d:places";
+    private static final String DAY_PLACE_SET_KEY_FORMAT = "trip:%d:day:%d:places:set";
     private static final String TEMP_LIST_KEY_FORMAT = "trip:%d:temp:places";
 
-    public static String listKey(Long tripId, int day) {
-        return String.format(LIST_KEY_FORMAT, tripId, day);
+    public static String dayPlacesKey(Long tripId, int day) {
+        return String.format(DAY_PLACES_KEY_FORMAT, tripId, day);
     }
 
-    public static String setKey(Long tripId, int day) {
-        return String.format(SET_KEY_FORMAT, tripId, day);
+    public static String dayPlaceSetKey(Long tripId, int day) {
+        return String.format(DAY_PLACE_SET_KEY_FORMAT, tripId, day);
     }
 
     public static String tempListKey(Long tripId) {

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
@@ -19,10 +19,73 @@ import java.util.List;
 @Tag(name = "[여행 생성 단계에서의 목적지 API]", description = "여행 목적지 관련 API")
 public interface TripPlaceEditingApi {
 
-    @TrackApi(description = "목적지 추가")
-    @Operation(summary = "목적지 추가", description = "목적지 추가하는 API입니다.")
+    @TrackApi(description = "임시 목적지 추가")
+    @Operation(summary = "임시 목적지 추가", description = "임시 추가하는 API입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "목적지 추가 성공",
+            @ApiResponse(responseCode = "201", description = "임시 추가 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 201,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> addTempPlace(@PathVariable Long tripId,
+                                   @RequestBody TripPlaceReq.Request request);
+
+    @TrackApi(description = "임시 목적지 조회")
+    @Operation(summary = "임시 목적지 조회", description = "임시 목적지 조회하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "임시 목적지 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": [
+                                                {
+                                                    "id": "place-id1",
+                                                    "name": "목적지1",
+                                                    "latitude": 32.33,
+                                                    "longitude": 87.123,
+                                                    "placeCategory": "관광지"
+                                                },
+                                                {
+                                                    "id": "place-id2",
+                                                    "name": "목적지2",
+                                                    "latitude": 132.33,
+                                                    "longitude": 287.123,
+                                                    "placeCategory": "식당"
+                                                }
+                                            ]
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getTempPlaces(@PathVariable Long tripId);
+
+    @TrackApi(description = "임시 목적지 삭제")
+    @Operation(summary = "임시 목적지 삭제", description = "임시 삭제하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "임시 목적지 삭제 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> deleteTempPlace(@PathVariable Long tripId,
+                                      @PathVariable String placeId);
+
+    @TrackApi(description = "목적지 일차에 이동")
+    @Operation(summary = "목적지 일차에 이동", description = "목적지 일차에 이동하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "목적지 이동 성공",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                         {
@@ -35,11 +98,20 @@ public interface TripPlaceEditingApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                         {
-                                            "code": "T002",
-                                            "message": "이미 추가된 장소입니다."
+                                            "code": "T004",
+                                            "message": "임시 저장소에 해당 장소가 존재하지 않습니다."
                                         }
                                     """)
                     })),
+            @ApiResponse(responseCode = "404", description = "임시 목적지 목록에 없는 목적지",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": "T003",
+                                            "message": "이미 추가된 장소입니다."
+                                        }
+                                    """)
+                    }))
     })
     ResponseEntity<?> assignPlaceToDay(@PathVariable Long tripId,
                                        @PathVariable int day,

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
@@ -106,7 +106,7 @@ public interface TripPlaceEditingApi {
                                     """)
                     }))
     })
-    ResponseEntity<?> deletePlace(@PathVariable Long tripId,
+    ResponseEntity<?> deleteAssignedPlace(@PathVariable Long tripId,
                                   @PathVariable int day,
                                   @PathVariable String placeId);
 }

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
@@ -98,8 +98,8 @@ public interface TripPlaceEditingApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                         {
-                                            "code": "T004",
-                                            "message": "임시 저장소에 해당 장소가 존재하지 않습니다."
+                                            "code": "T002",
+                                            "message": "이미 추가된 장소입니다."
                                         }
                                     """)
                     })),
@@ -107,8 +107,8 @@ public interface TripPlaceEditingApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                         {
-                                            "code": "T003",
-                                            "message": "이미 추가된 장소입니다."
+                                            "code": "T004",
+                                            "message": "임시 저장소에 해당 장소가 존재하지 않습니다."
                                         }
                                     """)
                     }))

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
@@ -42,8 +42,8 @@ public interface TripPlaceEditingApi {
                     })),
     })
     ResponseEntity<?> assignPlaceToDay(@PathVariable Long tripId,
-                               @PathVariable int day,
-                               @RequestBody TripPlaceReq.Request request);
+                                       @PathVariable int day,
+                                       @PathVariable String placeId);
 
     @TrackApi(description = "일자별 목적지 조회")
     @Operation(summary = "일자별 목적지 조회", description = "일자별 목적지 조회하는 API입니다.")
@@ -107,6 +107,6 @@ public interface TripPlaceEditingApi {
                     }))
     })
     ResponseEntity<?> deleteAssignedPlace(@PathVariable Long tripId,
-                                  @PathVariable int day,
-                                  @PathVariable String placeId);
+                                          @PathVariable int day,
+                                          @PathVariable String placeId);
 }

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
@@ -41,7 +41,7 @@ public interface TripPlaceEditingApi {
                                     """)
                     })),
     })
-    ResponseEntity<?> addPlace(@PathVariable Long tripId,
+    ResponseEntity<?> assignPlaceToDay(@PathVariable Long tripId,
                                @PathVariable int day,
                                @RequestBody TripPlaceReq.Request request);
 
@@ -74,7 +74,7 @@ public interface TripPlaceEditingApi {
                                     """)
                     }))
     })
-    ResponseEntity<?> getPlaces(@PathVariable Long tripId, @PathVariable int day);
+    ResponseEntity<?> getAssignedPlaces(@PathVariable Long tripId, @PathVariable int day);
 
     @TrackApi(description = "목적지 수정")
     @Operation(summary = "목적지 수정", description = "목적지 수정하는 API입니다.")

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
@@ -25,12 +25,12 @@ public class TripPlaceEditingController implements TripPlaceEditingApi {
     private final TripPlaceEditingService tripPlaceEditingService;
 
     @Override
-    @PostMapping("/{tripId}/days/{day}/places")
+    @PostMapping("/{tripId}/days/{day}/places/{placeId}")
     public ResponseEntity<?> assignPlaceToDay(@PathVariable Long tripId,
-                                      @PathVariable int day,
-                                      @RequestBody TripPlaceReq.Request request) {
+                                              @PathVariable int day,
+                                              @PathVariable String placeId) {
 
-        tripPlaceEditingService.assignPlaceToDay(tripId, day, request);
+        tripPlaceEditingService.assignPlaceToDay(tripId, day, placeId);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
     }
 
@@ -55,8 +55,8 @@ public class TripPlaceEditingController implements TripPlaceEditingApi {
     @Override
     @DeleteMapping("/{tripId}/days/{day}/places/{placeId}")
     public ResponseEntity<?> deleteAssignedPlace(@PathVariable Long tripId,
-                                         @PathVariable int day,
-                                         @PathVariable String placeId) {
+                                                 @PathVariable int day,
+                                                 @PathVariable String placeId) {
 
         tripPlaceEditingService.deleteAssignedPlace(tripId, day, placeId);
         return ResponseEntity.ok(SuccessResponse.ok());

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
@@ -54,11 +54,11 @@ public class TripPlaceEditingController implements TripPlaceEditingApi {
 
     @Override
     @DeleteMapping("/{tripId}/days/{day}/places/{placeId}")
-    public ResponseEntity<?> deletePlace(@PathVariable Long tripId,
+    public ResponseEntity<?> deleteAssignedPlace(@PathVariable Long tripId,
                                          @PathVariable int day,
                                          @PathVariable String placeId) {
 
-        tripPlaceEditingService.deletePlace(tripId, day, placeId);
+        tripPlaceEditingService.deleteAssignedPlace(tripId, day, placeId);
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
@@ -24,6 +24,7 @@ import java.util.List;
 public class TripPlaceEditingController implements TripPlaceEditingApi {
     private final TripPlaceEditingService tripPlaceEditingService;
 
+    @Override
     @PostMapping("/{tripId}/temp-places")
     public ResponseEntity<?> addTempPlace(@PathVariable Long tripId,
                                           @RequestBody TripPlaceReq.Request request) {
@@ -31,6 +32,7 @@ public class TripPlaceEditingController implements TripPlaceEditingApi {
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
     }
 
+    @Override
     @GetMapping("/{tripId}/temp-places")
     public ResponseEntity<?> getTempPlaces(@PathVariable Long tripId) {
         return ResponseEntity.ok(
@@ -38,6 +40,7 @@ public class TripPlaceEditingController implements TripPlaceEditingApi {
         );
     }
 
+    @Override
     @DeleteMapping("/{tripId}/temp-places/{placeId}")
     public ResponseEntity<?> deleteTempPlace(@PathVariable Long tripId,
                                              @PathVariable String placeId) {

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
@@ -26,19 +26,19 @@ public class TripPlaceEditingController implements TripPlaceEditingApi {
 
     @Override
     @PostMapping("/{tripId}/days/{day}/places")
-    public ResponseEntity<?> addPlace(@PathVariable Long tripId,
+    public ResponseEntity<?> assignPlaceToDay(@PathVariable Long tripId,
                                       @PathVariable int day,
                                       @RequestBody TripPlaceReq.Request request) {
 
-        tripPlaceEditingService.addPlace(tripId, day, request);
+        tripPlaceEditingService.assignPlaceToDay(tripId, day, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
     }
 
     @Override
     @GetMapping("/{tripId}/days/{day}/places")
-    public ResponseEntity<?> getPlaces(@PathVariable Long tripId, @PathVariable int day) {
+    public ResponseEntity<?> getAssignedPlaces(@PathVariable Long tripId, @PathVariable int day) {
         return ResponseEntity.ok(
-                SuccessResponse.from(tripPlaceEditingService.getPlaces(tripId, day))
+                SuccessResponse.from(tripPlaceEditingService.getAssignedPlaces(tripId, day))
         );
     }
 

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
@@ -24,6 +24,27 @@ import java.util.List;
 public class TripPlaceEditingController implements TripPlaceEditingApi {
     private final TripPlaceEditingService tripPlaceEditingService;
 
+    @PostMapping("/{tripId}/temp-places")
+    public ResponseEntity<?> addTempPlace(@PathVariable Long tripId,
+                                          @RequestBody TripPlaceReq.Request request) {
+        tripPlaceEditingService.addTempPlace(tripId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
+    }
+
+    @GetMapping("/{tripId}/temp-places")
+    public ResponseEntity<?> getTempPlaces(@PathVariable Long tripId) {
+        return ResponseEntity.ok(
+                SuccessResponse.from(tripPlaceEditingService.getTempPlaces(tripId))
+        );
+    }
+
+    @DeleteMapping("/{tripId}/temp-places/{placeId}")
+    public ResponseEntity<?> deleteTempPlace(@PathVariable Long tripId,
+                                             @PathVariable String placeId) {
+        tripPlaceEditingService.deleteTempPlace(tripId, placeId);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+
     @Override
     @PostMapping("/{tripId}/days/{day}/places/{placeId}")
     public ResponseEntity<?> assignPlaceToDay(@PathVariable Long tripId,

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingServiceTest.java
@@ -14,12 +14,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -41,40 +43,66 @@ public class TripPlaceEditingServiceTest {
 
     @Nested
     @DisplayName("목적지 추가 테스트")
-    class AddPlaceTest {
+    class AssignPlaceToDayTest {
 
-        private final TripPlaceReq.Request place = TripPlaceReq.Request.builder()
-                .name("목적지1")
-                .latitude(0.0)
-                .longitude(0.0)
-                .placeType("카페")
-                .build();
+        private final String placeId = "place-id";
 
         @Test
         @DisplayName("성공")
         void addPlaceInEditingSuccess() {
             // given
-            String setKey = PlaceConstant.setKey(tripId, day);
-            given(redisRepository.existsInSet(eq(setKey), anyString())).willReturn(false);
+            String tempListKey = PlaceConstant.tempListKey(tripId);
+            List<TripPlaceReq.StoredFormat> mockPlaces = List.of(
+                    new TripPlaceReq.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.CAFE.getGroupName())
+            );
+            given(redisRepository.getList(eq(tempListKey), eq(TripPlaceReq.StoredFormat.class)))
+                    .willReturn(mockPlaces);
+
+            String dayPlaceSetKey = PlaceConstant.dayPlaceSetKey(tripId, day);
+            given(redisRepository.existsInSet(eq(dayPlaceSetKey), anyString())).willReturn(false);
 
             // when
-            tripPlaceEditingService.assignPlaceToDay(tripId, day, place);
+            tripPlaceEditingService.assignPlaceToDay(tripId, day, placeId);
 
             // then
             verify(redisRepository, times(1)).setList(anyString(), any(TripPlaceReq.StoredFormat.class));
-            verify(redisRepository, times(1)).addToSet(eq(setKey), anyString());
+            verify(redisRepository, times(1)).addToSet(eq(dayPlaceSetKey), anyString());
+        }
+
+        @Test
+        @DisplayName("실패 - 담겨져 있지 않은 목적지")
+        void addPlaceInEditingFailNotFoundPlace() {
+            String tempListKey = PlaceConstant.tempListKey(tripId);
+            given(redisRepository.getList(eq(tempListKey), eq(TripPlaceReq.StoredFormat.class)))
+                    .willReturn(Collections.emptyList());
+
+
+            // when
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    tripPlaceEditingService.assignPlaceToDay(tripId, day, placeId)
+            );
+
+            // then
+            assertEquals(TripErrorType.NOT_FOUND_TEMP_PLACE, exception.getErrorType());
         }
 
         @Test
         @DisplayName("실패 - 중복")
         void addPlaceInEditingFailAlreadyAdded() {
             // given
-            String setKey = PlaceConstant.setKey(tripId, day);
-            given(redisRepository.existsInSet(eq(setKey), anyString())).willReturn(true);
+            String tempListKey = PlaceConstant.tempListKey(tripId);
+            List<TripPlaceReq.StoredFormat> mockPlaces = List.of(
+                    new TripPlaceReq.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.CAFE.getGroupName())
+            );
+            given(redisRepository.getList(eq(tempListKey), eq(TripPlaceReq.StoredFormat.class)))
+                    .willReturn(mockPlaces);
+
+            String dayPlaceSetKey = PlaceConstant.dayPlaceSetKey(tripId, day);
+            given(redisRepository.existsInSet(eq(dayPlaceSetKey), anyString())).willReturn(true);
 
             // when
             CustomException exception = assertThrows(CustomException.class, () ->
-                    tripPlaceEditingService.assignPlaceToDay(tripId, day, place)
+                    tripPlaceEditingService.assignPlaceToDay(tripId, day, placeId)
             );
 
             // then

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingServiceTest.java
@@ -58,7 +58,7 @@ public class TripPlaceEditingServiceTest {
             given(redisRepository.existsInSet(eq(setKey), anyString())).willReturn(false);
 
             // when
-            tripPlaceEditingService.addPlace(tripId, day, place);
+            tripPlaceEditingService.assignPlaceToDay(tripId, day, place);
 
             // then
             verify(redisRepository, times(1)).setList(anyString(), any(TripPlaceReq.StoredFormat.class));
@@ -74,7 +74,7 @@ public class TripPlaceEditingServiceTest {
 
             // when
             CustomException exception = assertThrows(CustomException.class, () ->
-                    tripPlaceEditingService.addPlace(tripId, day, place)
+                    tripPlaceEditingService.assignPlaceToDay(tripId, day, place)
             );
 
             // then
@@ -163,7 +163,7 @@ public class TripPlaceEditingServiceTest {
         given(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class))).willReturn(mockPlaces);
 
         // when
-        List<TripPlaceReq.StoredFormat> result = tripPlaceEditingService.getPlaces(tripId, day);
+        List<TripPlaceReq.StoredFormat> result = tripPlaceEditingService.getAssignedPlaces(tripId, day);
 
         // then
         assertEquals(1, result.size());

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingServiceTest.java
@@ -100,7 +100,7 @@ public class TripPlaceEditingServiceTest {
                     .willReturn(List.of(place));
 
             // when
-            tripPlaceEditingService.deletePlace(tripId, day, placeId);
+            tripPlaceEditingService.deleteAssignedPlace(tripId, day, placeId);
 
             // then
             verify(redisRepository, times(1)).removeFromList(anyString(), eq(place));
@@ -115,7 +115,7 @@ public class TripPlaceEditingServiceTest {
                     .willReturn(List.of());
 
             // when
-            assertDoesNotThrow(() -> tripPlaceEditingService.deletePlace(tripId, day, placeId));
+            assertDoesNotThrow(() -> tripPlaceEditingService.deleteAssignedPlace(tripId, day, placeId));
 
             // then
             verify(redisRepository, never()).removeFromList(anyString(), any());

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceEditingServiceTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -42,7 +41,87 @@ public class TripPlaceEditingServiceTest {
     private final int day = 1;
 
     @Nested
-    @DisplayName("목적지 추가 테스트")
+    @DisplayName("임시 저장소 목적지 테스트")
+    class TempPlaceTest {
+
+        private final String placeId = "place-id";
+
+        @Test
+        @DisplayName("임시 저장소에 목적지 추가 성공")
+        void addTempPlaceSuccess() {
+            // given
+            TripPlaceReq.Request request = TripPlaceReq.Request.builder()
+                    .name("목적지1")
+                    .latitude(0.0)
+                    .longitude(0.0)
+                    .placeType("카페")
+                    .build();
+
+            // when
+            tripPlaceEditingService.addTempPlace(tripId, request);
+
+            // then
+            verify(redisRepository, times(1)).setList(anyString(), any());
+        }
+
+        @Test
+        @DisplayName("임시 저장소 목적지 목록 조회 성공")
+        void getTempPlacesSuccess() {
+            // given
+            TripPlaceReq.StoredFormat storedPlace = new TripPlaceReq.StoredFormat(
+                    placeId, "목적지1", 0.0, 0.0, "식당"
+            );
+
+            String tempListKey = PlaceConstant.tempListKey(tripId);
+            given(redisRepository.getList(eq(tempListKey), eq(TripPlaceReq.StoredFormat.class)))
+                    .willReturn(List.of(storedPlace));
+
+            // when
+            List<TripPlaceReq.StoredFormat> result = tripPlaceEditingService.getTempPlaces(tripId);
+
+            // then
+            assertEquals(1, result.size());
+            assertEquals("목적지1", result.get(0).name());
+            assertEquals("식당", result.get(0).placeCategory());
+        }
+
+        @Test
+        @DisplayName("임시 저장소에서 목적지 삭제 성공")
+        void deleteTempPlaceSuccess() {
+            // given
+            TripPlaceReq.StoredFormat storedPlace = new TripPlaceReq.StoredFormat(
+                    placeId, "목적지1", 0.0, 0.0, "식당"
+            );
+
+            String tempListKey = PlaceConstant.tempListKey(tripId);
+            given(redisRepository.getList(eq(tempListKey), eq(TripPlaceReq.StoredFormat.class)))
+                    .willReturn(List.of(storedPlace));
+
+            // when
+            tripPlaceEditingService.deleteTempPlace(tripId, placeId);
+
+            // then
+            verify(redisRepository).removeFromList(eq(tempListKey), eq(storedPlace));
+        }
+
+        @Test
+        @DisplayName("임시 저장소에서 목적지 삭제 실패 - 존재하지 않음")
+        void deleteTempPlaceNotFound() {
+            // given
+            String key = PlaceConstant.tempListKey(tripId);
+            given(redisRepository.getList(eq(key), eq(TripPlaceReq.StoredFormat.class)))
+                    .willReturn(List.of());
+
+            // when
+            assertDoesNotThrow(() -> tripPlaceEditingService.deleteTempPlace(tripId, placeId));
+
+            // then
+            verify(redisRepository, never()).removeFromList(anyString(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("일정에 목적지 담기 테스트")
     class AssignPlaceToDayTest {
 
         private final String placeId = "place-id";

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceSavingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceSavingServiceTest.java
@@ -56,9 +56,9 @@ public class TripPlaceSavingServiceTest {
         // then
         verify(redisRepository, times(2)).getList(anyString(), eq(TripPlaceReq.StoredFormat.class));
         verify(tripDayPlaceService, times(1)).saveAll(any());
-        verify(redisRepository, times(1)).del(PlaceConstant.listKey(tripId, 1));
-        verify(redisRepository, times(1)).del(PlaceConstant.setKey(tripId, 1));
-        verify(redisRepository, times(1)).del(PlaceConstant.listKey(tripId, 2));
-        verify(redisRepository, times(1)).del(PlaceConstant.setKey(tripId, 2));
+        verify(redisRepository, times(1)).del(PlaceConstant.dayPlacesKey(tripId, 1));
+        verify(redisRepository, times(1)).del(PlaceConstant.dayPlaceSetKey(tripId, 1));
+        verify(redisRepository, times(1)).del(PlaceConstant.dayPlacesKey(tripId, 2));
+        verify(redisRepository, times(1)).del(PlaceConstant.dayPlaceSetKey(tripId, 2));
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingControllerTest.java
@@ -68,6 +68,78 @@ public class TripPlaceEditingControllerTest {
     }
 
     @Nested
+    @DisplayName("임시 저장소 목적지 테스트")
+    class TempPlaceTest {
+
+        private final TripPlaceReq.Request request = TripPlaceReq.Request.builder()
+                .name("목적지1")
+                .latitude(0.0)
+                .longitude(0.0)
+                .placeType("카페")
+                .build();
+
+        private final String placeId = "place-id";
+
+        @Test
+        @DisplayName("추가 성공")
+        void addTempPlaceSuccess() throws Exception {
+            // given
+            doNothing().when(tripPlaceEditingService).addTempPlace(anyLong(), any());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/trip/{tripId}/temp-places", tripId)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            // then
+            resultActions.andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
+        }
+
+        @Test
+        @DisplayName("조회 성공")
+        void getTempPlacesSuccess() throws Exception {
+            // given
+
+            List<TripPlaceReq.StoredFormat> tempPlaces = List.of(
+                    new TripPlaceReq.StoredFormat(placeId, "목적지1", 0.0, 0.0, "식당")
+            );
+            given(tripPlaceEditingService.getTempPlaces(tripId)).willReturn(tempPlaces);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip/{tripId}/temp-places", tripId)
+            );
+
+            // then
+            resultActions.andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data[0].name").value("목적지1"))
+                    .andExpect(jsonPath("$.data[0].placeCategory").value("식당"));
+        }
+
+        @Test
+        @DisplayName("삭제 성공")
+        void deleteTempPlaceSuccess() throws Exception {
+            // given
+            doNothing().when(tripPlaceEditingService).deleteTempPlace(anyLong(), any());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    delete("/api/v1/trip/{tripId}/temp-places/{placeId}", tripId, placeId)
+            );
+
+            // then
+            resultActions.andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
+        }
+    }
+
+    @Nested
     @DisplayName("목적지 추가 테스트")
     class AssignPlaceToDayTest {
 

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingControllerTest.java
@@ -82,7 +82,7 @@ public class TripPlaceEditingControllerTest {
         @DisplayName("성공")
         void addPlaceSuccess() throws Exception {
             // given
-            doNothing().when(tripPlaceEditingService).addPlace(anyLong(), anyInt(), any());
+            doNothing().when(tripPlaceEditingService).assignPlaceToDay(anyLong(), anyInt(), any());
 
             // when
             ResultActions resultActions = mockMvc.perform(
@@ -103,7 +103,7 @@ public class TripPlaceEditingControllerTest {
         void addPlaceFailAlreadyAdded() throws Exception {
             // given
             doThrow(new CustomException(TripErrorType.ALREADY_ADDED_PLACE))
-                    .when(tripPlaceEditingService).addPlace(anyLong(), anyInt(), any());
+                    .when(tripPlaceEditingService).assignPlaceToDay(anyLong(), anyInt(), any());
 
             // when
             ResultActions resultActions = mockMvc.perform(
@@ -171,7 +171,7 @@ public class TripPlaceEditingControllerTest {
         List<TripPlaceReq.StoredFormat> mockPlaces = List.of(
                 new TripPlaceReq.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.CAFE.getGroupName())
         );
-        given(tripPlaceEditingService.getPlaces(tripId, day)).willReturn(mockPlaces);
+        given(tripPlaceEditingService.getAssignedPlaces(tripId, day)).willReturn(mockPlaces);
 
         // when
         ResultActions resultActions = mockMvc.perform(

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingControllerTest.java
@@ -69,7 +69,7 @@ public class TripPlaceEditingControllerTest {
 
     @Nested
     @DisplayName("목적지 추가 테스트")
-    class AddPlaceTest {
+    class AssignPlaceToDayTest {
 
         private final TripPlaceReq.Request request = TripPlaceReq.Request.builder()
                 .name("목적지1")
@@ -77,6 +77,8 @@ public class TripPlaceEditingControllerTest {
                 .longitude(0.0)
                 .placeType("카페")
                 .build();
+
+        private final String placeId = "place-id";
 
         @Test
         @DisplayName("성공")
@@ -86,7 +88,7 @@ public class TripPlaceEditingControllerTest {
 
             // when
             ResultActions resultActions = mockMvc.perform(
-                    post("/api/v1/trip/{tripId}/days/{day}/places", tripId, day)
+                    post("/api/v1/trip/{tripId}/days/{day}/places/{placeId}", tripId, day, placeId)
                             .contentType(APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request))
             );
@@ -107,7 +109,7 @@ public class TripPlaceEditingControllerTest {
 
             // when
             ResultActions resultActions = mockMvc.perform(
-                    post("/api/v1/trip/{tripId}/days/{day}/places", tripId, day)
+                    post("/api/v1/trip/{tripId}/days/{day}/places/{placeId}", tripId, day, placeId)
                             .contentType(APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request))
             );
@@ -166,7 +168,7 @@ public class TripPlaceEditingControllerTest {
 
     @Test
     @DisplayName("목적지 조회 성공")
-    void getPlacesSuccess() throws Exception {
+    void getAssignedPlacesSuccess() throws Exception {
         // given
         List<TripPlaceReq.StoredFormat> mockPlaces = List.of(
                 new TripPlaceReq.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.CAFE.getGroupName())

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingControllerTest.java
@@ -150,7 +150,7 @@ public class TripPlaceEditingControllerTest {
     @DisplayName("목적지 삭제 성공")
     void deletePlaceSuccess() throws Exception {
         // given
-        doNothing().when(tripPlaceEditingService).deletePlace(anyLong(), anyInt(), Mockito.anyString());
+        doNothing().when(tripPlaceEditingService).deleteAssignedPlace(anyLong(), anyInt(), Mockito.anyString());
 
         // when
         ResultActions resultActions = mockMvc.perform(


### PR DESCRIPTION
## 배경
일정에 담기 전, 임시 목적지 담기 로직이 필요

## 작업 사항
- 기존 여행 일정 목적지 메서드명 변경 (2fd10181492d8e6177b67882615b712169c16403)
- 임시 목적지 로직 구현 (d993db03c47155329bcb2a4b3148aa4c9458f009)
    - 임시 목적지 담기 로직으로 인해, 일자별 목적지 이동하는 로직 변경 (5a8695f4a28a16c99ecd273e508c0492d6554f03)
        - 임시 목적지를 담았던 redis 값으로부터 조회 -> 일정으로 이동 (그리고 임시 목적지의 값은 삭제)

## 기타
- 비즈니스 로직에 대한 변경이 생기다 보니 기존 로직에서도 변화가 생겼습니다. 복잡할수도 있지만, 잘못된 부분이 보인다면 말씀해주세요!