### PR TITLE
Feature(IL-55): 회원 탈퇴

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
@@ -9,11 +9,11 @@ public class SignInDto {
     @Builder
     @Schema(name = "SingInDto.Request", description = "일반 로그인 요청 DTO")
     public record Request(
-            @Schema(name = "아이디", example = "testid")
+            @Schema(description = "아이디", example = "testid")
             @NotBlank(message = "아이디는 필수 입력값입니다.")
             String username,
 
-            @Schema(name = "비밀번호", example = "testpw")
+            @Schema(description = "비밀번호", example = "testpw")
             @NotBlank(message = "비밀번호는 필수 입력값입니다.")
             String password
     ) {

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/SignUpDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/SignUpDto.java
@@ -13,20 +13,20 @@ public class SignUpDto {
     @Builder
     @Schema(name = "SignUpDto.Request", description = "회원가입 요청 DTO")
     public record Request(
-            @Schema(name = "아이디", example = "testid")
+            @Schema(description = "아이디", example = "testid")
             @NotBlank(message = "아이디는 필수 입력값입니다.")
             String username,
 
-            @Schema(name = "비밀번호", example = "testpw")
+            @Schema(description = "비밀번호", example = "testpw")
             @NotBlank(message = "비밀번호는 필수 입력값입니다.")
             String password,
 
-            @Schema(name = "이메일", example = "test@test.com")
+            @Schema(description = "이메일", example = "test@test.com")
             @NotBlank(message = "이메일은 필수 입력값입니다.")
             @Pattern(regexp = "^[\\w!#$%&'*+/=?`{|}~^.-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$", message = "잘못된 이메일 형식입니다.")
             String email,
 
-            @Schema(name = "닉네임", example = "testnick")
+            @Schema(description = "닉네임", example = "testnick")
             @NotBlank(message = "닉네임은 필수 입력값입니다.")
             String nickname
     ) {
@@ -42,7 +42,7 @@ public class SignUpDto {
     }
 
     public record Register(
-            @Schema(name = "닉네임", example = "testnick")
+            @Schema(description = "닉네임", example = "testnick")
             @NotBlank(message = "닉네임은 필수 입력값입니다.")
             String nickname
     ) {

--- a/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
@@ -11,6 +11,9 @@ import kr.co.yeogiga.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +29,7 @@ public class AuthService {
      * @param request           회원가입 요청 dto(username, password, email, nickname)
      * @throws CustomException  UserErrorType.ALREADY_EXISTS_USERNAME 이미 존재하는 아이디
      */
+    @Transactional
     public void signUp(SignUpDto.Request request) {
         String username = request.username();
 
@@ -36,7 +40,6 @@ public class AuthService {
         User newUser = request.toEntity(passwordEncoder.encode(request.password()));
 
         newUser.upgradeRoleToUser();
-        userService.save(newUser);
     }
 
     /**
@@ -46,10 +49,14 @@ public class AuthService {
      * @throws CustomException      AuthErrorType.AUTHENTICATION_FAIL 아이디 및 비밀번호 불일치
      * @return                      토큰(accessToken, refreshToken)
      */
+    @Transactional
     public TokenDto signIn(SignInDto.Request request) {
-        User user = userService.readByUsername(request.username())
+        User user = userService.readIncludeDeletedUserByUsername(request.username())
                 .orElseThrow(() -> new CustomException(AuthErrorType.AUTHENTICATION_FAIL));
 
+        if (Objects.nonNull(user.getDeletedAt())) {
+            user.revertWithdrawal();
+        }
 
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
             throw new CustomException(AuthErrorType.AUTHENTICATION_FAIL);

--- a/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
@@ -40,6 +40,7 @@ public class AuthService {
         User newUser = request.toEntity(passwordEncoder.encode(request.password()));
 
         newUser.upgradeRoleToUser();
+        userService.save(newUser);
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -18,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
+
 @Service
 @RequiredArgsConstructor
 public class OAuthManagementService {
@@ -68,11 +70,16 @@ public class OAuthManagementService {
      * @return              User, 추가 정보 입력 필요 여부
      */
     private UserStatusDto getUserStatus(OAuthPlatform platform, UserInfoDto userInfo) {
-        return userService.readByPlatformAndPlatformId(platform, userInfo.platformId())
-                .map(user -> user.isSignedUp()
-                        ? UserStatusDto.of(user, false)
-                        : UserStatusDto.of(user, true)
-                )
+        return userService.readIncludeDeletedUserByPlatformAndPlatformId(platform, userInfo.platformId())
+                .map(user -> {
+                    if (!Objects.isNull(user.getDeletedAt())) {
+                        user.revertWithdrawal();
+                    }
+
+                    return user.isSignedUp()
+                            ? UserStatusDto.of(user, false)
+                            : UserStatusDto.of(user, true);
+                    })
                 .orElseGet(() -> UserStatusDto.of(registerUser(platform, userInfo), true));
     }
 

--- a/src/main/java/kr/co/yeogiga/application/user/scheduler/UserScheduler.java
+++ b/src/main/java/kr/co/yeogiga/application/user/scheduler/UserScheduler.java
@@ -1,0 +1,17 @@
+package kr.co.yeogiga.application.user.scheduler;
+
+import kr.co.yeogiga.application.user.service.UserDeletionProcessor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserScheduler {
+    private final UserDeletionProcessor userDeletionProcessor;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void runUserCleanUpJob() {
+        userDeletionProcessor.process();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/user/scheduler/UserScheduler.java
+++ b/src/main/java/kr/co/yeogiga/application/user/scheduler/UserScheduler.java
@@ -10,8 +10,10 @@ import org.springframework.stereotype.Component;
 public class UserScheduler {
     private final UserDeletionProcessor userDeletionProcessor;
 
+
+    /* TODO: 개발 환경 내 유저 데이터 삭제 로직 실행 보류로 인한 차후 변경 예정
     @Scheduled(cron = "0 0 0 * * *")
     public void runUserCleanUpJob() {
         userDeletionProcessor.process();
-    }
+    }*/
 }

--- a/src/main/java/kr/co/yeogiga/application/user/service/UserDeletionProcessor.java
+++ b/src/main/java/kr/co/yeogiga/application/user/service/UserDeletionProcessor.java
@@ -1,0 +1,28 @@
+package kr.co.yeogiga.application.user.service;
+
+import kr.co.yeogiga.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class UserDeletionProcessor {
+    private final UserService userService;
+
+    @Transactional
+    public void process() {
+        LocalDate dateBeforeOneWeek = LocalDate.now().minusDays(7);
+        List<Long> userIds = userService.readDeletedUserIdBefore(dateBeforeOneWeek);
+
+        if (userIds.isEmpty()) {
+            return;
+        }
+
+        /* TODO: 차후 연관 데이터 삭제 예정*/
+        userService.deleteHardAllByIds(userIds);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/user/service/UserDeletionProcessor.java
+++ b/src/main/java/kr/co/yeogiga/application/user/service/UserDeletionProcessor.java
@@ -13,6 +13,11 @@ import java.util.List;
 public class UserDeletionProcessor {
     private final UserService userService;
 
+    /**
+     * 탈퇴 보류 기간 후 사용자 정보 완전 삭제 메서드
+     * - Soft Delete 정책에 따른 탈퇴 7일 이후 사용자 정보 삭제
+     * - 사용자 관련 정보 일괄 삭제 예졍
+     */
     @Transactional
     public void process() {
         LocalDate dateBeforeOneWeek = LocalDate.now().minusDays(7);

--- a/src/main/java/kr/co/yeogiga/application/user/service/UserDeletionProcessor.java
+++ b/src/main/java/kr/co/yeogiga/application/user/service/UserDeletionProcessor.java
@@ -16,7 +16,7 @@ public class UserDeletionProcessor {
     /**
      * 탈퇴 보류 기간 후 사용자 정보 완전 삭제 메서드
      * - Soft Delete 정책에 따른 탈퇴 7일 이후 사용자 정보 삭제
-     * - 사용자 관련 정보 일괄 삭제 예졍
+     * - 사용자 관련 정보 일괄 삭제
      */
     @Transactional
     public void process() {
@@ -27,7 +27,7 @@ public class UserDeletionProcessor {
             return;
         }
 
-        /* TODO: 차후 연관 데이터 삭제 예정*/
+        /* TODO: 차후 연관 데이터 삭제 예정 */
         userService.deleteHardAllByIds(userIds);
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
@@ -44,6 +44,11 @@ public class UserManagementService {
         user.updatePassword(passwordEncoder.encode(passwordReq.newPassword()));
     }
 
+    /**
+     * 회원탈퇴 메서드
+     *
+     * @param userId            사용자 ID
+     */
     @Transactional
     public void withdraw(Long userId) {
         User user = userService.readIncludeDeletedUserById(userId)

--- a/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.application.user.service;
 
+import kr.co.yeogiga.application.auth.service.RefreshTokenService;
 import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.user.entity.User;
@@ -10,11 +11,14 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
+
 @Service
 @RequiredArgsConstructor
 public class UserManagementService {
     private final PasswordEncoder passwordEncoder;
     private final UserService userService;
+    private final RefreshTokenService refreshTokenService;
 
     /**
      * 사용자 비밀번호 갱신 메서드
@@ -38,5 +42,18 @@ public class UserManagementService {
         }
 
         user.updatePassword(passwordEncoder.encode(passwordReq.newPassword()));
+    }
+
+    @Transactional
+    public void withdraw(Long userId) {
+        User user = userService.readIncludeDeletedUserById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
+
+        if (Objects.nonNull(user.getDeletedAt())) {
+            throw new CustomException(UserErrorType.ALREADY_WITHDRAW);
+        }
+
+        refreshTokenService.delete(userId);
+        userService.deleteById(userId);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/oauth/type/OAuthPlatform.java
+++ b/src/main/java/kr/co/yeogiga/domain/oauth/type/OAuthPlatform.java
@@ -6,9 +6,5 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum OAuthPlatform {
-    KAKAO("KAKAO"),
-    NAVER("NAVER"),
-    ;
-
-    private final String name;
+    NAVER, KAKAO;
 }

--- a/src/main/java/kr/co/yeogiga/domain/oauth/type/OAuthPlatform.java
+++ b/src/main/java/kr/co/yeogiga/domain/oauth/type/OAuthPlatform.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public enum OAuthPlatform {
     NAVER, KAKAO;
 }

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -67,4 +67,8 @@ public class User extends BaseTimeEntity {
     public void updatePassword(String password) {
         this.password = password;
     }
+
+    public void revertWithdrawal() {
+        this.deletedAt = null;
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 @Entity(name = "users")
 @DynamicUpdate
 @SQLRestriction("deleted_at IS NULL")
-@SQLDelete(sql = "UPDATE user SET deleted_at = NOW() WHERE id = ?")
+@SQLDelete(sql = "UPDATE users SET deleted_at = NOW() WHERE id = ?")
 public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kr/co/yeogiga/domain/user/exception/UserErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/exception/UserErrorType.java
@@ -12,7 +12,9 @@ public enum UserErrorType implements BaseErrorType {
     NOT_FOUND(HttpStatus.NOT_FOUND, "U000", "존재하지 않는 사용자입니다."),
     ALREADY_EXIST_USERNAME(HttpStatus.CONFLICT, "U001", "이미 존재하는 아이디입니다."),
     SAME_PASSWORD(HttpStatus.CONFLICT, "U002", "기존과 동일한 비밀번호입니다."),
-    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "U003", "비밀번호가 불일치합니다.");
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "U003", "비밀번호가 불일치합니다."),
+    ALREADY_WITHDRAW(HttpStatus.BAD_REQUEST, "U004", "이미 회원탈퇴한 사용자입니다.");
+
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
@@ -3,19 +3,38 @@ package kr.co.yeogiga.domain.user.repository;
 import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
 import kr.co.yeogiga.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    @Query("SELECT u " +
-            "FROM users u " +
-            "JOIN oauth o ON u.id = o.user.id " +
-            "WHERE o.platform = :platform AND o.platformId = :platformId")
-    Optional<User> findByPlatformAndPlatformId(@Param("platform") OAuthPlatform platform, @Param("platformId") String platformId);
+
+    @Query(value = "SELECT u.id, u.username, u.password, u.email, u.nickname, u.signed_up, u.role, u.deleted_at, u.created_at, u.modified_at " +
+                   "FROM users u " +
+                   "INNER JOIN oauth o ON u.id = o.user_id " +
+                   "WHERE o.platform = :platform AND o.platform_id = :platformId", nativeQuery = true)
+    Optional<User> findUserIncludeDeletedByPlatformAndPlatformId(@Param(value = "platform") OAuthPlatform platform, @Param("platformId") String platformId);
+
+    @Query(value = "SELECT * " +
+                   "FROM users " +
+                   "WHERE id = :id", nativeQuery = true)
+    Optional<User> findUserIncludeDeletedById(@Param(value = "id") Long id);
 
     Optional<User> findByUsername(String username);
+
+    @Query(value = "SELECT * " +
+            "FROM users " +
+            "WHERE username = :username", nativeQuery = true)
+    Optional<User> findUserIncludeDeletedByUsername(@Param(value = "username") String username);
+
+    @Query(value = "SELECT id " +
+                   "FROM users " +
+                   "WHERE deleted_at IS NOT NULL AND deleted_at <= :date", nativeQuery = true)
+    List<Long> findDeletedUserIdBefore(@Param(value = "date") LocalDate date);
 
     boolean existsByUsername(String username);
 }

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
@@ -37,4 +37,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<Long> findDeletedUserIdBefore(@Param(value = "date") LocalDate date);
 
     boolean existsByUsername(String username);
+
+    @Modifying
+    @Query(value = "DELETE " +
+            "FROM users " +
+            "WHERE id IN :ids", nativeQuery = true)
+    void deleteHardAllByIds(List<Long> ids);
 }

--- a/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
@@ -46,4 +46,13 @@ public class UserService {
     public boolean existsByUsername(String username) {
         return userRepository.existsByUsername(username);
     }
+
+
+    public void deleteById(Long userId) {
+        userRepository.deleteById(userId);
+    }
+
+    public void deleteHardAllByIds(List<Long> ids) {
+        userRepository.deleteHardAllByIds(ids);
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
@@ -6,6 +6,8 @@ import kr.co.yeogiga.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -21,12 +23,24 @@ public class UserService {
         return userRepository.findById(id);
     }
 
+    public Optional<User> readIncludeDeletedUserById(Long id) {
+        return userRepository.findUserIncludeDeletedById(id);
+    }
+
     public Optional<User> readByUsername(String username) {
         return userRepository.findByUsername(username);
     }
 
-    public Optional<User> readByPlatformAndPlatformId(OAuthPlatform platform, String platformId) {
-        return userRepository.findByPlatformAndPlatformId(platform, platformId);
+    public Optional<User> readIncludeDeletedUserByUsername(String username) {
+        return userRepository.findUserIncludeDeletedByUsername(username);
+    }
+
+    public Optional<User> readIncludeDeletedUserByPlatformAndPlatformId(OAuthPlatform platform, String platformId) {
+        return userRepository.findUserIncludeDeletedByPlatformAndPlatformId(platform, platformId);
+    }
+
+    public List<Long> readDeletedUserIdBefore(LocalDate date) {
+        return userRepository.findDeletedUserIdBefore(date);
     }
 
     public boolean existsByUsername(String username) {

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/SchedulingConfig.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package kr.co.yeogiga.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
@@ -71,4 +71,39 @@ public interface UserApi {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody PasswordUpdateReq passwordUpdateReq
     );
+
+    @TrackApi(description = "회원 탈퇴")
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "회원 탈퇴 성공", value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "회원 탈퇴 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "이미 회원 탈퇴한 사용자", value = """
+                                        {
+                                            "code": "U004",
+                                            "message": "이미 회원탈퇴한 사용자입니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "회원 탈퇴 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "존재하지 않는 사용자", value = """
+                                        {
+                                            "code": "U000",
+                                            "message": "존재하지 않는 사용자입니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> withdraw(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
 }

--- a/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
@@ -5,14 +5,19 @@ import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
 import kr.co.yeogiga.application.user.service.UserManagementService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.util.CookieUtil;
 import kr.co.yeogiga.presentation.user.api.UserApi;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static kr.co.yeogiga.application.auth.constant.AuthConstants.REFRESH_TOKEN_PREFIX;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -28,5 +33,15 @@ public class UserController implements UserApi {
     ) {
         userManagementService.updatePassword(userDetails.getUserId(), passwordUpdateReq);
         return ResponseEntity.ok(SuccessResponse.ok());
+    }
+
+    @DeleteMapping
+    public ResponseEntity<?> withdraw(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        userManagementService.withdraw(userDetails.getUserId());
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, CookieUtil.removeCookie(REFRESH_TOKEN_PREFIX).toString())
+                .body(SuccessResponse.ok());
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
@@ -35,6 +35,7 @@ public class UserController implements UserApi {
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 
+    @Override
     @DeleteMapping
     public ResponseEntity<?> withdraw(
             @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
@@ -26,6 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -98,6 +100,9 @@ public class AuthServiceTest {
     class SignUp {
 
         @Captor
+        private ArgumentCaptor<String> stringCaptor;
+
+        @Captor
         private ArgumentCaptor<User> userCaptor;
 
         @Test
@@ -113,16 +118,17 @@ public class AuthServiceTest {
 
             when(userService.existsByUsername(request.username())).thenReturn(false);
             when(passwordEncoder.encode(request.password())).thenReturn("encodedPassword");
+            doNothing().when(userService).save(any());
 
             // when
             authService.signUp(request);
 
             // then
-            verify(userService).save(userCaptor.capture());
+            verify(passwordEncoder, times(1)).encode(stringCaptor.capture());
+            verify(userService, times(1)).save(userCaptor.capture());
 
-            assertEquals(request.username(), userCaptor.getValue().getUsername());
-            assertEquals(userCaptor.getValue().isSignedUp(), true);
-            assertEquals(userCaptor.getValue().getRole(), Role.USER);
+            assertEquals("testpw", stringCaptor.getValue());
+            assertEquals("encodedPassword", userCaptor.getValue().getPassword());
         }
 
         @Test
@@ -166,7 +172,7 @@ public class AuthServiceTest {
                     .password("testpw")
                     .build();
 
-            when(userService.readByUsername(request.username())).thenReturn(Optional.of(newUser));
+            when(userService.readIncludeDeletedUserByUsername(request.username())).thenReturn(Optional.of(newUser));
             when(passwordEncoder.matches(request.password(), newUser.getPassword())).thenReturn(true);
             when(jwtService.generateToken(any(), any(), any())).thenReturn(tokenDto);
 
@@ -181,7 +187,7 @@ public class AuthServiceTest {
         @DisplayName("실패 - 존재하지 않는 아이디")
         void failSignInNotFountId() {
             // given
-            when(userService.readByUsername(request.username())).thenReturn(Optional.ofNullable(null));
+            when(userService.readIncludeDeletedUserByUsername(request.username())).thenReturn(Optional.ofNullable(null));
 
             // when
             CustomException exception = assertThrows(CustomException.class, () -> authService.signIn(request));
@@ -201,7 +207,7 @@ public class AuthServiceTest {
                     .password("testpw")
                     .build();
 
-            when(userService.readByUsername(request.username())).thenReturn(Optional.of(newUser));
+            when(userService.readIncludeDeletedUserByUsername(request.username())).thenReturn(Optional.of(newUser));
             when(passwordEncoder.matches(request.password(), newUser.getPassword())).thenReturn(false);
 
             // when

--- a/src/test/java/kr/co/yeogiga/application/user/service/UserManagementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/user/service/UserManagementServiceTest.java
@@ -137,6 +137,7 @@ public class UserManagementServiceTest {
         void failUserNotFound() {
             // given
             when(userService.readIncludeDeletedUserById(eq(userId))).thenReturn(Optional.empty());
+
             // when
             CustomException exception = assertThrows(CustomException.class, () -> userManagementService.withdraw(userId));
 

--- a/src/test/java/kr/co/yeogiga/application/user/service/UserManagementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/user/service/UserManagementServiceTest.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.application.user.service;
 
+import kr.co.yeogiga.application.auth.service.RefreshTokenService;
 import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.user.entity.User;
@@ -14,12 +15,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -32,6 +36,9 @@ public class UserManagementServiceTest {
 
     @Mock
     private UserService userService;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
 
     @InjectMocks
     private UserManagementService userManagementService;
@@ -95,5 +102,62 @@ public class UserManagementServiceTest {
             // then
             assertEquals(UserErrorType.PASSWORD_MISMATCH, exception.getErrorType());
         }
+    }
+
+    @Nested
+    @DisplayName("회원 탈퇴")
+    class Withdraw {
+        private final Long userId = 1L;
+        private final User user = User.builder()
+                .username("test")
+                .nickname("test")
+                .password("test")
+                .email("test@test.com")
+                .role(Role.USER)
+                .build();
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            when(userService.readIncludeDeletedUserById(eq(userId))).thenReturn(Optional.of(user));
+            doNothing().when(refreshTokenService).delete(eq(userId));
+            doNothing().when(userService).deleteById(eq(userId));
+
+            // when
+            userManagementService.withdraw(userId);
+
+            // then
+            verify(userService, times(1)).readIncludeDeletedUserById(eq(userId));
+            verify(refreshTokenService, times(1)).delete(eq(userId));
+            verify(userService, times(1)).deleteById(eq(userId));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 사용자")
+        void failUserNotFound() {
+            // given
+            when(userService.readIncludeDeletedUserById(eq(userId))).thenReturn(Optional.empty());
+            // when
+            CustomException exception = assertThrows(CustomException.class, () -> userManagementService.withdraw(userId));
+
+            // then
+            assertEquals(exception.getErrorType(), UserErrorType.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 회원탈퇴를 진행한 경우")
+        void failAlreadyWithdraw() {
+            // given
+            when(userService.readIncludeDeletedUserById(eq(userId))).thenReturn(Optional.of(user));
+            ReflectionTestUtils.setField(user, "deletedAt", LocalDateTime.now());
+
+            // when
+            CustomException exception = assertThrows(CustomException.class, () -> userManagementService.withdraw(userId));
+
+            // then
+            assertEquals(exception.getErrorType(), UserErrorType.ALREADY_WITHDRAW);
+        }
+
+
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/user/controller/UserControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/user/controller/UserControllerTest.java
@@ -1,8 +1,10 @@
 package kr.co.yeogiga.presentation.user.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.application.auth.constant.AuthConstants;
 import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
 import kr.co.yeogiga.application.user.service.UserManagementService;
+import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.response.error.type.CommonErrorType;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
@@ -10,6 +12,7 @@ import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
 import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
 import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.exception.UserErrorType;
 import kr.co.yeogiga.domain.user.type.Role;
 import kr.co.yeogiga.infrastructure.TestSecurityConfig;
 import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
@@ -30,12 +33,17 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -66,6 +74,7 @@ public class UserControllerTest {
                 .alwaysDo(print())
                 .apply(springSecurity())
                 .defaultRequest(patch("/**").with(csrf()))
+                .defaultRequest(delete("/**").with(csrf()))
                 .build();
     }
 
@@ -153,6 +162,91 @@ public class UserControllerTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value(CommonErrorType.VALIDATION_ERROR.getCode()))
                     .andExpect(jsonPath("$.errors").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 탈퇴")
+    class Withdraw {
+        private final Long userId = 1L;
+
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            doNothing().when(userManagementService).withdraw(userId);
+            setUpUserDetails(Role.USER);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    delete("/api/v1/users")
+                            .with(user(userDetails))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(cookie().maxAge(AuthConstants.REFRESH_TOKEN_PREFIX, 0))
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
+
+        @Test
+        @DisplayName("실패 - 접근 권한 오류")
+        void failAuthorization() throws Exception {
+            // given
+            doNothing().when(userManagementService).withdraw(userId);
+            setUpUserDetails(Role.GUEST);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    delete("/api/v1/users")
+                            .with(user(userDetails))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.message").value(AuthErrorType.UN_REGISTERED_USER.getMessage()));
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 탈퇴한 사용자")
+        void failAlreadyWithdraw() throws Exception {
+            // given
+            doThrow(new CustomException(UserErrorType.ALREADY_WITHDRAW)).when(userManagementService).withdraw(any());
+            setUpUserDetails(Role.USER);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    delete("/api/v1/users")
+                            .with(user(userDetails))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(UserErrorType.ALREADY_WITHDRAW.getCode()))
+                    .andExpect(jsonPath("$.message").value(UserErrorType.ALREADY_WITHDRAW.getMessage()));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 사용자")
+        void failNotFound() throws Exception {
+            // given
+            doThrow(new CustomException(UserErrorType.NOT_FOUND)).when(userManagementService).withdraw(any());
+            setUpUserDetails(Role.USER);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    delete("/api/v1/users")
+                            .with(user(userDetails))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(UserErrorType.NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.message").value(UserErrorType.NOT_FOUND.getMessage()));
         }
     }
 }


### PR DESCRIPTION
## 배경
- Soft Delete 정책을 적용한 회원 탈퇴 기능 요구

## 작업 사항
- 회원 탈퇴(withdraw) 작업
- Soft Delete 정책에 따른 회원 정보 보류 기간(7일) 이내 재로그인 한 경우 `deleted_at` 컬럼 null 처리
- 매일 자정, 탈퇴 후 7일이 지난 사용자 정보 삭제 - (64ad4636959443668cfec40ed912b7b1aa7d2391)
   - 차후 사용자 연관 데이터 삭제 로직 추가 예정 (TripMember 등) - (2b9170f7289a8dcae62b516a86f44da44ba193ae)

## 추가 논의
- 회원 탈퇴 후 재로그인 시
   - 현재는 재로그인 시 바로 다시 로그인이 되면서, 서버 내부에서 `deleted_at` 컬럼을 다시 null로 전환하여 바로 로그인이 되도록 구성해놓았습니다.
   - 혹시, 탈퇴 후 재로그인한 경우에는 먼저 에러(탈퇴한 사용자)를 응답하고 차후 '재가입' api 요청을 별도로 진행하도록 구성해야할 지 고민입니다. 더 나은 방향에 대한 추천이 있으시다면 부탁드리겠습니다.
