### PR TITLE
Feature(IL-53): 비밀번호 갱신

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/user/dto/PasswordUpdateReq.java
+++ b/src/main/java/kr/co/yeogiga/application/user/dto/PasswordUpdateReq.java
@@ -1,0 +1,9 @@
+package kr.co.yeogiga.application.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PasswordUpdateReq (
+        @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+        String password
+) {
+}

--- a/src/main/java/kr/co/yeogiga/application/user/dto/PasswordUpdateReq.java
+++ b/src/main/java/kr/co/yeogiga/application/user/dto/PasswordUpdateReq.java
@@ -1,8 +1,12 @@
 package kr.co.yeogiga.application.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(name = "PasswordUpdateReq", description = "비밀번호 갱신 요청 dto")
 public record PasswordUpdateReq (
+
+        @Schema(description = "비밀번호", example = "password")
         @NotBlank(message = "비밀번호는 필수 입력값입니다.")
         String password
 ) {

--- a/src/main/java/kr/co/yeogiga/application/user/dto/PasswordUpdateReq.java
+++ b/src/main/java/kr/co/yeogiga/application/user/dto/PasswordUpdateReq.java
@@ -6,8 +6,12 @@ import jakarta.validation.constraints.NotBlank;
 @Schema(name = "PasswordUpdateReq", description = "비밀번호 갱신 요청 dto")
 public record PasswordUpdateReq (
 
-        @Schema(description = "비밀번호", example = "password")
-        @NotBlank(message = "비밀번호는 필수 입력값입니다.")
-        String password
+        @Schema(description = "기존 비밀번호", example = "originalPassword")
+        @NotBlank(message = "기존 비밀번호는 필수 입력값입니다.")
+        String originalPassword,
+
+        @Schema(description = "새로운 비밀번호", example = "newPassword")
+        @NotBlank(message = "새로운 비밀번호는 필수 입력값입니다.")
+        String newPassword
 ) {
 }

--- a/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
@@ -16,6 +16,13 @@ public class UserManagementService {
     private final PasswordEncoder passwordEncoder;
     private final UserService userService;
 
+    /**
+     * 사용자 비밀번호 갱신 메서드
+     *
+     * @param userId            사용자 ID
+     * @param passwordReq       비밀번호 갱신 요청 dto(password)
+     * @throws CustomException  UserErrorType.SAME_PASSWORD - 기존 비밀번호와 동일할 경우
+     */
     @Transactional
     public void updatePassword(Long userId, PasswordUpdateReq passwordReq) {
         User user = userService.readById(userId)

--- a/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
@@ -20,18 +20,23 @@ public class UserManagementService {
      * 사용자 비밀번호 갱신 메서드
      *
      * @param userId            사용자 ID
-     * @param passwordReq       비밀번호 갱신 요청 dto(password)
-     * @throws CustomException  UserErrorType.SAME_PASSWORD - 기존 비밀번호와 동일할 경우
+     * @param passwordReq       비밀번호 갱신 요청 dto(originalPassword, newPassword)
+     * @throws CustomException  UserErrorType.PASSWORD_MISMATCH - 기존 비밀번호가 불일치할 경우
+     * @throws CustomException  UserErrorType.SAME_PASSWORD - 새로운 비밀번호가 기존 비밀번호와 동일할 경우
      */
     @Transactional
     public void updatePassword(Long userId, PasswordUpdateReq passwordReq) {
         User user = userService.readById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
 
-        if (passwordEncoder.matches(passwordReq.password(), user.getPassword())) {
+        if (!passwordEncoder.matches(passwordReq.originalPassword(), user.getPassword())) {
+            throw new CustomException(UserErrorType.PASSWORD_MISMATCH);
+        }
+
+        if (passwordEncoder.matches(passwordReq.newPassword(), user.getPassword())) {
             throw new CustomException(UserErrorType.SAME_PASSWORD);
         }
 
-        user.updatePassword(passwordEncoder.encode(passwordReq.password()));
+        user.updatePassword(passwordEncoder.encode(passwordReq.newPassword()));
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
@@ -1,0 +1,30 @@
+package kr.co.yeogiga.application.user.service;
+
+import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.exception.UserErrorType;
+import kr.co.yeogiga.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserManagementService {
+    private final PasswordEncoder passwordEncoder;
+    private final UserService userService;
+
+    @Transactional
+    public void updatePassword(Long userId, PasswordUpdateReq passwordReq) {
+        User user = userService.readById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
+
+        if (passwordEncoder.matches(passwordReq.password(), user.getPassword())) {
+            throw new CustomException(UserErrorType.SAME_PASSWORD);
+        }
+
+        user.updatePassword(passwordEncoder.encode(passwordReq.password()));
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -63,4 +63,8 @@ public class User extends BaseTimeEntity {
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/user/exception/UserErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/exception/UserErrorType.java
@@ -11,7 +11,8 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorType implements BaseErrorType {
     NOT_FOUND(HttpStatus.NOT_FOUND, "U000", "존재하지 않는 사용자입니다."),
     ALREADY_EXIST_USERNAME(HttpStatus.CONFLICT, "U001", "이미 존재하는 아이디입니다."),
-    SAME_PASSWORD(HttpStatus.CONFLICT, "U002", "기존과 동일한 비밀번호입니다.");
+    SAME_PASSWORD(HttpStatus.CONFLICT, "U002", "기존과 동일한 비밀번호입니다."),
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "U003", "비밀번호가 불일치합니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/co/yeogiga/domain/user/exception/UserErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/exception/UserErrorType.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserErrorType implements BaseErrorType {
     NOT_FOUND(HttpStatus.NOT_FOUND, "U000", "존재하지 않는 사용자입니다."),
-    ALREADY_EXIST_USERNAME(HttpStatus.CONFLICT, "U001", "이미 존재하는 아이디입니다.");
+    ALREADY_EXIST_USERNAME(HttpStatus.CONFLICT, "U001", "이미 존재하는 아이디입니다."),
+    SAME_PASSWORD(HttpStatus.CONFLICT, "U002", "기존과 동일한 비밀번호입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
@@ -11,7 +11,7 @@ public final class EndpointConstants {
 
     public static final String[] USER_ENDPOINTS = {
             "/api/v1/trip/**",
-            "/api/v1/user/**",
+            "/api/v1/users/**",
     };
 
     public static final String[] GUEST_ENDPOINTS = {

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
@@ -11,6 +11,7 @@ public final class EndpointConstants {
 
     public static final String[] USER_ENDPOINTS = {
             "/api/v1/trip/**",
+            "/api/v1/user/**",
     };
 
     public static final String[] GUEST_ENDPOINTS = {

--- a/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
@@ -31,6 +31,23 @@ public interface UserApi {
                                         }
                                     """)
                     })),
+            @ApiResponse(responseCode = "400", description = "비밀번호 갱신 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "기존 비밀번호 불일치", value = """
+                                        {
+                                            "code": "U003",
+                                            "message": "비밀번호가 불일치합니다."
+                                        }
+                                    """),
+                            @ExampleObject(name = "유효성 검증 실패", value = """
+                                        {
+                                            "code": "G002",
+                                            "errors": {
+                                                "originalPassword": "기존 비밀번호는 필수 입력값입니다."
+                                            }
+                                        }
+                                    """)
+                    })),
             @ApiResponse(responseCode = "401", description = "비밀번호 갱신 실패",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(name = "토큰 미포함", value = """

--- a/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
@@ -1,0 +1,57 @@
+package kr.co.yeogiga.presentation.user.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@ApiGroup(value = "[사용자 관련 API]")
+@Tag(name = "[사용자 관련 API]", description = "사용지 관련 API")
+public interface UserApi {
+
+    @TrackApi(description = "비밀번호 갱신")
+    @Operation(summary = "비밀번호 갱신", description = "비밀번호 갱신 요청 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "비밀번호 갱신 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "비밀번호 갱신 성공", value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "401", description = "비밀번호 갱신 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "토큰 미포함", value = """
+                                        {
+                                            "code": "A003",
+                                            "message": "인증에 실패하였습니다. 토큰을 확인해주세요."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "409", description = "비밀번호 갱신 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "기존과 동일한 비밀번호", value = """
+                                        {
+                                            "code": "U002",
+                                            "message": "기존과 동일한 비밀번호입니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> updatePassword(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody PasswordUpdateReq passwordUpdateReq
+    );
+}

--- a/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
@@ -1,0 +1,30 @@
+package kr.co.yeogiga.presentation.user.controller;
+
+import jakarta.validation.Valid;
+import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
+import kr.co.yeogiga.application.user.service.UserManagementService;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserManagementService userManagementService;
+
+    @PatchMapping("/password")
+    public ResponseEntity<?> updatePassword(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody PasswordUpdateReq passwordUpdateReq
+    ) {
+        userManagementService.updatePassword(userDetails.getUserId(), passwordUpdateReq);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
@@ -5,6 +5,7 @@ import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
 import kr.co.yeogiga.application.user.service.UserManagementService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.presentation.user.api.UserApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,9 +17,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
-public class UserController {
+public class UserController implements UserApi {
     private final UserManagementService userManagementService;
 
+    @Override
     @PatchMapping("/password")
     public ResponseEntity<?> updatePassword(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/test/java/kr/co/yeogiga/application/user/service/UserManagementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/user/service/UserManagementServiceTest.java
@@ -49,21 +49,22 @@ public class UserManagementServiceTest {
                 .nickname("test")
                 .build();
 
-        private final PasswordUpdateReq request = new PasswordUpdateReq("newPassword");
+        private final PasswordUpdateReq request = new PasswordUpdateReq("originalPassword", "newPassword");
 
         @Test
         @DisplayName("성공")
         void success() {
             // given
             when(userService.readById(eq(userId))).thenReturn(Optional.of(user));
-            when(passwordEncoder.matches(eq(request.password()), eq(user.getPassword()))).thenReturn(false);
-            when(passwordEncoder.encode(eq(request.password()))).thenReturn("newBcryptPassword");
+            when(passwordEncoder.matches(eq(request.originalPassword()), eq(user.getPassword()))).thenReturn(false);
+            when(passwordEncoder.matches(eq(request.newPassword()), eq(user.getPassword()))).thenReturn(false);
+            when(passwordEncoder.encode(eq(request.newPassword()))).thenReturn("BcryptPassword");
 
             // when
             userManagementService.updatePassword(userId, request);
 
             // then
-            verify(passwordEncoder, times(1)).encode(eq(request.password()));
+            verify(passwordEncoder, times(1)).encode(eq(request.newPassword()));
         }
 
         @Test
@@ -71,13 +72,28 @@ public class UserManagementServiceTest {
         void failIfPasswordAlreadyUsed() {
             // given
             when(userService.readById(eq(userId))).thenReturn(Optional.of(user));
-            when(passwordEncoder.matches(eq(request.password()), eq(user.getPassword()))).thenReturn(true);
+            when(passwordEncoder.matches(eq(request.originalPassword()), eq(user.getPassword()))).thenReturn(false);
+            when(passwordEncoder.matches(eq(request.newPassword()), eq(user.getPassword()))).thenReturn(true);
 
             // when
             CustomException exception = assertThrows(CustomException.class, () -> userManagementService.updatePassword(userId, request));
 
             // then
             assertEquals(UserErrorType.SAME_PASSWORD, exception.getErrorType());
+        }
+
+        @Test
+        @DisplayName("실패 - 현재 비밀번호 불일치")
+        void failIfOriginalPasswordNotMatch() {
+            // given
+            when(userService.readById(eq(userId))).thenReturn(Optional.of(user));
+            when(passwordEncoder.matches(eq(request.originalPassword()), eq(user.getPassword()))).thenReturn(true);
+
+            // when
+            CustomException exception = assertThrows(CustomException.class, () -> userManagementService.updatePassword(userId, request));
+
+            // then
+            assertEquals(UserErrorType.PASSWORD_MISMATCH, exception.getErrorType());
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/application/user/service/UserManagementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/user/service/UserManagementServiceTest.java
@@ -1,0 +1,83 @@
+package kr.co.yeogiga.application.user.service;
+
+import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.exception.UserErrorType;
+import kr.co.yeogiga.domain.user.service.UserService;
+import kr.co.yeogiga.domain.user.type.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+public class UserManagementServiceTest {
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private UserManagementService userManagementService;
+
+    @Nested
+    @DisplayName("비밀번호 갱신")
+    class UpdatePassword {
+        private final Long userId = 1L;
+
+        private final User user = User.builder()
+                .username("test")
+                .password("bcryptPassword")
+                .email("test@test.com")
+                .role(Role.USER)
+                .nickname("test")
+                .build();
+
+        private final PasswordUpdateReq request = new PasswordUpdateReq("newPassword");
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            when(userService.readById(eq(userId))).thenReturn(Optional.of(user));
+            when(passwordEncoder.matches(eq(request.password()), eq(user.getPassword()))).thenReturn(false);
+            when(passwordEncoder.encode(eq(request.password()))).thenReturn("newBcryptPassword");
+
+            // when
+            userManagementService.updatePassword(userId, request);
+
+            // then
+            verify(passwordEncoder, times(1)).encode(eq(request.password()));
+        }
+
+        @Test
+        @DisplayName("실패 - 기존 사용 비밀번호")
+        void failIfPasswordAlreadyUsed() {
+            // given
+            when(userService.readById(eq(userId))).thenReturn(Optional.of(user));
+            when(passwordEncoder.matches(eq(request.password()), eq(user.getPassword()))).thenReturn(true);
+
+            // when
+            CustomException exception = assertThrows(CustomException.class, () -> userManagementService.updatePassword(userId, request));
+
+            // then
+            assertEquals(UserErrorType.SAME_PASSWORD, exception.getErrorType());
+        }
+    }
+}

--- a/src/test/java/kr/co/yeogiga/application/user/service/UserManagementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/user/service/UserManagementServiceTest.java
@@ -56,7 +56,7 @@ public class UserManagementServiceTest {
         void success() {
             // given
             when(userService.readById(eq(userId))).thenReturn(Optional.of(user));
-            when(passwordEncoder.matches(eq(request.originalPassword()), eq(user.getPassword()))).thenReturn(false);
+            when(passwordEncoder.matches(eq(request.originalPassword()), eq(user.getPassword()))).thenReturn(true);
             when(passwordEncoder.matches(eq(request.newPassword()), eq(user.getPassword()))).thenReturn(false);
             when(passwordEncoder.encode(eq(request.newPassword()))).thenReturn("BcryptPassword");
 
@@ -72,7 +72,7 @@ public class UserManagementServiceTest {
         void failIfPasswordAlreadyUsed() {
             // given
             when(userService.readById(eq(userId))).thenReturn(Optional.of(user));
-            when(passwordEncoder.matches(eq(request.originalPassword()), eq(user.getPassword()))).thenReturn(false);
+            when(passwordEncoder.matches(eq(request.originalPassword()), eq(user.getPassword()))).thenReturn(true);
             when(passwordEncoder.matches(eq(request.newPassword()), eq(user.getPassword()))).thenReturn(true);
 
             // when
@@ -87,7 +87,7 @@ public class UserManagementServiceTest {
         void failIfOriginalPasswordNotMatch() {
             // given
             when(userService.readById(eq(userId))).thenReturn(Optional.of(user));
-            when(passwordEncoder.matches(eq(request.originalPassword()), eq(user.getPassword()))).thenReturn(true);
+            when(passwordEncoder.matches(eq(request.originalPassword()), eq(user.getPassword()))).thenReturn(false);
 
             // when
             CustomException exception = assertThrows(CustomException.class, () -> userManagementService.updatePassword(userId, request));

--- a/src/test/java/kr/co/yeogiga/infrastructure/TestSecurityConfig.java
+++ b/src/test/java/kr/co/yeogiga/infrastructure/TestSecurityConfig.java
@@ -1,0 +1,32 @@
+package kr.co.yeogiga.infrastructure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.common.security.filter.AccessDeniedHandlerImpl;
+import kr.co.yeogiga.domain.user.type.Role;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static kr.co.yeogiga.infrastructure.config.security.constant.EndpointConstants.GUEST_ENDPOINTS;
+import static kr.co.yeogiga.infrastructure.config.security.constant.EndpointConstants.PUBLIC_ENDPOINTS;
+import static kr.co.yeogiga.infrastructure.config.security.constant.EndpointConstants.USER_ENDPOINTS;
+
+@Configuration
+public class TestSecurityConfig {
+    @Bean
+    public SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize ->
+                        authorize
+                                .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
+                                .requestMatchers(USER_ENDPOINTS).hasAuthority(Role.USER.name())
+                                .requestMatchers(GUEST_ENDPOINTS).hasAuthority(Role.GUEST.name())
+                                .anyRequest().authenticated())
+                .exceptionHandling(exceptionConfig -> exceptionConfig
+                .accessDeniedHandler(new AccessDeniedHandlerImpl(new ObjectMapper()))
+                ).build();
+    }
+}

--- a/src/test/java/kr/co/yeogiga/presentation/user/controller/UserControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/user/controller/UserControllerTest.java
@@ -89,7 +89,7 @@ public class UserControllerTest {
 
         private final Long userId = 1L;
 
-        private PasswordUpdateReq request = new PasswordUpdateReq("newPassword");
+        private PasswordUpdateReq request = new PasswordUpdateReq("originalPassword", "newPassword");
 
         @Test
         @DisplayName("성공")
@@ -138,7 +138,7 @@ public class UserControllerTest {
             // given
             setUpUserDetails(Role.USER);
             doNothing().when(userManagementService).updatePassword(userId, request);
-            PasswordUpdateReq request = new PasswordUpdateReq(" ");
+            PasswordUpdateReq request = new PasswordUpdateReq(" ", "  ");
 
             // when
             ResultActions resultActions = mockMvc.perform(

--- a/src/test/java/kr/co/yeogiga/presentation/user/controller/UserControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/user/controller/UserControllerTest.java
@@ -1,0 +1,158 @@
+package kr.co.yeogiga.presentation.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
+import kr.co.yeogiga.application.user.service.UserManagementService;
+import kr.co.yeogiga.common.response.error.type.CommonErrorType;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
+import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.type.Role;
+import kr.co.yeogiga.infrastructure.TestSecurityConfig;
+import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = UserController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthenticationFilter.class})
+        }
+)
+@Import({TestSecurityConfig.class})
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserManagementService userManagementService;
+
+    private CustomUserDetails userDetails;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .alwaysDo(print())
+                .apply(springSecurity())
+                .defaultRequest(patch("/**").with(csrf()))
+                .build();
+    }
+
+    void setUpUserDetails(Role role) {
+        User user = User.builder()
+                .username("test")
+                .password("password")
+                .email("test@test.com")
+                .role(role)
+                .nickname("nickname")
+                .build();
+
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        userDetails = new CustomUserDetailsImpl(user);
+    }
+
+    @Nested
+    @DisplayName("비밀번호 갱신")
+    class UpdatePassword {
+
+        private final Long userId = 1L;
+
+        private PasswordUpdateReq request = new PasswordUpdateReq("newPassword");
+
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            setUpUserDetails(Role.USER);
+            doNothing().when(userManagementService).updatePassword(userId, request);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    patch("/api/v1/users/password")
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsBytes(request))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
+
+        @Test
+        @DisplayName("실패 - 접근 권한 오류")
+        void failUnAuthorization() throws Exception {
+            // given
+            setUpUserDetails(Role.GUEST);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    patch("/api/v1/users/password")
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsBytes(request))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.message").value(AuthErrorType.UN_REGISTERED_USER.getMessage()));
+        }
+
+        @Test
+        @DisplayName("실패 - 유효성 검증 실패")
+        void failValidation() throws Exception {
+            // given
+            setUpUserDetails(Role.USER);
+            doNothing().when(userManagementService).updatePassword(userId, request);
+            PasswordUpdateReq request = new PasswordUpdateReq(" ");
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    patch("/api/v1/users/password")
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsBytes(request))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(CommonErrorType.VALIDATION_ERROR.getCode()))
+                    .andExpect(jsonPath("$.errors").exists());
+        }
+    }
+}


### PR DESCRIPTION
## 배경
- 사용자 비밀번호 갱신 api 구현

## 작업 사항
- 사용자 비밀번호 갱신 api 구현
- 테스트용 스프링 시큐리티 설정 추가 - `TestSecurityConfig` - (4de96d31f4bd7ef7091db15d7c69f430a3129f62)
   - 저의 미숙함때문일 가능성이 크지만, 저번 PR과 같이 현재 SpringSecurity를 도입하여 테스트를 진행하였을 때 `JwtAuthenticationFilter` 관련 의존성들을 추가로 주입하여야 한다는 에러가 지속적으로 발생하여 `JwtAuthenticationFilter`와 `SecurityConfig`는 제외한 채로 Presentation 레이어 테스트를 진행하였습니다. 사용자 권한 관련하여 테스트를 진행해보기 위해서 FilterChain 관련 설정이 필요하여 `TestSecurityConfig`를 구현하게 되었습니다. 

   - 해당 부분은 이틀을 넘게 찾아보았는데도 현재 방법이 최선이라 생각하여 적용하였습니다. 접근 권한 테스트를 진행할 일이 없다면 기존처럼 `SecurityConfig`, `JwtAuthenticationFilter`를 제외한 채 테스트를 진행하면 될 것 같습니다. 혹시라도 더 나은 방법이 있다면 알려주시면 감사하겠습니다!

## 추가 논의
- 원래는 "회원탈퇴" 기능도 동시에 구현하려 하였으나, 테스트 코드로 인하여 PR 크기가 커져 회원 탈퇴는 다음 PR로 미루도록 하겠습니다.