### PR TITLE
Feature(IL-60): 이미지 이동 로직 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/image/service/TempImageAssignProcessor.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/TempImageAssignProcessor.java
@@ -22,7 +22,7 @@ public class TempImageAssignProcessor {
      */
     public void assignFromTempStorage(String tripDayPlaceId) {
         TempPlaceImages tempPlaceImages = tempPlaceImagesService.readByTripDayPlaceId(tripDayPlaceId)
-                .orElseThrow(() -> new CustomException(ImageErrorType.NOT_FOUND_TEMP_IMAGE_STORE));
+                .orElseThrow(() -> new CustomException(ImageErrorType.TEMP_IMAGE_STORE_NOT_FOUND));
 
         tripPlaceImageAssignmentService.assignImageToTripDayPlace(tripDayPlaceId, tempPlaceImages.getImages());
 

--- a/src/main/java/kr/co/yeogiga/application/image/service/TempImageAssignProcessor.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/TempImageAssignProcessor.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.application.image.service;
 
-import kr.co.yeogiga.application.trip.service.TripPlaceImageService;
+import kr.co.yeogiga.application.tripplace.service.TripPlaceImageService;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.tripplace.entity.TempPlaceImages;
 import kr.co.yeogiga.domain.tripplace.exception.ImageErrorType;

--- a/src/main/java/kr/co/yeogiga/application/image/service/TempImageAssignProcessor.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/TempImageAssignProcessor.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.application.image.service;
 
-import kr.co.yeogiga.application.tripplace.service.TripPlaceImageService;
+import kr.co.yeogiga.application.tripplace.service.TripPlaceImageAssignmentService;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.tripplace.entity.TempPlaceImages;
 import kr.co.yeogiga.domain.tripplace.exception.ImageErrorType;
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TempImageAssignProcessor {
     private final TempPlaceImagesService tempPlaceImagesService;
-    private final TripPlaceImageService tripPlaceImageService;
+    private final TripPlaceImageAssignmentService tripPlaceImageAssignmentService;
 
     /**
      * 임시 저장소로부터 이미지를 불러와 TripDayPlace에 할당하는 메서드
@@ -24,7 +24,7 @@ public class TempImageAssignProcessor {
         TempPlaceImages tempPlaceImages = tempPlaceImagesService.readByTripDayPlaceId(tripDayPlaceId)
                 .orElseThrow(() -> new CustomException(ImageErrorType.NOT_FOUND_TEMP_IMAGE_STORE));
 
-        tripPlaceImageService.assignImageToTripDayPlace(tripDayPlaceId, tempPlaceImages.getImages());
+        tripPlaceImageAssignmentService.assignImageToTripDayPlace(tripDayPlaceId, tempPlaceImages.getImages());
 
         tempPlaceImagesService.deleteById(tempPlaceImages.getId());
     }

--- a/src/main/java/kr/co/yeogiga/application/image/service/TempImageAssignProcessor.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/TempImageAssignProcessor.java
@@ -22,7 +22,7 @@ public class TempImageAssignProcessor {
      */
     public void assignFromTempStorage(String tripDayPlaceId) {
         TempPlaceImages tempPlaceImages = tempPlaceImagesService.readByTripDayPlaceId(tripDayPlaceId)
-                .orElseThrow(() -> new CustomException(ImageErrorType.TEMP_IMAGE_STORE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ImageErrorType.TEMP_IMAGE_NOT_FOUND));
 
         tripPlaceImageAssignmentService.assignImageToTripDayPlace(tripDayPlaceId, tempPlaceImages.getImages());
 

--- a/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceImageDto.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceImageDto.java
@@ -1,23 +1,38 @@
 package kr.co.yeogiga.application.tripplace.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public class TripPlaceImageDto {
 
+    @Schema(name = "TripPlaceImageDto.ImageMoveReq", description = "같은 날짜 내 이미지 이동 요청 DTO")
     public record ImageMoveReq(
+            @Schema(description = "이미지가 현재 속한 목적지 ID", example = "place1-id")
             String fromPlaceId,
+            @Schema(description = "이미지를 옮길 목적지 ID", example = "place2-id")
             String toPlaceId,
+            @Schema(description = "이동할 이미지 ID", example = "image-id")
             String imageId
     ) { }
 
+    @Schema(name = "TripPlaceImageDto.ImageCrossDayMoveReq", description = "다른 날짜 간 이미지 이동 요청 DTO")
     public record ImageCrossDayMoveReq(
+            @Schema(description = "이미지가 속한 원본 TripDayPlace ID", example = "trip-day-1-id")
             String fromTripDayPlaceId,
+            @Schema(description = "이미지가 현재 속한 목적지 ID", example = "place1-id")
             String fromPlaceId,
+            @Schema(description = "이미지를 이동할 TripDayPlace ID", example = "trip-day-2-id")
             String toTripDayPlaceId,
+            @Schema(description = "이미지를 옮길 목적지 ID", example = "place2-id")
             String toPlaceId,
+            @Schema(description = "이동할 이미지 ID", example = "image-id")
             String imageId
     ) { }
 
+    @Schema(name = "TripPlaceImageDto.ImageUnmatchedMoveReq", description = "Unmatched <-> 목적지 이미지 이동 요청 DTO")
     public record ImageUnmatchedMoveReq(
+            @Schema(description = "대상 Place ID (Unmatched <-> Place 이동 시 Place ID)", example = "place1-id")
             String placeId,
+            @Schema(description = "이동할 이미지 ID", example = "image-id")
             String imageId
     ) { }
 }

--- a/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceImageDto.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceImageDto.java
@@ -1,0 +1,23 @@
+package kr.co.yeogiga.application.tripplace.dto;
+
+public class TripPlaceImageDto {
+
+    public record ImageMoveReq(
+            String fromPlaceId,
+            String toPlaceId,
+            String imageId
+    ) { }
+
+    public record ImageCrossDayMoveReq(
+            String fromTripDayPlaceId,
+            String fromPlaceId,
+            String toTripDayPlaceId,
+            String toPlaceId,
+            String imageId
+    ) { }
+
+    public record ImageUnmatchedMoveReq(
+            String placeId,
+            String imageId
+    ) { }
+}

--- a/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceReq.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceReq.java
@@ -1,4 +1,4 @@
-package kr.co.yeogiga.application.trip.dto;
+package kr.co.yeogiga.application.tripplace.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import kr.co.yeogiga.domain.tripplace.entity.Place;

--- a/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceRes.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceRes.java
@@ -1,4 +1,4 @@
-package kr.co.yeogiga.application.trip.dto;
+package kr.co.yeogiga.application.tripplace.dto;
 
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandService.java
@@ -1,6 +1,6 @@
-package kr.co.yeogiga.application.trip.service;
+package kr.co.yeogiga.application.tripplace.service;
 
-import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.entity.Place;

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandService.java
@@ -91,7 +91,7 @@ public class TripPlaceCommandService {
      */
     public void reorderPlaces(String tripDayPlaceId, TripPlaceReq.ReorderRequest reorderRequest) {
         TripDayPlace tripDayPlace = tripDayPlaceService.readById(tripDayPlaceId)
-                .orElseThrow(() -> new CustomException(TripErrorType.DAY_PLACE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(TripErrorType.TRIP_PLACE_NOT_FOUND));
 
         Map<String, Place> placeMap = tripDayPlace.getPlaces().stream()
                 .collect(Collectors.toMap(Place::getId, Function.identity()));

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingService.java
@@ -1,6 +1,6 @@
-package kr.co.yeogiga.application.trip.service;
+package kr.co.yeogiga.application.tripplace.service;
 
-import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.infrastructure.redis.RedisRepository;

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingService.java
@@ -59,7 +59,7 @@ public class TripPlaceEditingService {
 
         TripPlaceReq.StoredFormat place = findPlaceInList(tempListKey, placeId);
         if (place == null) {
-            throw new CustomException(TripErrorType.NOT_FOUND_TEMP_PLACE);
+            throw new CustomException(TripErrorType.TEMP_PLACE_NOT_FOUND);
         }
 
         String placeUniqueKey = makeUniqueKey(place.name(), place.latitude(), place.longitude());

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageAssignmentService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageAssignmentService.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
-public class TripPlaceImageService {
+public class TripPlaceImageAssignmentService {
     private final TripDayPlaceService tripDayPlaceService;
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageAssignmentService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageAssignmentService.java
@@ -29,7 +29,7 @@ public class TripPlaceImageAssignmentService {
      */
     public void assignImageToTripDayPlace(String tripDayPlaceId, List<Image> images) {
         TripDayPlace tripDayPlace = tripDayPlaceService.readById(tripDayPlaceId)
-                .orElseThrow(() -> new CustomException(TripErrorType.DAY_PLACE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(TripErrorType.TRIP_PLACE_NOT_FOUND));
 
         // GPS 정보를 기준으로 가장 가까운 장소별로 이미지 그룹핑
         List<Image> unmatchedImages = new ArrayList<>();

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageCommandService.java
@@ -1,0 +1,104 @@
+package kr.co.yeogiga.application.tripplace.service;
+
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceImageDto;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.tripplace.entity.Image;
+import kr.co.yeogiga.domain.tripplace.entity.Place;
+import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
+import kr.co.yeogiga.domain.tripplace.exception.ImageErrorType;
+import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TripPlaceImageCommandService {
+    private final TripDayPlaceService tripDayPlaceService;
+
+    /**
+     * 특정 Place의 이미지를 다른 Place로 이동시키는 메서드
+     *
+     * @param tripDayPlaceId TripDayPlace 문서 ID
+     * @param imageReq       이미지 이동에 필요한 정보를 담은 요청 DTO
+     */
+    public void moveImageToAnotherPlace(String tripDayPlaceId, TripPlaceImageDto.ImageMoveReq imageReq) {
+        Image image = getImageFromTripPlace(tripDayPlaceId, imageReq.fromPlaceId(), imageReq.imageId());
+
+        tripDayPlaceService.deleteImage(tripDayPlaceId, imageReq.fromPlaceId(), imageReq.imageId());
+        tripDayPlaceService.saveImage(tripDayPlaceId, imageReq.toPlaceId(), image);
+    }
+
+    /**
+     * 서로 다른 TripDayPlace 간에 이미지를 이동하는 메서드
+     *
+     * @param imageReq 이미지 이동에 필요한 정보를 담은 요청 DTO
+     */
+    public void moveImageBetweenDayPlaces(TripPlaceImageDto.ImageCrossDayMoveReq imageReq) {
+        Image image = getImageFromTripPlace(imageReq.fromTripDayPlaceId(), imageReq.fromPlaceId(), imageReq.imageId());
+
+        tripDayPlaceService.deleteImage(imageReq.fromTripDayPlaceId(), imageReq.fromPlaceId(), imageReq.imageId());
+        tripDayPlaceService.saveImage(imageReq.toTripDayPlaceId(), imageReq.toPlaceId(), image);
+    }
+
+    /**
+     * 특정 Place에 있는 이미지를 Unmatched(기타) 영역으로 이동시키는 메서드
+     *
+     * @param tripDayPlaceId TripDayPlace 문서 ID
+     * @param imageReq       이미지 이동에 필요한 정보를 담은 요청 DTO
+     */
+    public void moveImageToUnmatched(String tripDayPlaceId, TripPlaceImageDto.ImageUnmatchedMoveReq imageReq) {
+        Image image = getImageFromTripPlace(tripDayPlaceId, imageReq.placeId(), imageReq.imageId());
+
+        tripDayPlaceService.deleteImage(tripDayPlaceId, imageReq.placeId(), imageReq.imageId());
+        tripDayPlaceService.saveImageToUnmatched(tripDayPlaceId, image);
+    }
+
+    /**
+     * Unmatched(기타) 영역의 이미지를 특정 Place로 이동시키는 메서드
+     *
+     * @param tripDayPlaceId TripDayPlace 문서 ID
+     * @param imageReq       이미지 이동에 필요한 정보를 담은 요청 DTO
+     */
+    public void moveImageFromUnmatchedToPlace(String tripDayPlaceId, TripPlaceImageDto.ImageUnmatchedMoveReq imageReq) {
+        TripDayPlace tripDayPlace = getTripDayPlaceById(tripDayPlaceId);
+
+        Image image = tripDayPlace.getUnmatchedImages().stream()
+                .filter(i -> i.getId().equals(imageReq.imageId()))
+                .findFirst().orElseThrow(() -> new CustomException(ImageErrorType.NOT_FOUND));
+
+        tripDayPlaceService.deleteImageFromUnMatched(tripDayPlaceId, imageReq.imageId());
+        tripDayPlaceService.saveImage(tripDayPlaceId, imageReq.placeId(), image);
+    }
+
+    /**
+     * TripDayPlace 문서 내 특정 Place의 이미지 목록에서 주어진 이미지 ID에 해당하는 이미지를 조회 메서드
+     *
+     * @param tripDayPlaceId TripDayPlace 문서 ID
+     * @param placeId        이미지가 속한 Place ID
+     * @param imageId        조회할 이미지 ID
+     * @return 조회된 이미지
+     */
+    private Image getImageFromTripPlace(String tripDayPlaceId, String placeId, String imageId) {
+        TripDayPlace tripDayPlace = getTripDayPlaceById(tripDayPlaceId);
+
+        Place place = tripDayPlace.getPlaces().stream()
+                .filter(p -> p.getId().equals(placeId))
+                .findFirst().orElseThrow(() -> new CustomException(TripErrorType.PLACE_NOT_FOUND));
+
+        return place.getImages().stream()
+                .filter(i -> i.getId().equals(imageId))
+                .findFirst().orElseThrow(() -> new CustomException(ImageErrorType.NOT_FOUND));
+    }
+
+    /**
+     * TripDayPlace 문서를 ID로 조회하는 메서드
+     *
+     * @param tripDayPlaceId TripDayPlace 문서 ID
+     * @return TripDayPlace 객체
+     */
+    private TripDayPlace getTripDayPlaceById(String tripDayPlaceId) {
+        return tripDayPlaceService.readById(tripDayPlaceId)
+                .orElseThrow(() -> new CustomException(TripErrorType.DAY_PLACE_NOT_FOUND));
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageMovementService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageMovementService.java
@@ -99,6 +99,6 @@ public class TripPlaceImageMovementService {
      */
     private TripDayPlace getTripDayPlaceById(String tripDayPlaceId) {
         return tripDayPlaceService.readById(tripDayPlaceId)
-                .orElseThrow(() -> new CustomException(TripErrorType.DAY_PLACE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(TripErrorType.TRIP_PLACE_NOT_FOUND));
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageMovementService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageMovementService.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class TripPlaceImageCommandService {
+public class TripPlaceImageMovementService {
     private final TripDayPlaceService tripDayPlaceService;
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageService.java
@@ -1,4 +1,4 @@
-package kr.co.yeogiga.application.trip.service;
+package kr.co.yeogiga.application.tripplace.service;
 
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceQueryService.java
@@ -39,7 +39,7 @@ public class TripPlaceQueryService {
      */
     public List<TripPlaceRes.PlaceDetails> getPlaceDetailsInfo(String tripDayPlaceId) {
         TripDayPlace tripDayPlace = tripDayPlaceService.readByIdSortedByOrder(tripDayPlaceId)
-                .orElseThrow(() -> new CustomException(TripErrorType.DAY_PLACE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(TripErrorType.TRIP_PLACE_NOT_FOUND));
 
         return tripDayPlace.getPlaces().stream()
                 .map(TripPlaceRes.PlaceDetails::from)

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceQueryService.java
@@ -1,6 +1,6 @@
-package kr.co.yeogiga.application.trip.service;
+package kr.co.yeogiga.application.tripplace.service;
 
-import kr.co.yeogiga.application.trip.dto.TripPlaceRes;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingService.java
@@ -1,6 +1,6 @@
-package kr.co.yeogiga.application.trip.service;
+package kr.co.yeogiga.application.tripplace.service;
 
-import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;

--- a/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
@@ -13,7 +13,8 @@ public enum TripErrorType implements BaseErrorType {
     INVALID_PLACE(HttpStatus.BAD_REQUEST, "T001", "지원하지 않는 카테고리입니다."),
     ALREADY_ADDED_PLACE(HttpStatus.CONFLICT, "T002", "이미 추가된 장소입니다."),
     DAY_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "T003", "해당 여행 일차 정보가 존재하지 않습니다."),
-    NOT_FOUND_TEMP_PLACE(HttpStatus.NOT_FOUND, "T004", "임시 저장소에 해당 장소가 존재하지 않습니다.")
+    NOT_FOUND_TEMP_PLACE(HttpStatus.NOT_FOUND, "T004", "임시 저장소에 해당 장소가 존재하지 않습니다."),
+    PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "T005", "해당 목적지가 존재하지 않습니다")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
@@ -12,8 +12,8 @@ public enum TripErrorType implements BaseErrorType {
 
     INVALID_PLACE(HttpStatus.BAD_REQUEST, "T001", "지원하지 않는 카테고리입니다."),
     ALREADY_ADDED_PLACE(HttpStatus.CONFLICT, "T002", "이미 추가된 장소입니다."),
-    DAY_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "T003", "해당 여행 일차 정보가 존재하지 않습니다."),
-    NOT_FOUND_TEMP_PLACE(HttpStatus.NOT_FOUND, "T004", "임시 저장소에 해당 장소가 존재하지 않습니다."),
+    TRIP_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "T003", "해당 여행 일차 정보가 존재하지 않습니다."),
+    TEMP_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "T004", "임시 저장소에 해당 장소가 존재하지 않습니다."),
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "T005", "해당 목적지가 존재하지 않습니다")
     ;
 

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/exception/ImageErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/exception/ImageErrorType.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ImageErrorType implements BaseErrorType {
 
-    NOT_FOUND_TEMP_IMAGE_STORE(HttpStatus.NOT_FOUND, "I000", "임시 저장된 이미지가 존재하지 않습니다."),
+    TEMP_IMAGE_STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "I000", "임시 저장된 이미지가 존재하지 않습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "I001", "해당 이미지가 존재하지 않습니다.")
     ;
 

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/exception/ImageErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/exception/ImageErrorType.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ImageErrorType implements BaseErrorType {
 
-    TEMP_IMAGE_STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "I000", "임시 저장된 이미지가 존재하지 않습니다."),
+    TEMP_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "I000", "임시 저장된 이미지가 존재하지 않습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "I001", "해당 이미지가 존재하지 않습니다.")
     ;
 

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/exception/ImageErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/exception/ImageErrorType.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ImageErrorType implements BaseErrorType {
 
-    NOT_FOUND_TEMP_IMAGE_STORE(HttpStatus.NOT_FOUND, "I000", "임시 저장된 이미지가 존재하지 않습니다.");
+    NOT_FOUND_TEMP_IMAGE_STORE(HttpStatus.NOT_FOUND, "I000", "임시 저장된 이미지가 존재하지 않습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "I001", "해당 이미지가 존재하지 않습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.domain.tripplace.repository;
 
+import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 
@@ -8,8 +9,12 @@ import java.util.Optional;
 
 public interface CustomTripDayPlaceRepository {
     void savePlace(String id, Place place);
-    void deletePlace(String id, String placeId);
+    void saveImage(String id, String placeId, Image image);
+    void saveImageToUnmatched(String id, Image image);
     Double findOrderByIdAndPlaceId(String id, String placeId);
     Optional<TripDayPlace> findByIdSorted(String id);
     List<TripDayPlace> findByTripIdSorted(Long tripId);
+    void deletePlace(String id, String placeId);
+    void deleteImage(String id, String placeId, String imageId);
+    void deleteImageFromUnMatched(String id, String imageId);
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.domain.tripplace.repository;
 
+import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import lombok.RequiredArgsConstructor;
@@ -26,9 +27,19 @@ public class CustomTripDayPlaceRepositoryImpl implements CustomTripDayPlaceRepos
     }
 
     @Override
-    public void deletePlace(String id, String placeId) {
-        Query query = new Query(Criteria.where("_id").is(id));
-        Update update = new Update().pull("places", Query.query(Criteria.where("id").is(placeId)));
+    public void saveImage(String id, String placeId, Image image) {
+        Query query = Query.query(
+                Criteria.where("_id").is(id)
+                        .and("places.id").is(placeId)
+        );
+        Update update = new Update().push("places.$.images", image);
+        mongoTemplate.updateFirst(query, update, TripDayPlace.class);
+    }
+
+    @Override
+    public void saveImageToUnmatched(String id, Image image) {
+        Query query = Query.query(Criteria.where("_id").is(id));
+        Update update = new Update().push("unmatchedImages", image);
         mongoTemplate.updateFirst(query, update, TripDayPlace.class);
     }
 
@@ -87,5 +98,29 @@ public class CustomTripDayPlaceRepositoryImpl implements CustomTripDayPlaceRepos
         return results.getMappedResults();
     }
 
+    @Override
+    public void deletePlace(String id, String placeId) {
+        Query query = new Query(Criteria.where("_id").is(id));
+        Update update = new Update().pull("places", Query.query(Criteria.where("id").is(placeId)));
+        mongoTemplate.updateFirst(query, update, TripDayPlace.class);
+    }
 
+    @Override
+    public void deleteImage(String id, String placeId, String imageId) {
+        Query query = new Query(
+                Criteria.where("_id").is(id)
+                        .and("places.id").is(placeId)
+        );
+
+        Update update = new Update()
+                .pull("places.$.images", Query.query(Criteria.where("id").is(imageId)));
+        mongoTemplate.updateFirst(query, update, TripDayPlace.class);
+    }
+
+    @Override
+    public void deleteImageFromUnMatched(String id, String imageId) {
+        Query query = Query.query(Criteria.where("_id").is(id));
+        Update update = new Update().pull("unmatchedImages", Query.query(Criteria.where("id").is(imageId)));
+        mongoTemplate.updateFirst(query, update, TripDayPlace.class);
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.domain.tripplace.service;
 
+import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import kr.co.yeogiga.domain.tripplace.repository.TripDayPlaceRepository;
@@ -26,6 +27,14 @@ public class TripDayPlaceService {
         tripDayPlaceRepository.savePlace(id, place);
     }
 
+    public void saveImage(String id, String placeId, Image image) {
+        tripDayPlaceRepository.saveImage(id, placeId, image);
+    }
+
+    public void saveImageToUnmatched(String id, Image image) {
+        tripDayPlaceRepository.saveImageToUnmatched(id, image);
+    }
+
     public Optional<TripDayPlace> readById(String id) {
         return tripDayPlaceRepository.findById(id);
     }
@@ -44,5 +53,13 @@ public class TripDayPlaceService {
 
     public void deletePlace(String id, String placeId) {
         tripDayPlaceRepository.deletePlace(id, placeId);
+    }
+
+    public void deleteImage(String id, String placeId, String imageId) {
+        tripDayPlaceRepository.deleteImage(id, placeId, imageId);
+    }
+
+    public void deleteImageFromUnMatched(String id, String imageId) {
+        tripDayPlaceRepository.deleteImageFromUnMatched(id, imageId);
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/image/api/TripPlaceImageMovementApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/image/api/TripPlaceImageMovementApi.java
@@ -1,0 +1,178 @@
+package kr.co.yeogiga.presentation.image.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceImageDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@ApiGroup(value = "[이미지 위치 이동 API]")
+@Tag(name = "[이미지 위치 이동 API]", description = "이미지 위치 이동 관련 API")
+public interface TripPlaceImageMovementApi {
+
+    @TrackApi(description = "같은 날짜 목적지 to 목적지")
+    @Operation(summary = "같은 날짜 목적지 to 목적지", description = "같은 날짜 목적지 to 목적지 이동하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이미지 이동 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "찾을 수 없는 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "여행 일차 존재하지 않음", value = """
+                                        {
+                                            "code": "T003",
+                                            "message": "해당 여행 일차 정보가 존재하지 않습니다."
+                                        }
+                                    """),
+                            @ExampleObject(name = "목적지 존재하지 않음", value = """
+                                        {
+                                             "code": "T005",
+                                             "message": "해당 목적지가 존재하지 않습니다"
+                                        }
+                                    """),
+                            @ExampleObject(name = "이미지 존재하지 않음", value = """
+                                        {
+                                             "code": "I001",
+                                             "message": "해당 이미지가 존재하지 않습니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> moveImageToAnotherPlace(
+            @PathVariable Long tripId,
+            @PathVariable String tripDayPlaceId,
+            @RequestBody TripPlaceImageDto.ImageMoveReq imageReq
+    );
+
+    @TrackApi(description = "다른 날짜 목적지 to 목적지")
+    @Operation(summary = "다른 날짜 목적지 to 목적지", description = "다른 날짜 목적지 to 목적지 이동하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이미지 이동 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "찾을 수 없는 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "여행 일차 존재하지 않음", value = """
+                                        {
+                                            "code": "T003",
+                                            "message": "해당 여행 일차 정보가 존재하지 않습니다."
+                                        }
+                                    """),
+                            @ExampleObject(name = "목적지 존재하지 않음", value = """
+                                        {
+                                             "code": "T005",
+                                             "message": "해당 목적지가 존재하지 않습니다"
+                                        }
+                                    """),
+                            @ExampleObject(name = "이미지 존재하지 않음", value = """
+                                        {
+                                             "code": "I001",
+                                             "message": "해당 이미지가 존재하지 않습니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> moveImageBetweenDayPlaces(
+            @PathVariable Long tripId,
+            @RequestBody TripPlaceImageDto.ImageCrossDayMoveReq imageReq
+    );
+
+    @TrackApi(description = "같은 날짜 목적지 to unmatched(기타)")
+    @Operation(summary = "같은 날짜 목적지 to unmatched(기타)", description = "같은 날짜 목적지 to unmatched(기타) 이동하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이미지 이동 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "찾을 수 없는 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "여행 일차 존재하지 않음", value = """
+                                        {
+                                            "code": "T003",
+                                            "message": "해당 여행 일차 정보가 존재하지 않습니다."
+                                        }
+                                    """),
+                            @ExampleObject(name = "목적지 존재하지 않음", value = """
+                                        {
+                                             "code": "T005",
+                                             "message": "해당 목적지가 존재하지 않습니다"
+                                        }
+                                    """),
+                            @ExampleObject(name = "이미지 존재하지 않음", value = """
+                                        {
+                                             "code": "I001",
+                                             "message": "해당 이미지가 존재하지 않습니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> moveImageToUnmatched(
+            @PathVariable Long tripId,
+            @PathVariable String tripDayPlaceId,
+            @RequestBody TripPlaceImageDto.ImageUnmatchedMoveReq imageReq
+    );
+
+    @TrackApi(description = "같은 날짜 unmatched(기타) to 목적지")
+    @Operation(summary = "같은 날짜 unmatched(기타) to 목적지", description = "같은 날짜 unmatched(기타) to 목적지 이동하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이미지 이동 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "찾을 수 없는 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "여행 일차 존재하지 않음", value = """
+                                        {
+                                            "code": "T003",
+                                            "message": "해당 여행 일차 정보가 존재하지 않습니다."
+                                        }
+                                    """),
+                            @ExampleObject(name = "목적지 존재하지 않음", value = """
+                                        {
+                                             "code": "T005",
+                                             "message": "해당 목적지가 존재하지 않습니다"
+                                        }
+                                    """),
+                            @ExampleObject(name = "이미지 존재하지 않음", value = """
+                                        {
+                                             "code": "I001",
+                                             "message": "해당 이미지가 존재하지 않습니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> moveImageFromUnmatched(
+            @PathVariable Long tripId,
+            @PathVariable String tripDayPlaceId,
+            @RequestBody TripPlaceImageDto.ImageUnmatchedMoveReq imageReq
+    );
+}

--- a/src/main/java/kr/co/yeogiga/presentation/image/controller/TripPlaceImageMovementController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/image/controller/TripPlaceImageMovementController.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.presentation.image.controller;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceImageDto;
 import kr.co.yeogiga.application.tripplace.service.TripPlaceImageMovementService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.presentation.image.api.TripPlaceImageMovementApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -14,9 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/trip")
 @RequiredArgsConstructor
-public class TripPlaceImageMovementController {
+public class TripPlaceImageMovementController implements TripPlaceImageMovementApi {
     private final TripPlaceImageMovementService tripPlaceImageMovementService;
 
+    @Override
     @PatchMapping("/{tripId}/images/{tripDayPlaceId}/move")
     public ResponseEntity<?> moveImageToAnotherPlace(
             @PathVariable Long tripId,
@@ -27,6 +29,7 @@ public class TripPlaceImageMovementController {
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 
+    @Override
     @PatchMapping("/{tripId}/images/move-between-days")
     public ResponseEntity<?> moveImageBetweenDayPlaces(
             @PathVariable Long tripId,
@@ -36,6 +39,7 @@ public class TripPlaceImageMovementController {
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 
+    @Override
     @PatchMapping("/{tripId}/images/{tripDayPlaceId}/move-to-unmatched")
     public ResponseEntity<?> moveImageToUnmatched(
             @PathVariable Long tripId,
@@ -46,6 +50,7 @@ public class TripPlaceImageMovementController {
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 
+    @Override
     @PatchMapping("/{tripId}/images/{tripDayPlaceId}/move-from-unmatched")
     public ResponseEntity<?> moveImageFromUnmatched(
             @PathVariable Long tripId,

--- a/src/main/java/kr/co/yeogiga/presentation/image/controller/TripPlaceImageMovementController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/image/controller/TripPlaceImageMovementController.java
@@ -1,0 +1,58 @@
+package kr.co.yeogiga.presentation.image.controller;
+
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceImageDto;
+import kr.co.yeogiga.application.tripplace.service.TripPlaceImageMovementService;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/trip")
+@RequiredArgsConstructor
+public class TripPlaceImageMovementController {
+    private final TripPlaceImageMovementService tripPlaceImageMovementService;
+
+    @PatchMapping("/{tripId}/images/{tripDayPlaceId}/move")
+    public ResponseEntity<?> moveImageToAnotherPlace(
+            @PathVariable Long tripId,
+            @PathVariable String tripDayPlaceId,
+            @RequestBody TripPlaceImageDto.ImageMoveReq imageReq
+    ) {
+        tripPlaceImageMovementService.moveImageToAnotherPlace(tripDayPlaceId, imageReq);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+
+    @PatchMapping("/{tripId}/images/move-between-days")
+    public ResponseEntity<?> moveImageBetweenDayPlaces(
+            @PathVariable Long tripId,
+            @RequestBody TripPlaceImageDto.ImageCrossDayMoveReq imageReq
+    ) {
+        tripPlaceImageMovementService.moveImageBetweenDayPlaces(imageReq);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+
+    @PatchMapping("/{tripId}/images/{tripDayPlaceId}/move-to-unmatched")
+    public ResponseEntity<?> moveImageToUnmatched(
+            @PathVariable Long tripId,
+            @PathVariable String tripDayPlaceId,
+            @RequestBody TripPlaceImageDto.ImageUnmatchedMoveReq imageReq
+    ) {
+        tripPlaceImageMovementService.moveImageToUnmatched(tripDayPlaceId, imageReq);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+
+    @PatchMapping("/{tripId}/images/{tripDayPlaceId}/move-from-unmatched")
+    public ResponseEntity<?> moveImageFromUnmatched(
+            @PathVariable Long tripId,
+            @PathVariable String tripDayPlaceId,
+            @RequestBody TripPlaceImageDto.ImageUnmatchedMoveReq imageReq
+    ) {
+        tripPlaceImageMovementService.moveImageFromUnmatchedToPlace(tripDayPlaceId, imageReq);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceApi.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripPlaceEditingApi.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceController.java
@@ -1,9 +1,9 @@
 package kr.co.yeogiga.presentation.trip.controller;
 
-import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
-import kr.co.yeogiga.application.trip.service.TripPlaceCommandService;
-import kr.co.yeogiga.application.trip.service.TripPlaceQueryService;
-import kr.co.yeogiga.application.trip.service.TripPlaceSavingService;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.service.TripPlaceCommandService;
+import kr.co.yeogiga.application.tripplace.service.TripPlaceQueryService;
+import kr.co.yeogiga.application.tripplace.service.TripPlaceSavingService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.presentation.trip.api.TripPlaceApi;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingController.java
@@ -1,7 +1,7 @@
 package kr.co.yeogiga.presentation.trip.controller;
 
-import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
-import kr.co.yeogiga.application.trip.service.TripPlaceEditingService;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.service.TripPlaceEditingService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.presentation.trip.api.TripPlaceEditingApi;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandServiceTest.java
@@ -181,7 +181,7 @@ public class TripPlaceCommandServiceTest {
                     tripPlaceCommandService.reorderPlaces(tripDayPlaceId, reorderRequest));
 
             // then
-            assertEquals(TripErrorType.DAY_PLACE_NOT_FOUND, e.getErrorType());
+            assertEquals(TripErrorType.TRIP_PLACE_NOT_FOUND, e.getErrorType());
         }
     }
 

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandServiceTest.java
@@ -1,6 +1,6 @@
-package kr.co.yeogiga.application.trip.service;
+package kr.co.yeogiga.application.tripplace.service;
 
-import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.entity.Place;

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingServiceTest.java
@@ -1,6 +1,6 @@
-package kr.co.yeogiga.application.trip.service;
+package kr.co.yeogiga.application.tripplace.service;
 
-import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingServiceTest.java
@@ -162,7 +162,7 @@ public class TripPlaceEditingServiceTest {
             );
 
             // then
-            assertEquals(TripErrorType.NOT_FOUND_TEMP_PLACE, exception.getErrorType());
+            assertEquals(TripErrorType.TEMP_PLACE_NOT_FOUND, exception.getErrorType());
         }
 
         @Test

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageAssignmentServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageAssignmentServiceTest.java
@@ -107,7 +107,7 @@ class TripPlaceImageAssignmentServiceTest {
                 () -> tripPlaceImageAssignmentService.assignImageToTripDayPlace(tripDayPlaceId, tempImages));
 
         // then
-        assertEquals(TripErrorType.DAY_PLACE_NOT_FOUND, exception.getErrorType());
+        assertEquals(TripErrorType.TRIP_PLACE_NOT_FOUND, exception.getErrorType());
     }
 }
 

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageAssignmentServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageAssignmentServiceTest.java
@@ -27,13 +27,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-class TripPlaceImageServiceTest {
+class TripPlaceImageAssignmentServiceTest {
 
     @Mock
     private TripDayPlaceService tripDayPlaceService;
 
     @InjectMocks
-    private TripPlaceImageService tripPlaceImageService;
+    private TripPlaceImageAssignmentService tripPlaceImageAssignmentService;
 
     private final String tripDayPlaceId = "tripDayPlaceId";
 
@@ -88,7 +88,7 @@ class TripPlaceImageServiceTest {
         given(tripDayPlaceService.readById(tripDayPlaceId)).willReturn(Optional.of(tripDayPlace));
 
         // when
-        tripPlaceImageService.assignImageToTripDayPlace(tripDayPlaceId, tempImages);
+        tripPlaceImageAssignmentService.assignImageToTripDayPlace(tripDayPlaceId, tempImages);
 
         // then
         assertEquals(1, tripDayPlace.getPlaces().get(0).getImages().size());
@@ -104,7 +104,7 @@ class TripPlaceImageServiceTest {
 
         // when
         CustomException exception = assertThrows(CustomException.class,
-                () -> tripPlaceImageService.assignImageToTripDayPlace(tripDayPlaceId, tempImages));
+                () -> tripPlaceImageAssignmentService.assignImageToTripDayPlace(tripDayPlaceId, tempImages));
 
         // then
         assertEquals(TripErrorType.DAY_PLACE_NOT_FOUND, exception.getErrorType());

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageMovementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageMovementServiceTest.java
@@ -101,7 +101,7 @@ public class TripPlaceImageMovementServiceTest {
             );
 
             // then
-            assertEquals(TripErrorType.DAY_PLACE_NOT_FOUND, exception.getErrorType());
+            assertEquals(TripErrorType.TRIP_PLACE_NOT_FOUND, exception.getErrorType());
         }
 
         @Test

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageMovementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageMovementServiceTest.java
@@ -1,0 +1,204 @@
+package kr.co.yeogiga.application.tripplace.service;
+
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceImageDto;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.tripplace.entity.Image;
+import kr.co.yeogiga.domain.tripplace.entity.Place;
+import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
+import kr.co.yeogiga.domain.tripplace.exception.ImageErrorType;
+import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class TripPlaceImageMovementServiceTest {
+
+    @Mock
+    private TripDayPlaceService tripDayPlaceService;
+
+    @InjectMocks
+    private TripPlaceImageMovementService imageMovementService;
+
+    private final String tripDayPlaceId1 = "day1";
+    private final String tripDayPlaceId2 = "day2";
+    private final String fromPlaceId = "place1-id";
+    private final String toPlaceId = "place2-id";
+    private final String imageId = "image-id";
+
+    private Image buildImage() {
+        Image image = Image.builder().url("url").latitude(1.0).longitude(1.0).build();
+        ReflectionTestUtils.setField(image, "id", imageId);
+        return image;
+    }
+
+    private Place buildPlace(String id, String name, List<Image> images) {
+        Place place = Place.builder()
+                .id(id).name(name).latitude(1.0).longitude(1.0)
+                .placeType("카페").order(1)
+                .build();
+        place.addImages(images);
+        return place;
+    }
+
+    private TripDayPlace buildTripDayPlace(List<Place> places) {
+        return TripDayPlace.builder()
+                .tripId(1L).day(1)
+                .places(places)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("같은 날짜 다른 목적지 이미지 이동 테스트")
+    class MoveImageToAnotherPlaceTest {
+
+        private final TripPlaceImageDto.ImageMoveReq imageReq
+                = new TripPlaceImageDto.ImageMoveReq(fromPlaceId, toPlaceId, imageId);
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            Image image = buildImage();
+            Place from = buildPlace(fromPlaceId, "출발지", List.of(image));
+            Place to = buildPlace(toPlaceId, "도착지", List.of());
+            TripDayPlace tripDayPlace = buildTripDayPlace(List.of(from, to));
+
+            given(tripDayPlaceService.readById(tripDayPlaceId1)).willReturn(Optional.of(tripDayPlace));
+
+            // when
+            imageMovementService.moveImageToAnotherPlace(tripDayPlaceId1, imageReq);
+
+            // then
+            verify(tripDayPlaceService, times(1)).deleteImage(tripDayPlaceId1, fromPlaceId, image.getId());
+            verify(tripDayPlaceService, times(1)).saveImage(tripDayPlaceId1, toPlaceId, image);
+        }
+
+        @Test
+        @DisplayName("실패 - TripDayPlace 없음")
+        void failNotFoundTripDayPlace() {
+            // given
+            given(tripDayPlaceService.readById(tripDayPlaceId1)).willReturn(Optional.empty());
+
+            // when
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    imageMovementService.moveImageToAnotherPlace(tripDayPlaceId1, imageReq)
+            );
+
+            // then
+            assertEquals(TripErrorType.DAY_PLACE_NOT_FOUND, exception.getErrorType());
+        }
+
+        @Test
+        @DisplayName("실패 - Place 없음")
+        void failNotFoundPlace() {
+            // given
+            TripDayPlace tripDayPlace = buildTripDayPlace(List.of());
+            given(tripDayPlaceService.readById(tripDayPlaceId1)).willReturn(Optional.of(tripDayPlace));
+
+            // when
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    imageMovementService.moveImageToAnotherPlace(tripDayPlaceId1, imageReq)
+            );
+
+            // then
+            assertEquals(TripErrorType.PLACE_NOT_FOUND, exception.getErrorType());
+        }
+
+        @Test
+        @DisplayName("실패 - 이미지 없음")
+        void failNotFoundImage() {
+            // given
+            Place from = buildPlace(fromPlaceId, "목적지", List.of());
+            TripDayPlace tripDayPlace = buildTripDayPlace(List.of(from));
+            given(tripDayPlaceService.readById(tripDayPlaceId1)).willReturn(Optional.of(tripDayPlace));
+
+            // when
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    imageMovementService.moveImageToAnotherPlace(tripDayPlaceId1, imageReq)
+            );
+
+            // then
+            assertEquals(ImageErrorType.NOT_FOUND, exception.getErrorType());
+        }
+    }
+
+    @Test
+    @DisplayName("다른 날짜 간 이미지 이동 테스트")
+    void moveImageBetweenDayPlacesTest() {
+        // given
+        TripPlaceImageDto.ImageCrossDayMoveReq imageReq =
+                new TripPlaceImageDto.ImageCrossDayMoveReq(tripDayPlaceId1, fromPlaceId, tripDayPlaceId2, toPlaceId, imageId);
+
+        Image image = buildImage();
+        Place from = buildPlace(fromPlaceId, "목적지1", List.of(image));
+
+        TripDayPlace fromDay = buildTripDayPlace(List.of(from));
+
+        given(tripDayPlaceService.readById(tripDayPlaceId1)).willReturn(Optional.of(fromDay));
+
+        // when
+        imageMovementService.moveImageBetweenDayPlaces(imageReq);
+
+        // then
+        verify(tripDayPlaceService, times(1)).deleteImage(tripDayPlaceId1, fromPlaceId, imageId);
+        verify(tripDayPlaceService, times(1)).saveImage(tripDayPlaceId2, toPlaceId, image);
+    }
+
+    @Test
+    @DisplayName("이미지 Unmatched 영역으로 이동 테스트")
+    void moveImageToUnmatchedTest() {
+        // given
+        TripPlaceImageDto.ImageUnmatchedMoveReq imageReq =
+                new TripPlaceImageDto.ImageUnmatchedMoveReq(fromPlaceId, imageId);
+
+        Image image = buildImage();
+        Place from = buildPlace(fromPlaceId, "목적지", List.of(image));
+        TripDayPlace tripDayPlace = buildTripDayPlace(List.of(from));
+
+        given(tripDayPlaceService.readById(tripDayPlaceId1)).willReturn(Optional.of(tripDayPlace));
+
+        // when
+        imageMovementService.moveImageToUnmatched(tripDayPlaceId1, imageReq);
+
+        // then
+        verify(tripDayPlaceService).deleteImage(tripDayPlaceId1, fromPlaceId, imageId);
+        verify(tripDayPlaceService).saveImageToUnmatched(tripDayPlaceId1, image);
+    }
+
+    @Test
+    @DisplayName("Unmatched 영역에서 Place로 이미지 이동 테스트")
+    void MoveImageFromUnmatchedToPlaceTest() {
+        // given
+        TripPlaceImageDto.ImageUnmatchedMoveReq imageReq =
+                new TripPlaceImageDto.ImageUnmatchedMoveReq(toPlaceId, imageId);
+
+        Image image = buildImage();
+        TripDayPlace tripDayPlace = buildTripDayPlace(List.of());
+        tripDayPlace.addUnmatchedImages(List.of(image));
+
+        given(tripDayPlaceService.readById(tripDayPlaceId1)).willReturn(Optional.of(tripDayPlace));
+
+        // when
+        imageMovementService.moveImageFromUnmatchedToPlace(tripDayPlaceId1, imageReq);
+
+        // then
+        verify(tripDayPlaceService).deleteImageFromUnMatched(tripDayPlaceId1, imageId);
+        verify(tripDayPlaceService).saveImage(tripDayPlaceId1, toPlaceId, image);
+    }
+}

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageServiceTest.java
@@ -1,4 +1,4 @@
-package kr.co.yeogiga.application.trip.service;
+package kr.co.yeogiga.application.tripplace.service;
 
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceQueryServiceTest.java
@@ -97,7 +97,7 @@ public class TripPlaceQueryServiceTest {
             CustomException e = assertThrows(CustomException.class, () ->
                     tripPlaceQueryService.getPlaceDetailsInfo(tripDayPlaceId));
 
-            assertEquals(TripErrorType.DAY_PLACE_NOT_FOUND, e.getErrorType());
+            assertEquals(TripErrorType.TRIP_PLACE_NOT_FOUND, e.getErrorType());
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceQueryServiceTest.java
@@ -1,6 +1,6 @@
-package kr.co.yeogiga.application.trip.service;
+package kr.co.yeogiga.application.tripplace.service;
 
-import kr.co.yeogiga.application.trip.dto.TripPlaceRes;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.entity.Place;

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingServiceTest.java
@@ -1,6 +1,6 @@
-package kr.co.yeogiga.application.trip.service;
+package kr.co.yeogiga.application.tripplace.service;
 
-import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import kr.co.yeogiga.infrastructure.redis.RedisRepository;
 import kr.co.yeogiga.infrastructure.redis.constant.PlaceConstant;

--- a/src/test/java/kr/co/yeogiga/presentation/image/controller/TripPlaceImageMovementControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/image/controller/TripPlaceImageMovementControllerTest.java
@@ -1,0 +1,220 @@
+package kr.co.yeogiga.presentation.image.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceImageDto;
+import kr.co.yeogiga.application.tripplace.service.TripPlaceImageMovementService;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.tripplace.exception.ImageErrorType;
+import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = TripPlaceImageMovementController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthenticationFilter.class})
+        }
+)
+public class TripPlaceImageMovementControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private TripPlaceImageMovementService tripPlaceImageMovementService;
+
+    private final Long tripId = 1L;
+    private final String tripDayPlaceId = "dayId";
+    private final String fromPlaceId = "place1-id";
+    private final String toPlaceId = "place2-id";
+    private final String imageId = "image-id";
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("같은 날짜 내 이미지 이동 테스트")
+    class MoveImageToAnotherPlaceControllerTest {
+
+        private final TripPlaceImageDto.ImageMoveReq req =
+                new TripPlaceImageDto.ImageMoveReq(fromPlaceId, toPlaceId, imageId);
+
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            doNothing().when(tripPlaceImageMovementService).moveImageToAnotherPlace(tripDayPlaceId, req);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    patch("/api/v1/trip/{tripId}/images/{tripDayPlaceId}/move", tripId, tripDayPlaceId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req))
+            );
+
+            // then
+            resultActions
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
+        }
+
+        @Test
+        @DisplayName("실패 - 여행 날짜(TripDayPlace) 없음")
+        void FailNotFoundTripDayPlace() throws Exception {
+            // given
+            doThrow(new CustomException(TripErrorType.DAY_PLACE_NOT_FOUND))
+                    .when(tripPlaceImageMovementService).moveImageToAnotherPlace(tripDayPlaceId, req);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    patch("/api/v1/trip/{tripId}/images/{tripDayPlaceId}/move", tripId, tripDayPlaceId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req))
+            );
+
+            // then
+            resultActions
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(TripErrorType.DAY_PLACE_NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.message").value(TripErrorType.DAY_PLACE_NOT_FOUND.getMessage()));
+        }
+
+        @Test
+        @DisplayName("실패 - 출발지 목적지 없음")
+        void failNotFoundPlace() throws Exception {
+            // given
+            doThrow(new CustomException(TripErrorType.PLACE_NOT_FOUND))
+                    .when(tripPlaceImageMovementService).moveImageToAnotherPlace(tripDayPlaceId, req);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    patch("/api/v1/trip/{tripId}/images/{tripDayPlaceId}/move", tripId, tripDayPlaceId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req))
+            );
+
+            // then
+            resultActions
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(TripErrorType.PLACE_NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.message").value(TripErrorType.PLACE_NOT_FOUND.getMessage()));
+        }
+
+        @Test
+        @DisplayName("실패 - 이미지 없음")
+        void failNotFoundImage() throws Exception {
+            // given
+            doThrow(new CustomException(ImageErrorType.NOT_FOUND))
+                    .when(tripPlaceImageMovementService).moveImageToAnotherPlace(tripDayPlaceId, req);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    patch("/api/v1/trip/{tripId}/images/{tripDayPlaceId}/move", tripId, tripDayPlaceId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req))
+            );
+
+            // then
+            resultActions
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(ImageErrorType.NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.message").value(ImageErrorType.NOT_FOUND.getMessage()));
+        }
+    }
+
+    @Test
+    @DisplayName("다른 날짜 간 이미지 이동 성공")
+    void moveImageBetweenDayPlacesSuccess() throws Exception {
+        // given
+        TripPlaceImageDto.ImageCrossDayMoveReq req =
+                new TripPlaceImageDto.ImageCrossDayMoveReq("day1", fromPlaceId, "day2", toPlaceId, imageId);
+        doNothing().when(tripPlaceImageMovementService).moveImageBetweenDayPlaces(req);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                patch("/api/v1/trip/{tripId}/images/move-between-days", tripId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req))
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
+    }
+
+    @Test
+    @DisplayName("이미지를 Unmatched로 이동 성공")
+    void moveImageToUnmatchedSuccess() throws Exception {
+        // given
+        TripPlaceImageDto.ImageUnmatchedMoveReq req = new TripPlaceImageDto.ImageUnmatchedMoveReq(fromPlaceId, imageId);
+        doNothing().when(tripPlaceImageMovementService).moveImageToUnmatched(tripDayPlaceId, req);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                patch("/api/v1/trip/{tripId}/images/{tripDayPlaceId}/move-to-unmatched", tripId, tripDayPlaceId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req))
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
+    }
+
+    @Test
+    @DisplayName("Unmatched에서 이미지 복원 성공")
+    void moveImageFromUnmatchedToPlaceSuccess() throws Exception {
+        // given
+        TripPlaceImageDto.ImageUnmatchedMoveReq req = new TripPlaceImageDto.ImageUnmatchedMoveReq(toPlaceId, imageId);
+        doNothing().when(tripPlaceImageMovementService).moveImageFromUnmatchedToPlace(tripDayPlaceId, req);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                patch("/api/v1/trip/{tripId}/images/{tripDayPlaceId}/move-from-unmatched", tripId, tripDayPlaceId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req))
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
+    }
+}

--- a/src/test/java/kr/co/yeogiga/presentation/image/controller/TripPlaceImageMovementControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/image/controller/TripPlaceImageMovementControllerTest.java
@@ -91,7 +91,7 @@ public class TripPlaceImageMovementControllerTest {
         @DisplayName("실패 - 여행 날짜(TripDayPlace) 없음")
         void FailNotFoundTripDayPlace() throws Exception {
             // given
-            doThrow(new CustomException(TripErrorType.DAY_PLACE_NOT_FOUND))
+            doThrow(new CustomException(TripErrorType.TRIP_PLACE_NOT_FOUND))
                     .when(tripPlaceImageMovementService).moveImageToAnotherPlace(tripDayPlaceId, req);
 
             // when
@@ -105,8 +105,8 @@ public class TripPlaceImageMovementControllerTest {
             resultActions
                     .andDo(print())
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.code").value(TripErrorType.DAY_PLACE_NOT_FOUND.getCode()))
-                    .andExpect(jsonPath("$.message").value(TripErrorType.DAY_PLACE_NOT_FOUND.getMessage()));
+                    .andExpect(jsonPath("$.code").value(TripErrorType.TRIP_PLACE_NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.message").value(TripErrorType.TRIP_PLACE_NOT_FOUND.getMessage()));
         }
 
         @Test

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceControllerTest.java
@@ -186,7 +186,7 @@ public class TripPlaceControllerTest {
     void reorderPlacesFailDayPlaceNotFound() throws Exception {
         // given
         TripPlaceReq.ReorderRequest reorderRequest = new TripPlaceReq.ReorderRequest(List.of("id1", "id2"));
-        doThrow(new CustomException(TripErrorType.DAY_PLACE_NOT_FOUND))
+        doThrow(new CustomException(TripErrorType.TRIP_PLACE_NOT_FOUND))
                 .when(tripPlaceCommandService).reorderPlaces(tripDayPlaceId, reorderRequest);
 
         // when
@@ -200,8 +200,8 @@ public class TripPlaceControllerTest {
         resultActions
                 .andDo(print())
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value(TripErrorType.DAY_PLACE_NOT_FOUND.getCode()))
-                .andExpect(jsonPath("$.message").value(TripErrorType.DAY_PLACE_NOT_FOUND.getMessage()));
+                .andExpect(jsonPath("$.code").value(TripErrorType.TRIP_PLACE_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(TripErrorType.TRIP_PLACE_NOT_FOUND.getMessage()));
     }
 
     @Test

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceControllerTest.java
@@ -1,11 +1,11 @@
 package kr.co.yeogiga.presentation.trip.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
-import kr.co.yeogiga.application.trip.dto.TripPlaceRes;
-import kr.co.yeogiga.application.trip.service.TripPlaceCommandService;
-import kr.co.yeogiga.application.trip.service.TripPlaceQueryService;
-import kr.co.yeogiga.application.trip.service.TripPlaceSavingService;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
+import kr.co.yeogiga.application.tripplace.service.TripPlaceCommandService;
+import kr.co.yeogiga.application.tripplace.service.TripPlaceQueryService;
+import kr.co.yeogiga.application.tripplace.service.TripPlaceSavingService;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripPlaceEditingControllerTest.java
@@ -1,8 +1,8 @@
 package kr.co.yeogiga.presentation.trip.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.co.yeogiga.application.trip.dto.TripPlaceReq;
-import kr.co.yeogiga.application.trip.service.TripPlaceEditingService;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.service.TripPlaceEditingService;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;


### PR DESCRIPTION
## 배경
위치로 자동 매핑된 목적지별 이미지를 사용자가 옮기고 싶은 목적지로 이동이 필요.
같은 날짜 목적지간 이미지 이동,
같은 날짜 기타사진 -> 목적지,
같은 날짜 목적지 -> 기타사진,
다른 날짜 목적지간 이미지 이동

## 작업 사항
- 이미지 위치 이동을 위한 MongoDB 저장, 삭제 로직 구현 (2ee039a66d44b716bd2f0784aea58920464c1586)
- 이미지 이동을 위한 로직 구현 (544b2c33f8813b98b16a7638d4830a68da5fc99b)
  - 같은 날짜 목적지간 이미지 이동
  - 같은 날짜 기타사진 -> 목적지
  - 같은 날짜 목적지 -> 기타사진
  - 다른 날짜 목적지간 이미지 이동

## 추가 논의
현재 다른 날짜로 이미지를 이동하는 과정 중, 목적지 <-> 기타 이동이 없습니다. 추후에 필요한 경우에 넣을 예정입니다.