### PR TITLE
Feature(IL-57): 회원 정보 조회

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.application.auth.service;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
 import kr.co.yeogiga.application.auth.dto.SignUpDto;
 import kr.co.yeogiga.application.auth.dto.TokenDto;
+import kr.co.yeogiga.application.auth.type.LoginType;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
 import kr.co.yeogiga.domain.user.entity.User;
@@ -63,7 +64,7 @@ public class AuthService {
             throw new CustomException(AuthErrorType.AUTHENTICATION_FAIL);
         }
 
-        return jwtService.generateToken(user.getUsername(), user.getNickname(), user.getId());
+        return jwtService.generateToken(user.getUsername(), user.getNickname(), user.getId(), LoginType.NORMAL);
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
@@ -83,7 +83,7 @@ public class AuthService {
         User user = userService.readById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
 
-        return jwtService.generateToken(user.getUsername(), user.getNickname(), user.getId());
+        return jwtService.generateToken(user.getUsername(), user.getNickname(), user.getId(), LoginType.from(user.getPassword()));
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/auth/service/JwtService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/JwtService.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.application.auth.service;
 
 import kr.co.yeogiga.application.auth.dto.TokenDto;
+import kr.co.yeogiga.application.auth.type.LoginType;
 import kr.co.yeogiga.common.jwt.JwtHelper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,9 +12,9 @@ public class JwtService {
     private final JwtHelper jwtHelper;
     private final RefreshTokenService refreshTokenService;
 
-    public TokenDto generateToken(String username, String nickname, Long userId) {
-        String accessToken = jwtHelper.generateAccessToken(username, nickname, userId);
-        String refreshToken = jwtHelper.generateRefreshToken(username, nickname, userId);
+    public TokenDto generateToken(String username, String nickname, Long userId, LoginType loginType) {
+        String accessToken = jwtHelper.generateAccessToken(username, nickname, userId, loginType);
+        String refreshToken = jwtHelper.generateRefreshToken(username, nickname, userId, loginType);
         refreshTokenService.save(userId, refreshToken);
 
         return TokenDto.of(accessToken, refreshToken);

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -5,6 +5,7 @@ import kr.co.yeogiga.application.auth.dto.SignUpDto;
 import kr.co.yeogiga.application.auth.dto.TokenDto;
 import kr.co.yeogiga.application.auth.dto.UserInfoDto;
 import kr.co.yeogiga.application.auth.dto.UserStatusDto;
+import kr.co.yeogiga.application.auth.type.LoginType;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.oauth.entity.OAuth;
 import kr.co.yeogiga.domain.oauth.service.OAuthService;
@@ -122,7 +123,7 @@ public class OAuthManagementService {
         String nickname = user.getNickname();
         Long userId = user.getId();
 
-        TokenDto token = jwtService.generateToken(username, nickname, userId);
+        TokenDto token = jwtService.generateToken(username, nickname, userId, LoginType.SOCIAL);
 
         return SignInDto.Response.builder()
                 .token(token)

--- a/src/main/java/kr/co/yeogiga/application/auth/type/LoginType.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/type/LoginType.java
@@ -1,0 +1,11 @@
+package kr.co.yeogiga.application.auth.type;
+
+import java.util.Objects;
+
+public enum LoginType {
+    NORMAL, SOCIAL;
+
+    public static LoginType from(String password) {
+        return Objects.isNull(password) ? SOCIAL : NORMAL;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/user/dto/UserInfoRes.java
+++ b/src/main/java/kr/co/yeogiga/application/user/dto/UserInfoRes.java
@@ -1,0 +1,28 @@
+package kr.co.yeogiga.application.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import kr.co.yeogiga.domain.user.entity.User;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record UserInfoRes(
+        String username,
+        String nickname,
+        String email
+) {
+    public static UserInfoRes fromNormalUser(User user) {
+        return UserInfoRes.builder()
+                .username(user.getUsername())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .build();
+    }
+
+    public static UserInfoRes fromSocialUser(User user) {
+        return UserInfoRes.builder()
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
@@ -2,6 +2,7 @@ package kr.co.yeogiga.application.user.service;
 
 import kr.co.yeogiga.application.auth.service.RefreshTokenService;
 import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
+import kr.co.yeogiga.application.user.dto.UserInfoRes;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.exception.UserErrorType;
@@ -60,5 +61,15 @@ public class UserManagementService {
 
         refreshTokenService.delete(userId);
         userService.deleteById(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public UserInfoRes getUserInfo(Long userId) {
+        User user = userService.readById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
+
+        return Objects.isNull(user.getPassword())
+                ? UserInfoRes.fromSocialUser(user)
+                : UserInfoRes.fromNormalUser(user);
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
@@ -63,6 +63,14 @@ public class UserManagementService {
         userService.deleteById(userId);
     }
 
+    /**
+     * 회원 정보 조회 메서드
+     *
+     * @param userId    사용자 ID
+     * @return          UserInfoRes 사용자 정보
+     *                  - 소셜 로그인 사용자 -> nickname, email
+     *                  - 일반 로그인 사용자 -> nickname, email, username
+     */
     @Transactional(readOnly = true)
     public UserInfoRes getUserInfo(Long userId) {
         User user = userService.readById(userId)

--- a/src/main/java/kr/co/yeogiga/common/jwt/JwtHelper.java
+++ b/src/main/java/kr/co/yeogiga/common/jwt/JwtHelper.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.common.jwt;
 
 import io.jsonwebtoken.Claims;
+import kr.co.yeogiga.application.auth.type.LoginType;
 import kr.co.yeogiga.common.jwt.dto.JwtClaims;
 import kr.co.yeogiga.infrastructure.properties.JwtProperties;
 import lombok.RequiredArgsConstructor;
@@ -15,12 +16,12 @@ public class JwtHelper {
     private final TokenParser tokenParser;
     private final JwtProperties jwtProperties;
 
-    public String generateAccessToken(String username, String nickname, Long userId) {
-        return tokenBuilder.build(username, generateClaims(nickname, userId), jwtProperties.getAccessTokenExpiration());
+    public String generateAccessToken(String username, String nickname, Long userId, LoginType loginType) {
+        return tokenBuilder.build(username, generateClaims(nickname, userId, loginType), jwtProperties.getAccessTokenExpiration());
     }
 
-    public String generateRefreshToken(String username, String nickname, Long userId) {
-        return tokenBuilder.build(username, generateClaims(nickname, userId), jwtProperties.getRefreshTokenExpiration());
+    public String generateRefreshToken(String username, String nickname, Long userId, LoginType loginType) {
+        return tokenBuilder.build(username, generateClaims(nickname, userId, loginType), jwtProperties.getRefreshTokenExpiration());
     }
 
     public JwtClaims parseClaims(String token) {
@@ -33,9 +34,10 @@ public class JwtHelper {
                 .build();
     }
 
-    private Map<String, Object> generateClaims(String nickname, Long userId) {
+    private Map<String, Object> generateClaims(String nickname, Long userId, LoginType loginType) {
         return Map.of("nickname", nickname,
-                      "userId", userId);
+                      "userId", userId,
+                      "loginType", loginType);
 
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
@@ -13,6 +13,7 @@ import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @ApiGroup(value = "[사용자 관련 API]")
@@ -104,6 +105,48 @@ public interface UserApi {
                     }))
     })
     ResponseEntity<?> withdraw(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
+    @TrackApi(description = "회원 정보 조회")
+    @Operation(summary = "회원 정보 조회", description = "회원 정보 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원 정보 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "소셜 로그인 사용자", value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": {
+                                                "nickname": "test",
+                                                "email": "test@test.com"
+                                            }
+                                        }
+                                    """),
+                            @ExampleObject(name = "일반 로그인 사용자", value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": {
+                                                "username": "test",
+                                                "nickname": "test",
+                                                "email": "test@test.com"
+                                            }
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "회원 탈퇴 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "존재하지 않는 사용자", value = """
+                                        {
+                                            "code": "U000",
+                                            "message": "존재하지 않는 사용자입니다."
+                                        }
+                                    """)
+                    }))
+    })
+    @GetMapping("/my")
+    public ResponseEntity<?> getUserInfo(
             @AuthenticationPrincipal CustomUserDetails userDetails
     );
 }

--- a/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
@@ -146,7 +146,7 @@ public interface UserApi {
                     }))
     })
     @GetMapping("/my")
-    public ResponseEntity<?> getUserInfo(
+    ResponseEntity<?> getUserInfo(
             @AuthenticationPrincipal CustomUserDetails userDetails
     );
 }

--- a/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
@@ -145,7 +145,6 @@ public interface UserApi {
                                     """)
                     }))
     })
-    @GetMapping("/my")
     ResponseEntity<?> getUserInfo(
             @AuthenticationPrincipal CustomUserDetails userDetails
     );

--- a/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -44,5 +45,13 @@ public class UserController implements UserApi {
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, CookieUtil.removeCookie(REFRESH_TOKEN_PREFIX).toString())
                 .body(SuccessResponse.ok());
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<?> getUserInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ResponseEntity.ok()
+                .body(SuccessResponse.from(userManagementService.getUserInfo(userDetails.getUserId())));
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
@@ -47,6 +47,7 @@ public class UserController implements UserApi {
                 .body(SuccessResponse.ok());
     }
 
+    @Override
     @GetMapping("/my")
     public ResponseEntity<?> getUserInfo(
             @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
@@ -70,7 +70,7 @@ public class AuthServiceTest {
         when(jwtService.extractUserId(any())).thenReturn(userId);
         when(refreshTokenService.exists(userId)).thenReturn(true);
         when(userService.readById(userId)).thenReturn(Optional.ofNullable(user));
-        when(jwtService.generateToken(any(), any(), any())).thenReturn(tokenDto);
+        when(jwtService.generateToken(any(), any(), any(), any())).thenReturn(tokenDto);
 
         // when
         TokenDto reissuedToken = authService.reissueToken("old-refresh-token");
@@ -174,7 +174,7 @@ public class AuthServiceTest {
 
             when(userService.readIncludeDeletedUserByUsername(request.username())).thenReturn(Optional.of(newUser));
             when(passwordEncoder.matches(request.password(), newUser.getPassword())).thenReturn(true);
-            when(jwtService.generateToken(any(), any(), any())).thenReturn(tokenDto);
+            when(jwtService.generateToken(any(), any(), any(), any())).thenReturn(tokenDto);
 
             // when
             TokenDto token = authService.signIn(request);

--- a/src/test/java/kr/co/yeogiga/application/user/service/UserManagementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/user/service/UserManagementServiceTest.java
@@ -2,6 +2,7 @@ package kr.co.yeogiga.application.user.service;
 
 import kr.co.yeogiga.application.auth.service.RefreshTokenService;
 import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
+import kr.co.yeogiga.application.user.dto.UserInfoRes;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.exception.UserErrorType;
@@ -20,6 +21,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
@@ -158,7 +160,66 @@ public class UserManagementServiceTest {
             // then
             assertEquals(exception.getErrorType(), UserErrorType.ALREADY_WITHDRAW);
         }
+    }
 
+    @Nested
+    @DisplayName("회원 정보 조회")
+    class GetUserInfo {
+        private final Long userId = 1L;
+        @Test
+        @DisplayName("성공 - 소셜 로그인 사용자")
+        void successForSocialUser() {
+            // given
+            User socialUser = User.builder()
+                    .username("KAKAO 123")
+                    .nickname("nickname")
+                    .role(Role.USER)
+                    .email("test@test.com")
+                    .build();
+            when(userService.readById(eq(userId))).thenReturn(Optional.of(socialUser));
 
+            // when
+            UserInfoRes userInfoRes = userManagementService.getUserInfo(userId);
+
+            // then
+            assertEquals("nickname", userInfoRes.nickname());
+            assertEquals("test@test.com", userInfoRes.email());
+            assertThat(userInfoRes.username()).isNull();
+        }
+
+        @Test
+        @DisplayName("성공 - 일반 로그인 사용자")
+        void successForNormalUser() {
+            // given
+            User socialUser = User.builder()
+                    .username("username")
+                    .password("password")
+                    .nickname("nickname")
+                    .role(Role.USER)
+                    .email("test@test.com")
+                    .build();
+            when(userService.readById(eq(userId))).thenReturn(Optional.of(socialUser));
+
+            // when
+            UserInfoRes userInfoRes = userManagementService.getUserInfo(userId);
+
+            // then
+            assertEquals("nickname", userInfoRes.nickname());
+            assertEquals("username", userInfoRes.username());
+            assertEquals("test@test.com", userInfoRes.email());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 사용자")
+        void failUserNotFound() {
+            // given
+            when(userService.readById(eq(userId))).thenReturn(Optional.empty());
+
+            // when
+            CustomException exception = assertThrows(CustomException.class, () -> userManagementService.getUserInfo(userId));
+
+            // then
+            assertEquals(UserErrorType.NOT_FOUND, exception.getErrorType());
+        }
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/user/controller/UserControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/user/controller/UserControllerTest.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.presentation.user.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.auth.constant.AuthConstants;
 import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
+import kr.co.yeogiga.application.user.dto.UserInfoRes;
 import kr.co.yeogiga.application.user.service.UserManagementService;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.response.error.type.CommonErrorType;
@@ -34,13 +35,15 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
@@ -239,6 +242,82 @@ public class UserControllerTest {
             // when
             ResultActions resultActions = mockMvc.perform(
                     delete("/api/v1/users")
+                            .with(user(userDetails))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(UserErrorType.NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.message").value(UserErrorType.NOT_FOUND.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 정보 조회")
+    class GetUserInfo {
+        @Test
+        @DisplayName("성공 - 소셜 로그인 사용자")
+        void successForSocialUser() throws Exception {
+            // given
+            setUpUserDetails(Role.USER);
+            UserInfoRes userInfoRes = UserInfoRes.builder()
+                    .nickname("nickname")
+                    .email("test@test.com")
+                    .build();
+            when(userManagementService.getUserInfo(any())).thenReturn(userInfoRes);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/users/my")
+                            .with(user(userDetails))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.nickname").value("nickname"))
+                    .andExpect(jsonPath("$.data.email").value("test@test.com"))
+                    .andExpect(jsonPath("$.data.username").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("성공 - 일반 로그인 사용자")
+        void successForNormalUser() throws Exception {
+            // given
+            setUpUserDetails(Role.USER);
+            UserInfoRes userInfoRes = UserInfoRes.builder()
+                    .username("username")
+                    .nickname("nickname")
+                    .email("test@test.com")
+                    .build();
+            when(userManagementService.getUserInfo(any())).thenReturn(userInfoRes);
+
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/users/my")
+                            .with(user(userDetails))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.nickname").value("nickname"))
+                    .andExpect(jsonPath("$.data.email").value("test@test.com"))
+                    .andExpect(jsonPath("$.data.username").value("username"));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 사용자")
+        void failUserNotFound() throws Exception {
+            // given
+            doThrow(new CustomException(UserErrorType.NOT_FOUND)).when(userManagementService).getUserInfo(any());
+            setUpUserDetails(Role.USER);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/users/my")
                             .with(user(userDetails))
             );
 


### PR DESCRIPTION
## 배경
- 사용자 로그인 타입(소셜, 일반) 별 회원 정보 조회 필요

## 작업 사항
- 토큰 내 로그인 타입 추가(`loginType`: `SOCIAL`, `NORMAL`)
   : 차후 프론트엔드 측에서 유저 정보 보여줄 때 소셜 로그인, 일반 로그인 여부에 따라 다른 화면 구성할 수 있도록 토큰 내 로그인 타입 추가하였습니다.

- 회원 정보 조회 로직 추가
   - 응답 dto (ab4b22a7ca8ab3ae8eb5506d96e5ebd51fd5d22a)
      - 소셜 로그인 사용자: nickname, email
      - 일반 로그인 사용자: nickname, email, username
   - Controller 및 Service (4fe17f578af828486bcd3a5f6e211005f1c2543e)

## 추가 논의
- 서비스 코드 및 테스트 코드 작성하면서 클래스가 비대해진다는 느낌을 받긴 하였습니다. 특히 테스트 코드 작성 시에 많이 무겁다는 느낌을 받았습니다. 그래서 대영님이 작성하신 것처럼 `xxxQueryService`, `xxxCommandService`로 나눌까 생각해봤는데 현재는 너무 변경사항이 많은 것 같아 일단 이번 PR에서는 기존하던 방식대로 유지하였습니다.
   - 혹시 이 패턴이 CQRS 패턴이 맞을까요? 차후 `UserManagementService`에 위와 같이 Query-Command Service로 나누는 게 효율이 좋을 지 개인적으로 궁금하여 추가 논의에 올립니다!

- 로컬에서 브랜치명이 소문자로 만들어져 (feat/il-57-user-info) 브랜치명을 따로 바꿔서 PR 작성하였습니다. 이번 PR 끝난 후 해당 브랜치도 삭제하겠습니다.