### PR TITLE
Refact: 불필요 UserErrorType 제거에 따른 변경

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
@@ -32,7 +32,7 @@ public class AuthService {
     @Transactional
     public void signUp(SignUpDto.Request request) {
         if (userService.existsIncludeDeletedByUsername(request.username())) {
-            throw new CustomException(AuthErrorType.ALREADY_USED_USERNAME); // swagger 문서 수정 필요 / 테스트 코드 수정 필요
+            throw new CustomException(AuthErrorType.ALREADY_USED_USERNAME);
         }
 
         if (userService.existsIncludeDeletedByNickname(request.nickname())) {
@@ -97,6 +97,11 @@ public class AuthService {
         refreshTokenService.delete(userId);
     }
 
+    /**
+     * 아이디 중복 확인 메서드
+     *
+     * @param username      확인할 아이디
+     */
     @Transactional(readOnly = true)
     public void checkDuplicatedUsername(String username) {
         if (userService.existsIncludeDeletedByUsername(username)) {
@@ -104,6 +109,11 @@ public class AuthService {
         }
     }
 
+    /**
+     * 닉네임 중복 확인 메서드
+     *
+     * @param nickname      확인할 닉네임
+     */
     @Transactional(readOnly = true)
     public void checkDuplicatedNickname(String nickname) {
         if (userService.existsIncludeDeletedByNickname(nickname)) {

--- a/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
@@ -31,10 +31,12 @@ public class AuthService {
      */
     @Transactional
     public void signUp(SignUpDto.Request request) {
-        String username = request.username();
+        if (userService.existsIncludeDeletedByUsername(request.username())) {
+            throw new CustomException(AuthErrorType.ALREADY_USED_USERNAME); // swagger 문서 수정 필요 / 테스트 코드 수정 필요
+        }
 
-        if (userService.existsByUsername(username)) {
-            throw new CustomException(UserErrorType.ALREADY_EXIST_USERNAME);
+        if (userService.existsIncludeDeletedByNickname(request.nickname())) {
+            throw new CustomException(AuthErrorType.ALREADY_USED_NICKNAME);
         }
 
         User newUser = request.toEntity(passwordEncoder.encode(request.password()));
@@ -50,7 +52,7 @@ public class AuthService {
      * @throws CustomException      AuthErrorType.AUTHENTICATION_FAIL 아이디 및 비밀번호 불일치
      * @return                      토큰(accessToken, refreshToken)
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public TokenDto signIn(SignInDto.Request request) {
         User user = userService.readIncludeDeletedUserByUsername(request.username())
                 .orElseThrow(() -> new CustomException(AuthErrorType.AUTHENTICATION_FAIL));
@@ -93,5 +95,19 @@ public class AuthService {
     public void signOut(String refreshToken) {
         Long userId = jwtService.extractUserId(refreshToken);
         refreshTokenService.delete(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public void checkDuplicatedUsername(String username) {
+        if (userService.existsIncludeDeletedByUsername(username)) {
+            throw new CustomException(AuthErrorType.ALREADY_USED_USERNAME);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public void checkDuplicatedNickname(String nickname) {
+        if (userService.existsIncludeDeletedByNickname(nickname)) {
+            throw new CustomException(AuthErrorType.ALREADY_USED_NICKNAME);
+        }
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -59,7 +59,7 @@ public class OAuthManagementService {
         User user = userService.readById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
 
-        if (userService.readIncludeDeletedUserByNickname(request.nickname())) {
+        if (userService.existsIncludeDeletedByNickname(request.nickname())) {
             throw new CustomException(AuthErrorType.ALREADY_USED_NICKNAME);
         }
 

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -6,6 +6,7 @@ import kr.co.yeogiga.application.auth.dto.TokenDto;
 import kr.co.yeogiga.application.auth.dto.UserInfoDto;
 import kr.co.yeogiga.application.auth.dto.UserStatusDto;
 import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
 import kr.co.yeogiga.domain.oauth.entity.OAuth;
 import kr.co.yeogiga.domain.oauth.service.OAuthService;
 import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
@@ -57,6 +58,10 @@ public class OAuthManagementService {
     public void register(Long userId, SignUpDto.Register request) {
         User user = userService.readById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
+
+        if (userService.readIncludeDeletedUserByNickname(request.nickname())) {
+            throw new CustomException(AuthErrorType.ALREADY_USED_NICKNAME);
+        }
 
         user.updateNickname(request.nickname());
         user.upgradeRoleToUser();

--- a/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
@@ -20,7 +20,10 @@ public enum AuthErrorType implements BaseErrorType {
     REFRESH_TOKEN_EXPIRED(HttpStatus.NOT_FOUND, "A008", "리프레시 토큰이 만료되었습니다. 재로그인 해주세요."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "A009", "리프레시 토큰을 찾을 수 없습니다."),
 
-    AUTHENTICATION_FAIL(HttpStatus.BAD_REQUEST, "A010", "로그인에 실패하였습니다. 아이디 또는 비밀번호를 확인해주세요.");
+    AUTHENTICATION_FAIL(HttpStatus.BAD_REQUEST, "A010", "로그인에 실패하였습니다. 아이디 또는 비밀번호를 확인해주세요."),
+
+    ALREADY_USED_USERNAME(HttpStatus.CONFLICT, "A011", "이미 사용 중인 아이디입니다."),
+    ALREADY_USED_NICKNAME(HttpStatus.CONFLICT, "A012", "이미 사용 중인 닉네임입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/co/yeogiga/domain/user/exception/UserErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/exception/UserErrorType.java
@@ -10,10 +10,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserErrorType implements BaseErrorType {
     NOT_FOUND(HttpStatus.NOT_FOUND, "U000", "존재하지 않는 사용자입니다."),
-    ALREADY_EXIST_USERNAME(HttpStatus.CONFLICT, "U001", "이미 존재하는 아이디입니다."),
-    SAME_PASSWORD(HttpStatus.CONFLICT, "U002", "기존과 동일한 비밀번호입니다."),
-    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "U003", "비밀번호가 불일치합니다."),
-    ALREADY_WITHDRAW(HttpStatus.BAD_REQUEST, "U004", "이미 회원탈퇴한 사용자입니다.");
+    SAME_PASSWORD(HttpStatus.CONFLICT, "U001", "기존과 동일한 비밀번호입니다."),
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "U002", "비밀번호가 불일치합니다."),
+    ALREADY_WITHDRAW(HttpStatus.BAD_REQUEST, "U003", "이미 회원탈퇴한 사용자입니다.");
 
 
 

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
@@ -38,6 +38,16 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByUsername(String username);
 
+    @Query(value = "SELECT id " +
+                   "FROM users " +
+                   "WHERE username = :username LIMIT 1", nativeQuery = true)
+    Optional<Long> findUserIdIncludeDeletedByUsername(@Param(value = "username") String username);
+
+    @Query(value = "SELECT id " +
+                   "FROM users " +
+                   "WHERE nickname = :nickname LIMIT 1", nativeQuery = true)
+    Optional<Long> findUserIdIncludeDeletedByNickname(@Param(value = "nickname") String nickname);
+
     @Modifying
     @Query(value = "DELETE " +
             "FROM users " +

--- a/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
@@ -27,10 +27,6 @@ public class UserService {
         return userRepository.findUserIncludeDeletedById(id);
     }
 
-    public Optional<User> readByUsername(String username) {
-        return userRepository.findByUsername(username);
-    }
-
     public Optional<User> readIncludeDeletedUserByUsername(String username) {
         return userRepository.findUserIncludeDeletedByUsername(username);
     }
@@ -43,10 +39,17 @@ public class UserService {
         return userRepository.findDeletedUserIdBefore(date);
     }
 
-    public boolean existsByUsername(String username) {
-        return userRepository.existsByUsername(username);
+    public boolean existsIncludeDeletedByUsername(String username) {
+        return userRepository.findUserIdIncludeDeletedByUsername(username).isPresent();
     }
 
+    public boolean existsIncludeDeletedByNickname(String nickname) {
+        return userRepository.findUserIdIncludeDeletedByNickname(nickname).isPresent();
+    }
+
+    public boolean readIncludeDeletedUserByNickname(String nickname) {
+        return userRepository.findUserIdIncludeDeletedByNickname(nickname).isPresent();
+    }
 
     public void deleteById(Long userId) {
         userRepository.deleteById(userId);

--- a/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
@@ -47,10 +47,6 @@ public class UserService {
         return userRepository.findUserIdIncludeDeletedByNickname(nickname).isPresent();
     }
 
-    public boolean readIncludeDeletedUserByNickname(String nickname) {
-        return userRepository.findUserIdIncludeDeletedByNickname(nickname).isPresent();
-    }
-
     public void deleteById(Long userId) {
         userRepository.deleteById(userId);
     }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
@@ -51,8 +51,14 @@ public interface AuthApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(name = "회원가입 실패 - 이미 존재하는 아이디", value = """
                                         {
-                                            "code": "U001",
-                                            "message": "이미 존재하는 아이디입니다."
+                                            "code": "A011",
+                                            "message": "이미 사용 중인 아이디입니다."
+                                        }
+                                    """),
+                            @ExampleObject(name = "회원가입 실패 - 이미 존재하는 아이디", value = """
+                                        {
+                                            "code": "A012",
+                                            "message": "이미 사용 중인 닉네임입니다."
                                         }
                                     """)
                     }))

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @ApiGroup(value = "[인증 API]")
 @Tag(name = "[인증 API]", description = "인증 관련 API")
@@ -183,4 +184,51 @@ public interface AuthApi {
             @CookieValue(name = "refreshToken", required = false) String refreshTokenInCookie
     );
 
+    @TrackApi(description = "아이디 중복 확인")
+    @Operation(summary = "아이디 중복 확인", description = "아이디 중복 확인 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사용가능한 아이디",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "사용가능한 아이디", value = """
+                                        {
+                                            "code": 200,
+                                            "message": "사용 가능한 아이디입니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "409", description = "이미 사용 중인 아이디",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "이미 사용 중인 아이디", value = """
+                                        {
+                                            "code": "A011",
+                                            "message": "이미 사용 중인 아이디입니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> checkDuplicatedUsername(@RequestParam(name = "value") String username);
+
+    @TrackApi(description = "닉네임 중복 확인")
+    @Operation(summary = "닉네임 중복 확인", description = "닉네임 중복 확인 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사용가능한 닉네임",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "사용가능한 닉네임", value = """
+                                        {
+                                            "code": 200,
+                                            "message": "사용 가능한 닉네임입니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "409", description = "이미 사용 중인 닉네임",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "이미 사용 중인 닉네임", value = """
+                                        {
+                                            "code": "A012",
+                                            "message": "이미 사용 중인 닉네임입니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> checkDuplicatedNickname(@RequestParam(name = "value") String nickname);
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
@@ -131,6 +131,15 @@ public interface OAuthApi {
                                              "message": "접근 권한이 없습니다."
                                         }
                                     """)
+                    })),
+            @ApiResponse(responseCode = "409", description = "이미 사용 중인 닉네임 ",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "이미 사용 중인 닉네임", value = """
+                                        {
+                                            "code": "A012",
+                                            "message": "이미 사용 중인 닉네임입니다."
+                                        }
+                                    """)
                     }))
 
     })

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.Duration;
@@ -87,6 +88,24 @@ public class AuthController implements AuthApi {
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, CookieUtil.removeCookie(REFRESH_TOKEN_PREFIX).toString())
                 .body(SuccessResponse.ok());
+    }
+
+    @GetMapping("/dup-check/username")
+    public ResponseEntity<?> checkDuplicatedUsername(@RequestParam(name = "value") String username) {
+        authService.checkDuplicatedUsername(username);
+        return ResponseEntity.ok().body(SuccessResponse.builder()
+                .code(HttpStatus.OK.value())
+                .message("사용 가능한 아이디입니다.")
+                .build());
+    }
+
+    @GetMapping("/dup-check/nickname")
+    public ResponseEntity<?> checkDuplicatedNickname(@RequestParam(name = "value") String nickname) {
+        authService.checkDuplicatedNickname(nickname);
+        return ResponseEntity.ok().body(SuccessResponse.builder()
+                .code(HttpStatus.OK.value())
+                .message("사용 가능한 닉네임입니다.")
+                .build());
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
@@ -35,7 +35,7 @@ public interface UserApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(name = "기존 비밀번호 불일치", value = """
                                         {
-                                            "code": "U003",
+                                            "code": "U002",
                                             "message": "비밀번호가 불일치합니다."
                                         }
                                     """),
@@ -61,7 +61,7 @@ public interface UserApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(name = "기존과 동일한 비밀번호", value = """
                                         {
-                                            "code": "U002",
+                                            "code": "U001",
                                             "message": "기존과 동일한 비밀번호입니다."
                                         }
                                     """)
@@ -88,7 +88,7 @@ public interface UserApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(name = "이미 회원 탈퇴한 사용자", value = """
                                         {
-                                            "code": "U004",
+                                            "code": "U003",
                                             "message": "이미 회원탈퇴한 사용자입니다."
                                         }
                                     """)

--- a/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -236,6 +237,64 @@ public class AuthServiceTest {
 
             // then
             assertEquals(exception.getErrorType(), AuthErrorType.AUTHENTICATION_FAIL);
+        }
+    }
+
+    @Nested
+    @DisplayName("아이디 중복 확인")
+    class DupCheckUsername {
+        @Test
+        @DisplayName("사용 가능한 아이디")
+        void success() {
+            // given
+            String username = "test";
+            when(userService.existsIncludeDeletedByUsername(username)).thenReturn(false);
+
+            // when & then
+            assertDoesNotThrow(() -> authService.checkDuplicatedUsername(username));
+        }
+
+        @Test
+        @DisplayName("이미 사용 중인 아이디")
+        void failAlreadyUsedUsername() {
+            // given
+            String username = "test";
+            when(userService.existsIncludeDeletedByUsername(username)).thenReturn(true);
+
+            // when
+            CustomException exception = assertThrows(CustomException.class, () -> authService.checkDuplicatedUsername(username));
+
+            // then
+            assertEquals(AuthErrorType.ALREADY_USED_USERNAME, exception.getErrorType());
+        }
+    }
+
+    @Nested
+    @DisplayName("닉네임 중복 확인")
+    class DupCheckNickname {
+        @Test
+        @DisplayName("사용 가능한 닉네임")
+        void success() {
+            // given
+            String nickname = "test";
+            when(userService.existsIncludeDeletedByNickname(nickname)).thenReturn(false);
+
+            // when & then
+            assertDoesNotThrow(() -> authService.checkDuplicatedNickname(nickname));
+        }
+
+        @Test
+        @DisplayName("이미 사용 중인 닉네임")
+        void failAlreadyUsedNickname() {
+            // given
+            String nickname = "test";
+            when(userService.existsIncludeDeletedByNickname(nickname)).thenReturn(true);
+
+            // when
+            CustomException exception = assertThrows(CustomException.class, () -> authService.checkDuplicatedNickname(nickname));
+
+            // then
+            assertEquals(AuthErrorType.ALREADY_USED_NICKNAME, exception.getErrorType());
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
@@ -107,7 +107,7 @@ public class AuthServiceTest {
 
         @Test
         @DisplayName("성공")
-        void successSignUp() {
+        void success() {
             // given
             SignUpDto.Request request = SignUpDto.Request.builder()
                     .username("testid")
@@ -116,7 +116,8 @@ public class AuthServiceTest {
                     .password("testpw")
                     .build();
 
-            when(userService.existsByUsername(request.username())).thenReturn(false);
+            when(userService.existsIncludeDeletedByUsername(request.username())).thenReturn(false);
+            when(userService.existsIncludeDeletedByNickname(request.nickname())).thenReturn(false);
             when(passwordEncoder.encode(request.password())).thenReturn("encodedPassword");
             doNothing().when(userService).save(any());
 
@@ -132,8 +133,8 @@ public class AuthServiceTest {
         }
 
         @Test
-        @DisplayName("실패 - 이미 존재하는 유저")
-        void failSignUp() {
+        @DisplayName("실패 - 이미 사용 중인 아이디")
+        void failAlreadyUsedUsername() {
             // given
             SignUpDto.Request request = SignUpDto.Request.builder()
                     .username("testid")
@@ -142,15 +143,35 @@ public class AuthServiceTest {
                     .password("testpw")
                     .build();
 
-            when(userService.existsByUsername(request.username())).thenReturn(true);
+            when(userService.existsIncludeDeletedByUsername(request.username())).thenReturn(true);
 
             // when
             CustomException exception = assertThrows(CustomException.class, () -> authService.signUp(request));
 
             // then
-            assertEquals(exception.getErrorType(), UserErrorType.ALREADY_EXIST_USERNAME);
+            assertEquals(exception.getErrorType(), AuthErrorType.ALREADY_USED_USERNAME);
         }
 
+        @Test
+        @DisplayName("실패 - 이미 사용 중인 닉네임")
+        void failAlreadyUsedNickname() {
+            // given
+            SignUpDto.Request request = SignUpDto.Request.builder()
+                    .username("testid")
+                    .email("test@test.com")
+                    .nickname("testnick")
+                    .password("testpw")
+                    .build();
+
+            when(userService.existsIncludeDeletedByUsername(request.username())).thenReturn(false);
+            when(userService.existsIncludeDeletedByNickname(request.nickname())).thenReturn(true);
+
+            // when
+            CustomException exception = assertThrows(CustomException.class, () -> authService.signUp(request));
+
+            // then
+            assertEquals(exception.getErrorType(), AuthErrorType.ALREADY_USED_NICKNAME);
+        }
     }
 
     @Nested

--- a/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -33,6 +34,7 @@ import org.springframework.web.context.WebApplicationContext;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -435,6 +437,96 @@ public class AuthControllerTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value(AuthErrorType.AUTHENTICATION_FAIL.getCode()))
                     .andExpect(jsonPath("$.message").value(AuthErrorType.AUTHENTICATION_FAIL.getMessage()));;
+        }
+    }
+
+    @Nested
+    @DisplayName("아이디 중복 체크")
+    class DupCheckUsername {
+
+        @Test
+        @DisplayName("사용 가능한 아이디")
+        void isAvailable() throws Exception {
+            // given
+            String username = "test";
+            doNothing().when(authService).checkDuplicatedUsername(username);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/auth/dup-check/username")
+                            .param("value", username)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.message").value("사용 가능한 아이디입니다."));
+        }
+
+        @Test
+        @DisplayName("이미 사용 중인 아이디")
+        void isNotAvailable() throws Exception {
+            // given
+            String username = "test";
+            doThrow(new CustomException(AuthErrorType.ALREADY_USED_USERNAME)).when(authService).checkDuplicatedUsername(username);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/auth/dup-check/username")
+                            .param("value", username)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value(AuthErrorType.ALREADY_USED_USERNAME.getCode()))
+                    .andExpect(jsonPath("$.message").value(AuthErrorType.ALREADY_USED_USERNAME.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("닉네임 중복 체크")
+    class DupCheckNickname {
+
+        @Test
+        @DisplayName("사용 가능한 닉네임")
+        void isAvailable() throws Exception {
+            // given
+            String nickname = "test";
+            doNothing().when(authService).checkDuplicatedNickname(nickname);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/auth/dup-check/nickname")
+                            .param("value", nickname)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.message").value("사용 가능한 닉네임입니다."));
+        }
+
+        @Test
+        @DisplayName("이미 사용 중인 닉네임")
+        void isNotAvailable() throws Exception {
+            // given
+            String nickname = "test";
+            doThrow(new CustomException(AuthErrorType.ALREADY_USED_NICKNAME)).when(authService).checkDuplicatedNickname(nickname);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/auth/dup-check/nickname")
+                            .param("value", nickname)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value(AuthErrorType.ALREADY_USED_NICKNAME.getCode()))
+                    .andExpect(jsonPath("$.message").value(AuthErrorType.ALREADY_USED_NICKNAME.getMessage()));
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
@@ -307,7 +307,7 @@ public class AuthControllerTest {
         @DisplayName("실패 - 이미 존재하는 아이디")
         void failSignUpAlreadyExists() throws Exception {
             // given
-            doThrow(new CustomException(UserErrorType.ALREADY_EXIST_USERNAME)).when(authService).signUp(any());
+            doThrow(new CustomException(AuthErrorType.ALREADY_USED_USERNAME)).when(authService).signUp(any());
             SignUpDto.Request signUpDto = SignUpDto.Request.builder()
                     .username("testid")
                     .email("test@test.com")
@@ -325,8 +325,8 @@ public class AuthControllerTest {
             // then
             resultActions
                     .andExpect(status().isConflict())
-                    .andExpect(jsonPath("$.code").value(UserErrorType.ALREADY_EXIST_USERNAME.getCode()))
-                    .andExpect(jsonPath("$.message").value(UserErrorType.ALREADY_EXIST_USERNAME.getMessage()));
+                    .andExpect(jsonPath("$.code").value(AuthErrorType.ALREADY_USED_USERNAME.getCode()))
+                    .andExpect(jsonPath("$.message").value(AuthErrorType.ALREADY_USED_USERNAME.getMessage()));
         }
     }
 


### PR DESCRIPTION
## 배경
- `UserErrorType.ALREADY_EXIST_USERNAME` 미사용에 따른 제거
   - 그로 인한 나머지 에러 응답 코드 변경

## 작업 사항
- 에러 응답 코드 변경에 따른 Swagger 문서 수정 - 앞선 커밋들은`git merge` 하며 생긴 커밋이니 아래 커밋만 확인해주셔도 될 것 같습니다.
   - 불필요 UserErrorType 제거 (2076795e8cb2bf535e356b0f39af3b41f4be0260)
   - Swagger 문서 변경 (1c073e60e774a135b928b3eed6cb0ae0149eca87)
   - 테스트 코드 변경 (ccc85491ab2f371111d096f5ebd73de8e3eeabc3)
