### PR TITLE
Feature(IL-54): 업로드 이미지 임시 저장소 저장 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+**/.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,10 @@ dependencies {
 
     /* Redis */
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    /* JAXB */
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+    implementation 'com.sun.xml.bind:jaxb-impl:2.3.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/co/yeogiga/application/image/dto/ImageUploadRequest.java
+++ b/src/main/java/kr/co/yeogiga/application/image/dto/ImageUploadRequest.java
@@ -10,13 +10,13 @@ public record ImageUploadRequest(
         String contentType,
         long size,
         Long tripId,
-        String placeId
+        String tripDayPlaceId
 ) {
-    public static ImageUploadRequest from(MultipartFile file, Long tripId, String placeId) throws IOException {
+    public static ImageUploadRequest from(MultipartFile file, Long tripId, String tripDayPlaceId) throws IOException {
         return new ImageUploadRequest(
                 file.getBytes(), file.getOriginalFilename(),
                 file.getContentType(), file.getSize(),
-                tripId, placeId
+                tripId, tripDayPlaceId
         );
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/image/dto/ImageUploadRequest.java
+++ b/src/main/java/kr/co/yeogiga/application/image/dto/ImageUploadRequest.java
@@ -9,9 +9,14 @@ public record ImageUploadRequest(
         String originalFilename,
         String contentType,
         long size,
-        Long tripId
+        Long tripId,
+        String placeId
 ) {
-    public static ImageUploadRequest from(MultipartFile file, Long tripId) throws IOException {
-        return new ImageUploadRequest(file.getBytes(), file.getOriginalFilename(), file.getContentType(), file.getSize(), tripId);
+    public static ImageUploadRequest from(MultipartFile file, Long tripId, String placeId) throws IOException {
+        return new ImageUploadRequest(
+                file.getBytes(), file.getOriginalFilename(),
+                file.getContentType(), file.getSize(),
+                tripId, placeId
+        );
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/image/service/ImageProcessingService.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/ImageProcessingService.java
@@ -43,7 +43,7 @@ public class ImageProcessingService {
                     .date(metadata.date())
                     .build();
 
-            tempPlaceImagesCommandService.addImageToPlace(imageUploadRequest.placeId(), image);
+            tempPlaceImagesCommandService.addImageToPlace(imageUploadRequest.tripDayPlaceId(), image);
 
         } catch (Exception e) {
             log.error("Error processing image - filename: {}", imageUploadRequest.originalFilename(), e);

--- a/src/main/java/kr/co/yeogiga/application/image/service/ImageProcessingService.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/ImageProcessingService.java
@@ -2,6 +2,7 @@ package kr.co.yeogiga.application.image.service;
 
 import kr.co.yeogiga.application.image.dto.ImageMetadataDto;
 import kr.co.yeogiga.application.image.dto.ImageUploadRequest;
+import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.infrastructure.s3.AwsS3Storage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,11 +17,13 @@ import java.util.List;
 public class ImageProcessingService {
     private final ImageMetadataService imageMetadataService;
     private final AwsS3Storage awsS3Storage;
+    private final TempPlaceImagesCommandService tempPlaceImagesCommandService;
 
     /**
      * 이미지 업로드 및 메타데이터 추출을 비동기로 처리하는 메서드.
      * - 입력 받은 이미지 정보를 기반으로 메타데이터를 추출
      * - 이미지를 S3에 업로드
+     * - 업로드된 이미지 이미지 임시 저장소에 저장
      *
      * @param imageUploadRequest 업로드할 이미지 및 관련 정보가 담긴 DTO
      */
@@ -33,9 +36,14 @@ public class ImageProcessingService {
 
             String url = awsS3Storage.upload(imageUploadRequest);
 
-            log.info("Processed image - tripId: {}, filename: {}", imageUploadRequest.tripId(), imageUploadRequest.originalFilename());
-            log.info("Metadata - latitude: {}, longitude: {}, date: {}", metadata.latitude(), metadata.longitude(), metadata.date());
-            log.info("Uploaded URL - {}", url);
+            Image image = Image.builder()
+                    .url(url)
+                    .latitude(metadata.latitude())
+                    .longitude(metadata.longitude())
+                    .date(metadata.date())
+                    .build();
+
+            tempPlaceImagesCommandService.addImageToPlace(imageUploadRequest.placeId(), image);
 
         } catch (Exception e) {
             log.error("Error processing image - filename: {}", imageUploadRequest.originalFilename(), e);

--- a/src/main/java/kr/co/yeogiga/application/image/service/ImageUploadProcessor.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/ImageUploadProcessor.java
@@ -19,13 +19,14 @@ public class ImageUploadProcessor {
      * MultipartFile 이미지 리스트를 받아 각각 비동기 업로드 및 메타데이터 추출을 요청메서드
      * 스프링에서 MultipartFile의 경우 요청 범위 내에서만 유효하기 비동기 처리를 위해서 데이터 추출
      *
-     * @param images : 업로드 대상 이미지 리스트
-     * @param tripId : 이미지가 속한 여행 ID
+     * @param images  : 업로드 대상 이미지 리스트
+     * @param tripId  : 이미지가 속한 여행 ID
+     * @param placeId : 이미지가 속할 목적지 ID
      */
-    public void process(List<MultipartFile> images, Long tripId) {
+    public void process(List<MultipartFile> images, Long tripId, String placeId) {
         for (MultipartFile image : images) {
             try {
-                ImageUploadRequest imageUploadRequest = ImageUploadRequest.from(image, tripId);
+                ImageUploadRequest imageUploadRequest = ImageUploadRequest.from(image, tripId, placeId);
                 imageProcessingService.processImageUpload(imageUploadRequest);
             } catch (IOException e) {
                 log.error("Failed to process image - filename: {}", image.getOriginalFilename(), e);

--- a/src/main/java/kr/co/yeogiga/application/image/service/ImageUploadProcessor.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/ImageUploadProcessor.java
@@ -19,14 +19,14 @@ public class ImageUploadProcessor {
      * MultipartFile 이미지 리스트를 받아 각각 비동기 업로드 및 메타데이터 추출을 요청메서드
      * 스프링에서 MultipartFile의 경우 요청 범위 내에서만 유효하기 비동기 처리를 위해서 데이터 추출
      *
-     * @param images  : 업로드 대상 이미지 리스트
-     * @param tripId  : 이미지가 속한 여행 ID
-     * @param placeId : 이미지가 속할 목적지 ID
+     * @param images         : 업로드 대상 이미지 리스트
+     * @param tripId         : 이미지가 속한 여행 ID
+     * @param tripDayPlaceId : 이미지가 속할 여행 일차 ID
      */
-    public void process(List<MultipartFile> images, Long tripId, String placeId) {
+    public void process(List<MultipartFile> images, Long tripId, String tripDayPlaceId) {
         for (MultipartFile image : images) {
             try {
-                ImageUploadRequest imageUploadRequest = ImageUploadRequest.from(image, tripId, placeId);
+                ImageUploadRequest imageUploadRequest = ImageUploadRequest.from(image, tripId, tripDayPlaceId);
                 imageProcessingService.processImageUpload(imageUploadRequest);
             } catch (IOException e) {
                 log.error("Failed to process image - filename: {}", image.getOriginalFilename(), e);

--- a/src/main/java/kr/co/yeogiga/application/image/service/TempPlaceImagesCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/TempPlaceImagesCommandService.java
@@ -1,0 +1,22 @@
+package kr.co.yeogiga.application.image.service;
+
+import kr.co.yeogiga.domain.tripplace.entity.Image;
+import kr.co.yeogiga.domain.tripplace.service.TempPlaceImagesService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TempPlaceImagesCommandService {
+    private final TempPlaceImagesService tempPlaceImagesService;
+
+    /**
+     * 지정된 placeId를 가진 TempPlaceImages 문서에 이미지를 추가하는 메서드
+     *
+     * @param placeId 추가할 이미지가 속할 목적지 ID
+     * @param image   MongoDB에 저장할 이미지 객체
+     */
+    public void addImageToPlace(String placeId, Image image) {
+        tempPlaceImagesService.saveImage(placeId, image);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/image/service/TempPlaceImagesCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/TempPlaceImagesCommandService.java
@@ -13,10 +13,10 @@ public class TempPlaceImagesCommandService {
     /**
      * 지정된 placeId를 가진 TempPlaceImages 문서에 이미지를 추가하는 메서드
      *
-     * @param placeId 추가할 이미지가 속할 목적지 ID
-     * @param image   MongoDB에 저장할 이미지 객체
+     * @param tripDayPlaceId 추가할 이미지가 속할 여행일차 ID
+     * @param image          MongoDB에 저장할 이미지 객체
      */
-    public void addImageToPlace(String placeId, Image image) {
-        tempPlaceImagesService.saveImage(placeId, image);
+    public void addImageToPlace(String tripDayPlaceId, Image image) {
+        tempPlaceImagesService.saveImage(tripDayPlaceId, image);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/TempPlaceImages.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/TempPlaceImages.java
@@ -16,12 +16,12 @@ import java.util.List;
 public class TempPlaceImages {
     @Id
     private String id;
-    private String placeId;
+    private String tripDayPlaceId;
     private List<Image> images;
 
     @Builder
-    public TempPlaceImages(String placeId) {
-        this.placeId = placeId;
+    public TempPlaceImages(String tripDayPlaceId) {
+        this.tripDayPlaceId = tripDayPlaceId;
         this.images = new ArrayList<>();
     }
 

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/TempPlaceImages.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/TempPlaceImages.java
@@ -1,0 +1,31 @@
+package kr.co.yeogiga.domain.tripplace.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collection = "temp_place_images")
+public class TempPlaceImages {
+    @Id
+    private String id;
+    private String placeId;
+    private List<Image> images;
+
+    @Builder
+    public TempPlaceImages(String placeId) {
+        this.placeId = placeId;
+        this.images = new ArrayList<>();
+    }
+
+    public void addImage(Image image) {
+        this.images.add(image);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTempPlaceImagesRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTempPlaceImagesRepository.java
@@ -3,5 +3,5 @@ package kr.co.yeogiga.domain.tripplace.repository;
 import kr.co.yeogiga.domain.tripplace.entity.Image;
 
 public interface CustomTempPlaceImagesRepository {
-    void saveImage(String placeId, Image image);
+    void saveImage(String tripDayPlaceId, Image image);
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTempPlaceImagesRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTempPlaceImagesRepository.java
@@ -1,0 +1,7 @@
+package kr.co.yeogiga.domain.tripplace.repository;
+
+import kr.co.yeogiga.domain.tripplace.entity.Image;
+
+public interface CustomTempPlaceImagesRepository {
+    void saveImage(String placeId, Image image);
+}

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTempPlaceImagesRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTempPlaceImagesRepositoryImpl.java
@@ -17,12 +17,12 @@ public class CustomTempPlaceImagesRepositoryImpl implements CustomTempPlaceImage
      * - 문서가 존재하지 않으면 새로 생성함 (upsert)
      * - 기존 문서가 존재하면 images 필드에 새 이미지 객체를 push
      *
-     * @param placeId 이미지를 추가할 목적지 식별자
-     * @param image   추가할 이미지 객체
+     * @param tripDayPlaceId 이미지를 추가할 여행일차 식별자
+     * @param image          추가할 이미지 객체
      */
     @Override
-    public void saveImage(String placeId, Image image) {
-        Query query = new Query(Criteria.where("placeId").is(placeId));
+    public void saveImage(String tripDayPlaceId, Image image) {
+        Query query = new Query(Criteria.where("tripDayPlaceId").is(tripDayPlaceId));
         Update update = new Update().push("images", image);
 
         mongoTemplate.upsert(query, update, TempPlaceImages.class);

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTempPlaceImagesRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTempPlaceImagesRepositoryImpl.java
@@ -1,0 +1,30 @@
+package kr.co.yeogiga.domain.tripplace.repository;
+
+import kr.co.yeogiga.domain.tripplace.entity.Image;
+import kr.co.yeogiga.domain.tripplace.entity.TempPlaceImages;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+@RequiredArgsConstructor
+public class CustomTempPlaceImagesRepositoryImpl implements CustomTempPlaceImagesRepository {
+    private final MongoTemplate mongoTemplate;
+
+    /**
+     * 주어진 placeId에 해당하는 TempPlaceImages 문서에 이미지를 추가하는 쿼리
+     * - 문서가 존재하지 않으면 새로 생성함 (upsert)
+     * - 기존 문서가 존재하면 images 필드에 새 이미지 객체를 push
+     *
+     * @param placeId 이미지를 추가할 목적지 식별자
+     * @param image   추가할 이미지 객체
+     */
+    @Override
+    public void saveImage(String placeId, Image image) {
+        Query query = new Query(Criteria.where("placeId").is(placeId));
+        Update update = new Update().push("images", image);
+
+        mongoTemplate.upsert(query, update, TempPlaceImages.class);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/TempPlaceImagesRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/TempPlaceImagesRepository.java
@@ -1,0 +1,7 @@
+package kr.co.yeogiga.domain.tripplace.repository;
+
+import kr.co.yeogiga.domain.tripplace.entity.TempPlaceImages;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface TempPlaceImagesRepository extends MongoRepository<TempPlaceImages, String>, CustomTempPlaceImagesRepository {
+}

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/service/TempPlaceImagesService.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/service/TempPlaceImagesService.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 public class TempPlaceImagesService {
     private final TempPlaceImagesRepository tempPlaceImagesRepository;
 
-    public void saveImage(String placeId, Image image) {
-        tempPlaceImagesRepository.saveImage(placeId, image);
+    public void saveImage(String tripDayPlaceId, Image image) {
+        tempPlaceImagesRepository.saveImage(tripDayPlaceId, image);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/service/TempPlaceImagesService.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/service/TempPlaceImagesService.java
@@ -1,0 +1,16 @@
+package kr.co.yeogiga.domain.tripplace.service;
+
+import kr.co.yeogiga.domain.tripplace.entity.Image;
+import kr.co.yeogiga.domain.tripplace.repository.TempPlaceImagesRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TempPlaceImagesService {
+    private final TempPlaceImagesRepository tempPlaceImagesRepository;
+
+    public void saveImage(String placeId, Image image) {
+        tempPlaceImagesRepository.saveImage(placeId, image);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/image/api/ImageApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/image/api/ImageApi.java
@@ -36,7 +36,7 @@ public interface ImageApi {
     })
     ResponseEntity<?> uploadImages(@RequestPart(value = "images", required = false) List<MultipartFile> images,
                                    @PathVariable Long tripId,
-                                   @PathVariable String placeId);
+                                   @PathVariable String tripDayPlaceId);
 
     @TrackApi(description = "이미지 삭제")
     @Operation(summary = "이미지 삭제", description = "이미지 삭제하는 API입니다.")

--- a/src/main/java/kr/co/yeogiga/presentation/image/api/ImageApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/image/api/ImageApi.java
@@ -35,7 +35,8 @@ public interface ImageApi {
                     }))
     })
     ResponseEntity<?> uploadImages(@RequestPart(value = "images", required = false) List<MultipartFile> images,
-                                   @PathVariable Long tripId);
+                                   @PathVariable Long tripId,
+                                   @PathVariable String placeId);
 
     @TrackApi(description = "이미지 삭제")
     @Operation(summary = "이미지 삭제", description = "이미지 삭제하는 API입니다.")

--- a/src/main/java/kr/co/yeogiga/presentation/image/controller/ImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/image/controller/ImageController.java
@@ -27,11 +27,11 @@ public class ImageController implements ImageApi {
     private final ImageDeleteProcessor imageDeleteProcessor;
 
     @Override
-    @PostMapping("/{tripId}/images/{placeId}")
+    @PostMapping("/{tripId}/images/{tripDayPlaceId}")
     public ResponseEntity<?> uploadImages(@RequestPart(value = "images", required = false) List<MultipartFile> images,
                                           @PathVariable Long tripId,
-                                          @PathVariable String placeId) {
-        imageUploadProcessor.process(images, tripId, placeId);
+                                          @PathVariable String tripDayPlaceId) {
+        imageUploadProcessor.process(images, tripId, tripDayPlaceId);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
     }
 

--- a/src/main/java/kr/co/yeogiga/presentation/image/controller/ImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/image/controller/ImageController.java
@@ -27,10 +27,11 @@ public class ImageController implements ImageApi {
     private final ImageDeleteProcessor imageDeleteProcessor;
 
     @Override
-    @PostMapping("/{tripId}/images")
+    @PostMapping("/{tripId}/images/{placeId}")
     public ResponseEntity<?> uploadImages(@RequestPart(value = "images", required = false) List<MultipartFile> images,
-                                          @PathVariable Long tripId) {
-        imageUploadProcessor.process(images, tripId);
+                                          @PathVariable Long tripId,
+                                          @PathVariable String placeId) {
+        imageUploadProcessor.process(images, tripId, placeId);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
     }
 

--- a/src/test/java/kr/co/yeogiga/presentation/image/controller/ImageControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/image/controller/ImageControllerTest.java
@@ -50,7 +50,7 @@ public class ImageControllerTest {
     private ImageDeleteProcessor imageDeleteProcessor;
 
     private final Long tripId = 1L;
-    private final String placeId = "place-id";
+    private final String tripDayPlaceId = "trip-day-place-id";
 
     @BeforeEach
     void setUp(WebApplicationContext webApplicationContext) {
@@ -72,7 +72,7 @@ public class ImageControllerTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                multipart("/api/v1/trip/{tripId}/images/{placeId}", tripId, placeId)
+                multipart("/api/v1/trip/{tripId}/images/{tripDayPlaceId}", tripId, tripDayPlaceId)
                         .file(mockImage)
                         .with(request -> {
                             request.setMethod("POST");

--- a/src/test/java/kr/co/yeogiga/presentation/image/controller/ImageControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/image/controller/ImageControllerTest.java
@@ -50,6 +50,7 @@ public class ImageControllerTest {
     private ImageDeleteProcessor imageDeleteProcessor;
 
     private final Long tripId = 1L;
+    private final String placeId = "place-id";
 
     @BeforeEach
     void setUp(WebApplicationContext webApplicationContext) {
@@ -71,7 +72,7 @@ public class ImageControllerTest {
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                multipart("/api/v1/trip/{tripId}/images", tripId)
+                multipart("/api/v1/trip/{tripId}/images/{placeId}", tripId, placeId)
                         .file(mockImage)
                         .with(request -> {
                             request.setMethod("POST");


### PR DESCRIPTION
## 배경
이미지를 업로드한 후, '이미지 정렬'버튼을 눌러야 이미지들이 목적지로 매핑.
이미지를 임시로 저장할 공간이 필요.

## 작업 사항
- 이미지 임시 저장소 컬렉션 생성 (cb7d2334ac8aa64d5ffec7992047efb65a7c5d56)
- 이미지 임시 저장소 저장 로직 구현 (12488ef06ca839c4d85549d00a92b8a9b101a107)
    - `upsert`를 사용하여 `placeId`에 해당하는 데이터가 없으면 생성 후 저장.
    - 이미지 업로드는 비동기로 처리되기 때문에 MongoTemplate를 이용해 바로 push 하는 로직 구현
- 업로드된 이미지 임시 저장소 저장 로직 구현 (cf9eadaf74a192f29fd7d383b11090ea0814280d)

## 기타
1. 이미지 삭제 등과 같은 api는 `임시 저장된 이미지인지`, 정렬된 이미지 중 `기타 이미지인지`, `특정 목적지 이미지인지`에 대한 정보가 필요할 예정
2. 현재 구현되어 있는 위도/경도에 맞게 이미지를 목적지에 매핑하는 로직 변경 예정 (현재는 이미지를 push 후, save를 수행하지만, 현재 기능처럼 바로 push로 업데이트 할 예정)
3. Java 9 이상부터 JAXB가 JDK에서 빠지면서, AWS S3 업로드 중 아래와 같은 에러 문구 발생. fallback으로 동작을 한다는 것인데, AWS는 빠르고 최적화된 방식으로 수행을 할 수 있기에 JAXB 의존성 구현 (6acbe44e2627bd6dde9ecf060ed24ace7521103b)
   -  `JAXB is unavailable. Will fallback to SDK implementation which may be less performant.
If you are using Java 9+, you will need to include javax.xml.bind:jaxb-api as a dependency.`


## 테스트

| <img width="999" alt="스크린샷 2025-05-05 오후 5 17 04" src="https://github.com/user-attachments/assets/1a5429ee-5b28-4e11-8f38-18d80a516143" /> |
|---|
|임시 저장된 이미지 내역|