### PR TITLE
Feature(IL-59): 임시 이미지 정렬 로직 구체화

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/image/service/TempImageAssignProcessor.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/TempImageAssignProcessor.java
@@ -1,0 +1,31 @@
+package kr.co.yeogiga.application.image.service;
+
+import kr.co.yeogiga.application.trip.service.TripPlaceImageService;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.tripplace.entity.TempPlaceImages;
+import kr.co.yeogiga.domain.tripplace.exception.ImageErrorType;
+import kr.co.yeogiga.domain.tripplace.service.TempPlaceImagesService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TempImageAssignProcessor {
+    private final TempPlaceImagesService tempPlaceImagesService;
+    private final TripPlaceImageService tripPlaceImageService;
+
+    /**
+     * 임시 저장소로부터 이미지를 불러와 TripDayPlace에 할당하는 메서드
+     * - 사용이 끝난 임시 저장소 데이터를 삭제
+     *
+     * @param tripDayPlaceId 할당 대상이 되는 TripDayPlace의 ID
+     */
+    public void assignFromTempStorage(String tripDayPlaceId) {
+        TempPlaceImages tempPlaceImages = tempPlaceImagesService.readByTripDayPlaceId(tripDayPlaceId)
+                .orElseThrow(() -> new CustomException(ImageErrorType.NOT_FOUND_TEMP_IMAGE_STORE));
+
+        tripPlaceImageService.assignImageToTripDayPlace(tripDayPlaceId, tempPlaceImages.getImages());
+
+        tempPlaceImagesService.deleteById(tempPlaceImages.getId());
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceImageService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceImageService.java
@@ -4,45 +4,111 @@ import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
+import kr.co.yeogiga.domain.tripplace.entity.TempPlaceImages;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
+import kr.co.yeogiga.domain.tripplace.exception.ImageErrorType;
+import kr.co.yeogiga.domain.tripplace.service.TempPlaceImagesService;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class TripPlaceImageService {
     private final TripDayPlaceService tripDayPlaceService;
+    private final TempPlaceImagesService tempPlaceImagesService;
 
     /**
-     * 주어진 이미지 메타데이터 통해 해당 TripDayPlace에 할당하는 메서드
+     * 임시 저장된 이미지 메타데이터를 불러와 해당 TripDayPlace에 할당하는 메서드
      * - 위도/경도가 있을 경우 가장 가까운 목적지(Place)에 연결
      * - 위도/경도가 없거나 목적지가 없을 경우 기타(unmatchedImages)로 분류
      *
      * @param tripDayPlaceId TripDayPlace의 ID
-     * @param image          GPS 정보와 시간 정보를 가진 이미지 객체
      */
-    public void assignImageToTripDayPlace(String tripDayPlaceId, Image image) {
+    public void assignImageToTripDayPlace(String tripDayPlaceId) {
         TripDayPlace tripDayPlace = tripDayPlaceService.readById(tripDayPlaceId)
                 .orElseThrow(() -> new CustomException(TripErrorType.DAY_PLACE_NOT_FOUND));
 
-        // 위도 경도 없는 경우
-        if (!hasGpsInfo(image)) {
-            assignToUnmatched(tripDayPlace, image);
-            return;
-        }
+        TempPlaceImages tempPlaceImages = tempPlaceImagesService.readByTripDayPlaceId(tripDayPlaceId)
+                .orElseThrow(() -> new CustomException(ImageErrorType.NOT_FOUND_TEMP_IMAGE_STORE));
 
-        Place nearestPlace = findNearestPlace(tripDayPlace, image);
+        // GPS 정보를 기준으로 가장 가까운 장소별로 이미지 그룹핑
+        List<Image> unmatchedImages = new ArrayList<>();
+        Map<String, List<Image>> placeImageMap = groupImagesByNearestPlace(
+                tripDayPlace.getPlaces(),
+                tempPlaceImages.getImages(),
+                unmatchedImages
+        );
 
-        if (nearestPlace != null) {     // 담겨진 목적지가 없는 경우
-            nearestPlace.addImage(image);
-        } else {
-            assignToUnmatched(tripDayPlace, image);
-        }
+        // 그룹핑된 이미지들을 실제 TripDayPlace에 할당
+        assignGroupedImagesToTripDayPlace(tripDayPlace, placeImageMap, unmatchedImages);
 
         tripDayPlaceService.save(tripDayPlace);
+        tempPlaceImagesService.deleteById(tempPlaceImages.getId());
+    }
+
+    /**
+     * 이미지들을 가장 가까운 목적지별로 그룹핑하여 매핑하는 메서드
+     * - GPS 정보가 없으면 unmatchedImages에 추가
+     * - 가장 가까운 장소가 없는 경우(목적지 존재 x)에도 unmatchedImages에 추가
+     *
+     * @param places          이미지와 매칭할 대상 장소 리스트
+     * @param sourceImages    정렬할 이미지 리스트
+     * @param unmatchedImages 매칭되지 않은 이미지를 저장할 리스트
+     * @return 장소 ID를 키로 하고, 해당 장소에 할당될 이미지 리스트를 값으로 가지는 Map
+     */
+    private Map<String, List<Image>> groupImagesByNearestPlace(
+            List<Place> places,
+            List<Image> sourceImages,
+            List<Image> unmatchedImages
+    ) {
+        Map<String, List<Image>> placeImageMap = new HashMap<>();
+
+        for (Image image : sourceImages) {
+            if (!hasGpsInfo(image)) {
+                unmatchedImages.add(image);
+                continue;
+            }
+
+            Place nearestPlace = findNearestPlace(places, image);
+            if (nearestPlace != null) {
+                placeImageMap.computeIfAbsent(nearestPlace.getId(), k -> new ArrayList<>()).add(image);
+            } else {
+                unmatchedImages.add(image);
+            }
+        }
+
+        return placeImageMap;
+    }
+
+    /**
+     * 그룹핑된 이미지 데이터를 실제 TripDayPlace에 할당하는 메서드
+     * - 장소별로 할당된 이미지를 해당 Place 객체에 추가
+     * - 매칭되지 않은 이미지는 TripDayPlace의 unmatchedImages에 추가
+     *
+     * @param tripDayPlace    이미지가 할당될 대상 TripDayPlace
+     * @param placeImageMap   장소 ID별로 이미지가 그룹핑된 Map
+     * @param unmatchedImages 매칭되지 않은 이미지 리스트
+     */
+    private void assignGroupedImagesToTripDayPlace(
+            TripDayPlace tripDayPlace,
+            Map<String, List<Image>> placeImageMap,
+            List<Image> unmatchedImages
+    ) {
+        for (Place place : tripDayPlace.getPlaces()) {
+            List<Image> assignedImages = placeImageMap.get(place.getId());
+            if (assignedImages != null && !assignedImages.isEmpty()) {
+                place.addImages(assignedImages);
+            }
+        }
+
+        tripDayPlace.addUnmatchedImages(unmatchedImages);
     }
 
     /**
@@ -56,26 +122,15 @@ public class TripPlaceImageService {
     }
 
     /**
-     * GPS 정보가 없거나 적절한 목적지를 찾지 못한 이미지를 기타 목록에 추가하는 메서드
-     *
-     * @param tripDayPlace 이미지가 속한 TripDayPlace
-     * @param image        기타로 분류할 이미지
-     */
-    private void assignToUnmatched(TripDayPlace tripDayPlace, Image image) {
-        tripDayPlace.addUnmatchedImage(image);
-        tripDayPlaceService.save(tripDayPlace);
-    }
-
-    /**
      * 이미지와 가장 가까운 위치에 있는 목적지를 TripDayPlace 내에서 탐색하는 메서드
      * - Haversine 공식을 기반으로 계산된 거리 기준
      *
-     * @param tripDayPlace 비교 대상이 되는 장소 리스트
-     * @param image        위치 기준이 될 이미지
+     * @param places 비교 대상이 되는 장소 리스트
+     * @param image  위치 기준이 될 이미지
      * @return 가장 가까운 Place 객체, 없으면 null
      */
-    private Place findNearestPlace(TripDayPlace tripDayPlace, Image image) {
-        return tripDayPlace.getPlaces().stream()
+    private Place findNearestPlace(List<Place> places, Image image) {
+        return places.stream()
                 .min(Comparator.comparingDouble(place ->
                         calculateDistance(image.getLatitude(), image.getLongitude(),
                                 place.getLatitude(), place.getLongitude())))

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceImageService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceImageService.java
@@ -4,10 +4,7 @@ import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
-import kr.co.yeogiga.domain.tripplace.entity.TempPlaceImages;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
-import kr.co.yeogiga.domain.tripplace.exception.ImageErrorType;
-import kr.co.yeogiga.domain.tripplace.service.TempPlaceImagesService;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,27 +19,23 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class TripPlaceImageService {
     private final TripDayPlaceService tripDayPlaceService;
-    private final TempPlaceImagesService tempPlaceImagesService;
 
     /**
-     * 임시 저장된 이미지 메타데이터를 불러와 해당 TripDayPlace에 할당하는 메서드
+     * 이미지 메타데이터를 불러와 해당 TripDayPlace에 할당하는 메서드
      * - 위도/경도가 있을 경우 가장 가까운 목적지(Place)에 연결
      * - 위도/경도가 없거나 목적지가 없을 경우 기타(unmatchedImages)로 분류
      *
      * @param tripDayPlaceId TripDayPlace의 ID
      */
-    public void assignImageToTripDayPlace(String tripDayPlaceId) {
+    public void assignImageToTripDayPlace(String tripDayPlaceId, List<Image> images) {
         TripDayPlace tripDayPlace = tripDayPlaceService.readById(tripDayPlaceId)
                 .orElseThrow(() -> new CustomException(TripErrorType.DAY_PLACE_NOT_FOUND));
-
-        TempPlaceImages tempPlaceImages = tempPlaceImagesService.readByTripDayPlaceId(tripDayPlaceId)
-                .orElseThrow(() -> new CustomException(ImageErrorType.NOT_FOUND_TEMP_IMAGE_STORE));
 
         // GPS 정보를 기준으로 가장 가까운 장소별로 이미지 그룹핑
         List<Image> unmatchedImages = new ArrayList<>();
         Map<String, List<Image>> placeImageMap = groupImagesByNearestPlace(
                 tripDayPlace.getPlaces(),
-                tempPlaceImages.getImages(),
+                images,
                 unmatchedImages
         );
 
@@ -50,7 +43,6 @@ public class TripPlaceImageService {
         assignGroupedImagesToTripDayPlace(tripDayPlace, placeImageMap, unmatchedImages);
 
         tripDayPlaceService.save(tripDayPlace);
-        tempPlaceImagesService.deleteById(tempPlaceImages.getId());
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripPlaceQueryService.java
@@ -23,7 +23,7 @@ public class TripPlaceQueryService {
      * @return TripDayPlace 요약 정보 리스트
      */
     public List<TripPlaceRes.TripDayPlaceInfo> getTripDayPlacesInfo(Long tripId) {
-        List<TripDayPlace> tripDayPlaces = tripDayPlaceService.readByTripId(tripId);
+        List<TripDayPlace> tripDayPlaces = tripDayPlaceService.readByTripIdSortedByOrder(tripId);
 
         return tripDayPlaces.stream()
                 .map(TripPlaceRes.TripDayPlaceInfo::from)
@@ -38,7 +38,7 @@ public class TripPlaceQueryService {
      * @return 목적지 상세 정보 리스트
      */
     public List<TripPlaceRes.PlaceDetails> getPlaceDetailsInfo(String tripDayPlaceId) {
-        TripDayPlace tripDayPlace = tripDayPlaceService.readById(tripDayPlaceId)
+        TripDayPlace tripDayPlace = tripDayPlaceService.readByIdSortedByOrder(tripDayPlaceId)
                 .orElseThrow(() -> new CustomException(TripErrorType.DAY_PLACE_NOT_FOUND));
 
         return tripDayPlace.getPlaces().stream()

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
@@ -32,7 +32,7 @@ public class Place {
         this.order = order;
     }
 
-    public void addImage(Image image) {
-        this.images.add(image);
+    public void addImages(List<Image> images) {
+        this.images.addAll(images);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/TempPlaceImages.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/TempPlaceImages.java
@@ -24,8 +24,4 @@ public class TempPlaceImages {
         this.tripDayPlaceId = tripDayPlaceId;
         this.images = new ArrayList<>();
     }
-
-    public void addImage(Image image) {
-        this.images.add(image);
-    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/TripDayPlace.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/TripDayPlace.java
@@ -33,7 +33,7 @@ public class TripDayPlace {
         this.places = places;
     }
 
-    public void addUnmatchedImage(Image image) {
-        this.unmatchedImages.add(image);
+    public void addUnmatchedImages(List<Image> images) {
+        this.unmatchedImages.addAll(images);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/exception/ImageErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/exception/ImageErrorType.java
@@ -1,0 +1,34 @@
+package kr.co.yeogiga.domain.tripplace.exception;
+
+import kr.co.yeogiga.common.response.error.type.BaseErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Image ErrorCode: Ixxx
+ */
+@RequiredArgsConstructor
+public enum ImageErrorType implements BaseErrorType {
+
+    NOT_FOUND_TEMP_IMAGE_STORE(HttpStatus.NOT_FOUND, "I000", "임시 저장된 이미지가 존재하지 않습니다.");
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
@@ -53,7 +53,7 @@ public class CustomTripDayPlaceRepositoryImpl implements CustomTripDayPlaceRepos
     public Optional<TripDayPlace> findByIdSorted(String id) {
         Aggregation aggregation = Aggregation.newAggregation(
                 Aggregation.match(Criteria.where("_id").is(id)),
-                Aggregation.unwind("places"),
+                Aggregation.unwind("places", true),
                 Aggregation.sort(Sort.by(Sort.Direction.ASC, "places.order")),
                 Aggregation.group("_id")
                         .first("tripId").as("tripId")
@@ -72,12 +72,13 @@ public class CustomTripDayPlaceRepositoryImpl implements CustomTripDayPlaceRepos
     public List<TripDayPlace> findByTripIdSorted(Long tripId) {
         Aggregation aggregation = Aggregation.newAggregation(
                 Aggregation.match(Criteria.where("tripId").is(tripId)),
-                Aggregation.unwind("places"),
+                Aggregation.unwind("places", true),
                 Aggregation.sort(Sort.by(Sort.Direction.ASC, "places.order")),
                 Aggregation.group("_id")
                         .first("tripId").as("tripId")
                         .first("day").as("day")
-                        .push("places").as("places")
+                        .push("places").as("places"),
+                Aggregation.sort(Sort.by(Sort.Direction.ASC, "day"))
         );
 
         AggregationResults<TripDayPlace> results =

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/TempPlaceImagesRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/TempPlaceImagesRepository.java
@@ -3,5 +3,8 @@ package kr.co.yeogiga.domain.tripplace.repository;
 import kr.co.yeogiga.domain.tripplace.entity.TempPlaceImages;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.Optional;
+
 public interface TempPlaceImagesRepository extends MongoRepository<TempPlaceImages, String>, CustomTempPlaceImagesRepository {
+    Optional<TempPlaceImages> findByTripDayPlaceId(String tripDayPlaceId);
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/service/TempPlaceImagesService.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/service/TempPlaceImagesService.java
@@ -1,9 +1,12 @@
 package kr.co.yeogiga.domain.tripplace.service;
 
 import kr.co.yeogiga.domain.tripplace.entity.Image;
+import kr.co.yeogiga.domain.tripplace.entity.TempPlaceImages;
 import kr.co.yeogiga.domain.tripplace.repository.TempPlaceImagesRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -12,5 +15,13 @@ public class TempPlaceImagesService {
 
     public void saveImage(String tripDayPlaceId, Image image) {
         tempPlaceImagesRepository.saveImage(tripDayPlaceId, image);
+    }
+
+    public Optional<TempPlaceImages> readByTripDayPlaceId(String tripDayPlaceId) {
+        return tempPlaceImagesRepository.findByTripDayPlaceId(tripDayPlaceId);
+    }
+
+    public void deleteById(String id) {
+        tempPlaceImagesRepository.deleteById(id);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
@@ -27,10 +27,14 @@ public class TripDayPlaceService {
     }
 
     public Optional<TripDayPlace> readById(String id) {
+        return tripDayPlaceRepository.findById(id);
+    }
+
+    public Optional<TripDayPlace> readByIdSortedByOrder(String id) {
         return tripDayPlaceRepository.findByIdSorted(id);
     }
 
-    public List<TripDayPlace> readByTripId(Long tripId) {
+    public List<TripDayPlace> readByTripIdSortedByOrder(Long tripId) {
         return tripDayPlaceRepository.findByTripIdSorted(tripId);
     }
 

--- a/src/main/java/kr/co/yeogiga/presentation/image/api/ImageApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/image/api/ImageApi.java
@@ -49,6 +49,21 @@ public interface ImageApi {
                                             "message": "요청이 성공하였습니다."
                                         }
                                     """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "찾을 수 없는 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "임시 저장된 이미지가 없음", value = """
+                                        {
+                                             "code": "I000",
+                                             "message": "임시 저장된 이미지가 존재하지 않습니다."
+                                        }
+                                    """),
+                            @ExampleObject(name = "여행 일차 존재하지 않음", value = """
+                                        {
+                                            "code": "T003",
+                                            "message": "해당 여행 일차 정보가 존재하지 않습니다."
+                                        }
+                                    """)
                     }))
     })
     ResponseEntity<?> assignImages(@PathVariable Long tripId,

--- a/src/main/java/kr/co/yeogiga/presentation/image/api/ImageApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/image/api/ImageApi.java
@@ -38,6 +38,22 @@ public interface ImageApi {
                                    @PathVariable Long tripId,
                                    @PathVariable String tripDayPlaceId);
 
+    @TrackApi(description = "이미지 목적지 매핑")
+    @Operation(summary = "이미지 목적지 매핑", description = "이미지 목적지 매핑하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "이미지 목적지 매핑 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> assignImages(@PathVariable Long tripId,
+                                   @PathVariable String tripDayPlaceId);
+
     @TrackApi(description = "이미지 삭제")
     @Operation(summary = "이미지 삭제", description = "이미지 삭제하는 API입니다.")
     @ApiResponses({

--- a/src/main/java/kr/co/yeogiga/presentation/image/api/ImageApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/image/api/ImageApi.java
@@ -41,7 +41,7 @@ public interface ImageApi {
     @TrackApi(description = "이미지 목적지 매핑")
     @Operation(summary = "이미지 목적지 매핑", description = "이미지 목적지 매핑하는 API입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "이미지 목적지 매핑 성공",
+            @ApiResponse(responseCode = "200", description = "이미지 목적지 매핑 성공",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                         {

--- a/src/main/java/kr/co/yeogiga/presentation/image/controller/ImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/image/controller/ImageController.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.presentation.image.controller;
 import kr.co.yeogiga.application.image.dto.ImageUrlDto;
 import kr.co.yeogiga.application.image.service.ImageDeleteProcessor;
 import kr.co.yeogiga.application.image.service.ImageUploadProcessor;
+import kr.co.yeogiga.application.trip.service.TripPlaceImageService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.presentation.image.api.ImageApi;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import java.util.List;
 public class ImageController implements ImageApi {
     private final ImageUploadProcessor imageUploadProcessor;
     private final ImageDeleteProcessor imageDeleteProcessor;
+    private final TripPlaceImageService tripPlaceImageService;
 
     @Override
     @PostMapping("/{tripId}/images/{tripDayPlaceId}")
@@ -33,6 +35,13 @@ public class ImageController implements ImageApi {
                                           @PathVariable String tripDayPlaceId) {
         imageUploadProcessor.process(images, tripId, tripDayPlaceId);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
+    }
+
+    @PostMapping("/{tripId}/images/{tripDayPlaceId}/assign")
+    public ResponseEntity<?> assignImages(@PathVariable Long tripId,
+                                          @PathVariable String tripDayPlaceId) {
+        tripPlaceImageService.assignImageToTripDayPlace(tripDayPlaceId);
+        return ResponseEntity.ok(SuccessResponse.ok());
     }
 
     @Override

--- a/src/main/java/kr/co/yeogiga/presentation/image/controller/ImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/image/controller/ImageController.java
@@ -3,7 +3,7 @@ package kr.co.yeogiga.presentation.image.controller;
 import kr.co.yeogiga.application.image.dto.ImageUrlDto;
 import kr.co.yeogiga.application.image.service.ImageDeleteProcessor;
 import kr.co.yeogiga.application.image.service.ImageUploadProcessor;
-import kr.co.yeogiga.application.trip.service.TripPlaceImageService;
+import kr.co.yeogiga.application.image.service.TempImageAssignProcessor;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.presentation.image.api.ImageApi;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +26,7 @@ import java.util.List;
 public class ImageController implements ImageApi {
     private final ImageUploadProcessor imageUploadProcessor;
     private final ImageDeleteProcessor imageDeleteProcessor;
-    private final TripPlaceImageService tripPlaceImageService;
+    private final TempImageAssignProcessor tempImageAssignProcessor;
 
     @Override
     @PostMapping("/{tripId}/images/{tripDayPlaceId}")
@@ -41,7 +41,7 @@ public class ImageController implements ImageApi {
     @PostMapping("/{tripId}/images/{tripDayPlaceId}/assign")
     public ResponseEntity<?> assignImages(@PathVariable Long tripId,
                                           @PathVariable String tripDayPlaceId) {
-        tripPlaceImageService.assignImageToTripDayPlace(tripDayPlaceId);
+        tempImageAssignProcessor.assignFromTempStorage(tripDayPlaceId);
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 

--- a/src/main/java/kr/co/yeogiga/presentation/image/controller/ImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/image/controller/ImageController.java
@@ -37,6 +37,7 @@ public class ImageController implements ImageApi {
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
     }
 
+    @Override
     @PostMapping("/{tripId}/images/{tripDayPlaceId}/assign")
     public ResponseEntity<?> assignImages(@PathVariable Long tripId,
                                           @PathVariable String tripDayPlaceId) {

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceImageServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceImageServiceTest.java
@@ -4,10 +4,7 @@ import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
-import kr.co.yeogiga.domain.tripplace.entity.TempPlaceImages;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
-import kr.co.yeogiga.domain.tripplace.exception.ImageErrorType;
-import kr.co.yeogiga.domain.tripplace.service.TempPlaceImagesService;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -34,9 +31,6 @@ class TripPlaceImageServiceTest {
 
     @Mock
     private TripDayPlaceService tripDayPlaceService;
-
-    @Mock
-    private TempPlaceImagesService tempPlaceImagesService;
 
     @InjectMocks
     private TripPlaceImageService tripPlaceImageService;
@@ -91,16 +85,10 @@ class TripPlaceImageServiceTest {
         tempImages.add(imgWithGps);
         tempImages.add(imgWithoutGps);
 
-        TempPlaceImages tempPlaceImages = TempPlaceImages.builder()
-                .tripDayPlaceId(tripDayPlaceId)
-                .build();
-        tempPlaceImages.getImages().addAll(tempImages);
-
         given(tripDayPlaceService.readById(tripDayPlaceId)).willReturn(Optional.of(tripDayPlace));
-        given(tempPlaceImagesService.readByTripDayPlaceId(tripDayPlaceId)).willReturn(Optional.of(tempPlaceImages));
 
         // when
-        tripPlaceImageService.assignImageToTripDayPlace(tripDayPlaceId);
+        tripPlaceImageService.assignImageToTripDayPlace(tripDayPlaceId, tempImages);
 
         // then
         assertEquals(1, tripDayPlace.getPlaces().get(0).getImages().size());
@@ -116,25 +104,10 @@ class TripPlaceImageServiceTest {
 
         // when
         CustomException exception = assertThrows(CustomException.class,
-                () -> tripPlaceImageService.assignImageToTripDayPlace(tripDayPlaceId));
+                () -> tripPlaceImageService.assignImageToTripDayPlace(tripDayPlaceId, tempImages));
 
         // then
         assertEquals(TripErrorType.DAY_PLACE_NOT_FOUND, exception.getErrorType());
-    }
-
-    @Test
-    @DisplayName("예외 - TempPlaceImages 존재 x")
-    void assignImageFailTempImagesNotFound() {
-        // given
-        given(tripDayPlaceService.readById(tripDayPlaceId)).willReturn(Optional.of(tripDayPlace));
-        given(tempPlaceImagesService.readByTripDayPlaceId(tripDayPlaceId)).willReturn(Optional.empty());
-
-        // when
-        CustomException exception = assertThrows(CustomException.class,
-                () -> tripPlaceImageService.assignImageToTripDayPlace(tripDayPlaceId));
-
-        // then
-        assertEquals(ImageErrorType.NOT_FOUND_TEMP_IMAGE_STORE, exception.getErrorType());
     }
 }
 

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceImageServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceImageServiceTest.java
@@ -1,0 +1,140 @@
+package kr.co.yeogiga.application.trip.service;
+
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.tripplace.entity.Image;
+import kr.co.yeogiga.domain.tripplace.entity.Place;
+import kr.co.yeogiga.domain.tripplace.entity.TempPlaceImages;
+import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
+import kr.co.yeogiga.domain.tripplace.exception.ImageErrorType;
+import kr.co.yeogiga.domain.tripplace.service.TempPlaceImagesService;
+import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TripPlaceImageServiceTest {
+
+    @Mock
+    private TripDayPlaceService tripDayPlaceService;
+
+    @Mock
+    private TempPlaceImagesService tempPlaceImagesService;
+
+    @InjectMocks
+    private TripPlaceImageService tripPlaceImageService;
+
+    private final String tripDayPlaceId = "tripDayPlaceId";
+
+    private TripDayPlace tripDayPlace;
+    private List<Place> places;
+    private List<Image> tempImages;
+
+    @BeforeEach
+    void setup() {
+        Place place = Place.builder()
+                .id("place1")
+                .name("Place1")
+                .latitude(12.34)
+                .longitude(56.78)
+                .placeType("식당")
+                .order(1.0)
+                .build();
+
+        places = new ArrayList<>();
+        places.add(place);
+
+        tripDayPlace = TripDayPlace.builder()
+                .tripId(1L)
+                .day(1)
+                .places(places)
+                .build();
+
+        tempImages = new ArrayList<>();
+    }
+
+    @Test
+    @DisplayName("이미지 매칭 성공 - GPS 정보 있는 이미지는 장소에, 없는 이미지는 unmatched에")
+    void assignImageSuccessWithMixedImages() {
+        // given
+        Image imgWithGps = Image.builder()
+                .url("img1")
+                .latitude(37.001)
+                .longitude(127.001)
+                .date(LocalDateTime.now())
+                .build();
+
+        Image imgWithoutGps = Image.builder()
+                .url("img2")
+                .latitude(null)
+                .longitude(null)
+                .date(LocalDateTime.now())
+                .build();
+
+        tempImages.add(imgWithGps);
+        tempImages.add(imgWithoutGps);
+
+        TempPlaceImages tempPlaceImages = TempPlaceImages.builder()
+                .tripDayPlaceId(tripDayPlaceId)
+                .build();
+        tempPlaceImages.getImages().addAll(tempImages);
+
+        given(tripDayPlaceService.readById(tripDayPlaceId)).willReturn(Optional.of(tripDayPlace));
+        given(tempPlaceImagesService.readByTripDayPlaceId(tripDayPlaceId)).willReturn(Optional.of(tempPlaceImages));
+
+        // when
+        tripPlaceImageService.assignImageToTripDayPlace(tripDayPlaceId);
+
+        // then
+        assertEquals(1, tripDayPlace.getPlaces().get(0).getImages().size());
+        assertEquals(1, tripDayPlace.getUnmatchedImages().size());
+        verify(tripDayPlaceService, times(1)).save(tripDayPlace);
+    }
+
+    @Test
+    @DisplayName("실패 - TripDayPlace 존재 x")
+    void assignImageFailDayPlaceNotFound() {
+        // given
+        given(tripDayPlaceService.readById(anyString())).willReturn(Optional.empty());
+
+        // when
+        CustomException exception = assertThrows(CustomException.class,
+                () -> tripPlaceImageService.assignImageToTripDayPlace(tripDayPlaceId));
+
+        // then
+        assertEquals(TripErrorType.DAY_PLACE_NOT_FOUND, exception.getErrorType());
+    }
+
+    @Test
+    @DisplayName("예외 - TempPlaceImages 존재 x")
+    void assignImageFailTempImagesNotFound() {
+        // given
+        given(tripDayPlaceService.readById(tripDayPlaceId)).willReturn(Optional.of(tripDayPlace));
+        given(tempPlaceImagesService.readByTripDayPlaceId(tripDayPlaceId)).willReturn(Optional.empty());
+
+        // when
+        CustomException exception = assertThrows(CustomException.class,
+                () -> tripPlaceImageService.assignImageToTripDayPlace(tripDayPlaceId));
+
+        // then
+        assertEquals(ImageErrorType.NOT_FOUND_TEMP_IMAGE_STORE, exception.getErrorType());
+    }
+}
+

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripPlaceQueryServiceTest.java
@@ -46,7 +46,7 @@ public class TripPlaceQueryServiceTest {
                 .places(places)
                 .build();
 
-        given(tripDayPlaceService.readByTripId(tripId)).willReturn(List.of(tripDayPlace));
+        given(tripDayPlaceService.readByTripIdSortedByOrder(tripId)).willReturn(List.of(tripDayPlace));
 
         // when
         List<TripPlaceRes.TripDayPlaceInfo> result = tripPlaceQueryService.getTripDayPlacesInfo(tripId);
@@ -74,7 +74,7 @@ public class TripPlaceQueryServiceTest {
                     .places(places)
                     .build();
 
-            given(tripDayPlaceService.readById(tripDayPlaceId)).willReturn(Optional.of(tripDayPlace));
+            given(tripDayPlaceService.readByIdSortedByOrder(tripDayPlaceId)).willReturn(Optional.of(tripDayPlace));
 
             // when
             List<TripPlaceRes.PlaceDetails> result = tripPlaceQueryService.getPlaceDetailsInfo(tripDayPlaceId);
@@ -91,7 +91,7 @@ public class TripPlaceQueryServiceTest {
         void getPlaceDetailsInfoFail() {
             // given
             String tripDayPlaceId = "non-existent";
-            given(tripDayPlaceService.readById(tripDayPlaceId)).willReturn(Optional.empty());
+            given(tripDayPlaceService.readByIdSortedByOrder(tripDayPlaceId)).willReturn(Optional.empty());
 
             // when
             CustomException e = assertThrows(CustomException.class, () ->

--- a/src/test/java/kr/co/yeogiga/presentation/image/controller/ImageControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/image/controller/ImageControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.image.dto.ImageUrlDto;
 import kr.co.yeogiga.application.image.service.ImageDeleteProcessor;
 import kr.co.yeogiga.application.image.service.ImageUploadProcessor;
+import kr.co.yeogiga.application.trip.service.TripPlaceImageService;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
 import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +50,9 @@ public class ImageControllerTest {
     @MockBean
     private ImageDeleteProcessor imageDeleteProcessor;
 
+    @MockBean
+    private TripPlaceImageService tripPlaceImageService;
+
     private final Long tripId = 1L;
     private final String tripDayPlaceId = "trip-day-place-id";
 
@@ -84,6 +88,24 @@ public class ImageControllerTest {
         resultActions
                 .andDo(print())
                 .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
+    }
+
+    @Test
+    @DisplayName("이미지 매칭 테스트")
+    void assigneImageTest() throws Exception {
+        // given
+
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                multipart("/api/v1/trip/{tripId}/images/{tripDayPlaceId}/assign", tripId, tripDayPlaceId)
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
     }
 

--- a/src/test/java/kr/co/yeogiga/presentation/image/controller/ImageControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/image/controller/ImageControllerTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.image.dto.ImageUrlDto;
 import kr.co.yeogiga.application.image.service.ImageDeleteProcessor;
 import kr.co.yeogiga.application.image.service.ImageUploadProcessor;
-import kr.co.yeogiga.application.trip.service.TripPlaceImageService;
+import kr.co.yeogiga.application.image.service.TempImageAssignProcessor;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
 import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,7 +51,7 @@ public class ImageControllerTest {
     private ImageDeleteProcessor imageDeleteProcessor;
 
     @MockBean
-    private TripPlaceImageService tripPlaceImageService;
+    private TempImageAssignProcessor tempImageAssignProcessor;
 
     private final Long tripId = 1L;
     private final String tripDayPlaceId = "trip-day-place-id";
@@ -95,7 +95,6 @@ public class ImageControllerTest {
     @DisplayName("이미지 매칭 테스트")
     void assigneImageTest() throws Exception {
         // given
-
 
         // when
         ResultActions resultActions = mockMvc.perform(


### PR DESCRIPTION
## 배경
서비스 로직 구조 '이미지 임시 저장소 저장' -> '이미지 정렬 버튼' -> '이미지 목적지별 매핑'으로 진행. 해당 로직을 위한 비지니스 로직 구현.

## 작업 사항
- 여행 일정 조회 과정 중, 데이터가 없는 값 조회하도록 리팩토링 (04adf8a8bf3510e139e14f01dd69412cbbbdeb9e)
    - `Aggregation.unwind("places", true)` 와 같이 `true`를 추가함으로써 빈 값도 조회
- 이미지 임시 저장소로부터 이미지 매핑 로직 구현 (c58f49dd3af09c1f96e5ceeb1193d37ddabb6465)

## 추가 논의
- 이미지 관련 예외 클래스를 새로 추가하였습니다. 처음에는 여행 예외 처리에 추가할까 하다가 이미지는 여행과 많이 밀접하지만, 서로 다른 역할과 책임이라 생각하여 이미지 예외처리를 따로 나누었는데, 기영님은 이 구조에 대해서 어떻게 생각하시는 궁금합니다.
- 이전과 로직이 변한 부분이 좀 있습니다. 복잡한 로직에 대해 간단한 주석을 달아놨는데, 이상한 로직이 있다면 말씀해주세요!