### PR TITLE
Feature(IL-88): 회원 정보 수정

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/user/dto/UserInfoUpdateReq.java
+++ b/src/main/java/kr/co/yeogiga/application/user/dto/UserInfoUpdateReq.java
@@ -1,0 +1,7 @@
+package kr.co.yeogiga.application.user.dto;
+
+public record UserInfoUpdateReq(
+        String nickname,
+        String email
+) {
+}

--- a/src/main/java/kr/co/yeogiga/application/user/dto/UserInfoUpdateReq.java
+++ b/src/main/java/kr/co/yeogiga/application/user/dto/UserInfoUpdateReq.java
@@ -1,7 +1,14 @@
 package kr.co.yeogiga.application.user.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
 public record UserInfoUpdateReq(
+        @NotBlank(message = "닉네임은 필수 입력값입니다.")
         String nickname,
+
+        @NotBlank(message = "이메일은 필수 입력값입니다.")
         String email
 ) {
 }

--- a/src/main/java/kr/co/yeogiga/application/user/dto/UserInfoUpdateReq.java
+++ b/src/main/java/kr/co/yeogiga/application/user/dto/UserInfoUpdateReq.java
@@ -1,13 +1,16 @@
 package kr.co.yeogiga.application.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 @Builder
 public record UserInfoUpdateReq(
+        @Schema(description = "닉네임", example = "nickname")
         @NotBlank(message = "닉네임은 필수 입력값입니다.")
         String nickname,
 
+        @Schema(description = "이메일", example = "test@test.com")
         @NotBlank(message = "이메일은 필수 입력값입니다.")
         String email
 ) {

--- a/src/main/java/kr/co/yeogiga/application/user/dto/UserInfoUpdateReq.java
+++ b/src/main/java/kr/co/yeogiga/application/user/dto/UserInfoUpdateReq.java
@@ -8,10 +8,6 @@ import lombok.Builder;
 public record UserInfoUpdateReq(
         @Schema(description = "닉네임", example = "nickname")
         @NotBlank(message = "닉네임은 필수 입력값입니다.")
-        String nickname,
-
-        @Schema(description = "이메일", example = "test@test.com")
-        @NotBlank(message = "이메일은 필수 입력값입니다.")
-        String email
+        String nickname
 ) {
 }

--- a/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.application.user.service;
 import kr.co.yeogiga.application.auth.service.RefreshTokenService;
 import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
 import kr.co.yeogiga.application.user.dto.UserInfoRes;
+import kr.co.yeogiga.application.user.dto.UserInfoUpdateReq;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.exception.UserErrorType;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -79,5 +81,30 @@ public class UserManagementService {
         return Objects.isNull(user.getPassword())
                 ? UserInfoRes.fromSocialUser(user)
                 : UserInfoRes.fromNormalUser(user);
+    }
+
+    @Transactional
+    public void updateUserInfo(Long userId, UserInfoUpdateReq userInfoUpdateReq) {
+        String nickname = userInfoUpdateReq.nickname();
+        String email = userInfoUpdateReq.email();
+
+        Optional<User> foundUser = userService.readIncludeDeletedUserByNickname(nickname);
+
+        if (foundUser.isPresent() && !foundUser.get().getId().equals(userId)) {
+            throw new CustomException(UserErrorType.ALREADY_USED_NICKNAME);
+        }
+
+        User user = userService.readById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
+
+        if (user.getNickname().equals(nickname)) {
+            throw new CustomException(UserErrorType.SAME_NICKNAME);
+        }
+
+        if (user.getEmail().equals(email)) {
+            throw new CustomException(UserErrorType.SAME_EMAIL);
+        }
+
+        user.updateUserInfo(nickname, email);
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
@@ -96,13 +96,6 @@ public class UserManagementService {
     @Transactional
     public void updateUserInfo(Long userId, UserInfoUpdateReq userInfoUpdateReq) {
         String nickname = userInfoUpdateReq.nickname();
-        String email = userInfoUpdateReq.email();
-
-        Optional<User> foundUser = userService.readIncludeDeletedUserByNickname(nickname);
-
-        if (foundUser.isPresent() && !foundUser.get().getId().equals(userId)) {
-            throw new CustomException(UserErrorType.ALREADY_USED_NICKNAME);
-        }
 
         User user = userService.readById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
@@ -111,10 +104,10 @@ public class UserManagementService {
             throw new CustomException(UserErrorType.SAME_NICKNAME);
         }
 
-        if (user.getEmail().equals(email)) {
-            throw new CustomException(UserErrorType.SAME_EMAIL);
+        if (userService.existsIncludeDeletedByNickname(nickname)) {
+            throw new CustomException(UserErrorType.ALREADY_USED_NICKNAME);
         }
 
-        user.updateUserInfo(nickname, email);
+        user.updateNickname(nickname);
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -87,11 +86,10 @@ public class UserManagementService {
      * 회원 정보 수정 메서드
      *
      * @param userId                사용자 ID
-     * @param userInfoUpdateReq     사용자 정보 갱신 요청 dto(nickname, email)
+     * @param userInfoUpdateReq     사용자 정보 갱신 요청 dto(nickname)
      *
      * @throws CustomException      UserErrorType.ALREADY_USED_NICKNAME 동일한 닉네임 사용자가 존재하는 경우
      * @throws CustomException      UserErrorType.SAME_NICKNAME         기존과 동일한 닉네임의 경우
-     * @throws CustomException      UserErrorType.SAME_EMAIL            기존과 동일한 이메일의 경우
      */
     @Transactional
     public void updateUserInfo(Long userId, UserInfoUpdateReq userInfoUpdateReq) {

--- a/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
@@ -83,6 +83,16 @@ public class UserManagementService {
                 : UserInfoRes.fromNormalUser(user);
     }
 
+    /**
+     * 회원 정보 수정 메서드
+     *
+     * @param userId                사용자 ID
+     * @param userInfoUpdateReq     사용자 정보 갱신 요청 dto(nickname, email)
+     *
+     * @throws CustomException      UserErrorType.ALREADY_USED_NICKNAME 동일한 닉네임 사용자가 존재하는 경우
+     * @throws CustomException      UserErrorType.SAME_NICKNAME         기존과 동일한 닉네임의 경우
+     * @throws CustomException      UserErrorType.SAME_EMAIL            기존과 동일한 이메일의 경우
+     */
     @Transactional
     public void updateUserInfo(Long userId, UserInfoUpdateReq userInfoUpdateReq) {
         String nickname = userInfoUpdateReq.nickname();

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -71,9 +71,4 @@ public class User extends BaseTimeEntity {
     public void revertWithdrawal() {
         this.deletedAt = null;
     }
-
-    public void updateUserInfo(String nickname, String email) {
-        this.nickname = nickname;
-        this.email = email;
-    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -71,4 +71,9 @@ public class User extends BaseTimeEntity {
     public void revertWithdrawal() {
         this.deletedAt = null;
     }
+
+    public void updateUserInfo(String nickname, String email) {
+        this.nickname = nickname;
+        this.email = email;
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/user/exception/UserErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/exception/UserErrorType.java
@@ -12,7 +12,10 @@ public enum UserErrorType implements BaseErrorType {
     NOT_FOUND(HttpStatus.NOT_FOUND, "U000", "존재하지 않는 사용자입니다."),
     SAME_PASSWORD(HttpStatus.CONFLICT, "U001", "기존과 동일한 비밀번호입니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "U002", "비밀번호가 불일치합니다."),
-    ALREADY_WITHDRAW(HttpStatus.BAD_REQUEST, "U003", "이미 회원탈퇴한 사용자입니다.");
+    ALREADY_WITHDRAW(HttpStatus.BAD_REQUEST, "U003", "이미 회원탈퇴한 사용자입니다."),
+    ALREADY_USED_NICKNAME(HttpStatus.CONFLICT, "U004", "이미 사용 중인 닉네임입니다."),
+    SAME_NICKNAME(HttpStatus.CONFLICT, "U005", "기존과 동일한 닉네임 입니다."),
+    SAME_EMAIL(HttpStatus.CONFLICT, "U006", "기존과 동일한 이메일 입니다.");
 
 
 

--- a/src/main/java/kr/co/yeogiga/domain/user/exception/UserErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/exception/UserErrorType.java
@@ -14,9 +14,7 @@ public enum UserErrorType implements BaseErrorType {
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "U002", "비밀번호가 불일치합니다."),
     ALREADY_WITHDRAW(HttpStatus.BAD_REQUEST, "U003", "이미 회원탈퇴한 사용자입니다."),
     ALREADY_USED_NICKNAME(HttpStatus.CONFLICT, "U004", "이미 사용 중인 닉네임입니다."),
-    SAME_NICKNAME(HttpStatus.CONFLICT, "U005", "기존과 동일한 닉네임 입니다."),
-    SAME_EMAIL(HttpStatus.CONFLICT, "U006", "기존과 동일한 이메일 입니다.");
-
+    SAME_NICKNAME(HttpStatus.CONFLICT, "U005", "기존과 동일한 닉네임 입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
@@ -24,6 +24,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
                    "WHERE id = :id", nativeQuery = true)
     Optional<User> findUserIncludeDeletedById(@Param(value = "id") Long id);
 
+    @Query(value = "SELECT * " +
+            "FROM users " +
+            "WHERE nickname = :nickname", nativeQuery = true)
     Optional<User> findUserIncludeDeletedByNickname(String nickname);
 
     @Query(value = "SELECT * " +

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
@@ -24,7 +24,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
                    "WHERE id = :id", nativeQuery = true)
     Optional<User> findUserIncludeDeletedById(@Param(value = "id") Long id);
 
-    Optional<User> findByUsername(String username);
+    Optional<User> findUserIncludeDeletedByNickname(String nickname);
 
     @Query(value = "SELECT * " +
             "FROM users " +

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
@@ -36,8 +36,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
                    "WHERE deleted_at IS NOT NULL AND deleted_at <= :date", nativeQuery = true)
     List<Long> findDeletedUserIdBefore(@Param(value = "date") LocalDate date);
 
-    boolean existsByUsername(String username);
-
     @Query(value = "SELECT id " +
                    "FROM users " +
                    "WHERE username = :username LIMIT 1", nativeQuery = true)

--- a/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
@@ -31,6 +31,10 @@ public class UserService {
         return userRepository.findUserIncludeDeletedByUsername(username);
     }
 
+    public Optional<User> readIncludeDeletedUserByNickname(String nickname) {
+        return userRepository.findUserIncludeDeletedByNickname(nickname);
+    }
+
     public Optional<User> readIncludeDeletedUserByPlatformAndPlatformId(OAuthPlatform platform, String platformId) {
         return userRepository.findUserIncludeDeletedByPlatformAndPlatformId(platform, platformId);
     }

--- a/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
@@ -175,12 +175,6 @@ public interface UserApi {
                                             "code": "U005",
                                             "message": "기존과 동일한 닉네임 입니다."
                                         }
-                                    """),
-                            @ExampleObject(name = "기존과 동일한 이메일", value = """
-                                        {
-                                            "code": "U006",
-                                            "message": "기존과 동일한 이메일 입니다."
-                                        }
                                     """)
                     }))
     })

--- a/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
+import kr.co.yeogiga.application.user.dto.UserInfoUpdateReq;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -147,5 +148,44 @@ public interface UserApi {
     })
     ResponseEntity<?> getUserInfo(
             @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
+    @TrackApi(description = "회원 정보 수정")
+    @Operation(summary = "회원 정보 수정", description = "회원 정보 수정 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원 정보 수정 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "성공", value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "409", description = "회원 정보 수정 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "이미 사용 중인 닉네임", value = """
+                                        {
+                                            "code": "U004",
+                                            "message": "이미 사용 중인 닉네임입니다."
+                                        }
+                                    """),
+                            @ExampleObject(name = "기존과 동일한 닉네임", value = """
+                                        {
+                                            "code": "U005",
+                                            "message": "기존과 동일한 닉네임 입니다."
+                                        }
+                                    """),
+                            @ExampleObject(name = "기존과 동일한 이메일", value = """
+                                        {
+                                            "code": "U006",
+                                            "message": "기존과 동일한 이메일 입니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> update(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UserInfoUpdateReq userInfoUpdateReq
     );
 }

--- a/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
@@ -2,6 +2,7 @@ package kr.co.yeogiga.presentation.user.controller;
 
 import jakarta.validation.Valid;
 import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
+import kr.co.yeogiga.application.user.dto.UserInfoUpdateReq;
 import kr.co.yeogiga.application.user.service.UserManagementService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
@@ -14,6 +15,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -54,5 +56,14 @@ public class UserController implements UserApi {
     ) {
         return ResponseEntity.ok()
                 .body(SuccessResponse.from(userManagementService.getUserInfo(userDetails.getUserId())));
+    }
+
+    @PutMapping
+    public ResponseEntity<?> update(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UserInfoUpdateReq userInfoUpdateReq
+    ) {
+        userManagementService.updateUserInfo(userDetails.getUserId(), userInfoUpdateReq);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
@@ -61,9 +61,9 @@ public class UserController implements UserApi {
     @PutMapping
     public ResponseEntity<?> update(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody UserInfoUpdateReq userInfoUpdateReq
+            @Valid @RequestBody UserInfoUpdateReq userInfoUpdateReq
     ) {
         userManagementService.updateUserInfo(userDetails.getUserId(), userInfoUpdateReq);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok().body(SuccessResponse.ok());
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
@@ -58,6 +58,7 @@ public class UserController implements UserApi {
                 .body(SuccessResponse.from(userManagementService.getUserInfo(userDetails.getUserId())));
     }
 
+    @Override
     @PutMapping
     public ResponseEntity<?> update(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/test/java/kr/co/yeogiga/application/user/service/UserManagementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/user/service/UserManagementServiceTest.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.application.user.service;
 import kr.co.yeogiga.application.auth.service.RefreshTokenService;
 import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
 import kr.co.yeogiga.application.user.dto.UserInfoRes;
+import kr.co.yeogiga.application.user.dto.UserInfoUpdateReq;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.exception.UserErrorType;
@@ -220,6 +221,90 @@ public class UserManagementServiceTest {
 
             // then
             assertEquals(UserErrorType.NOT_FOUND, exception.getErrorType());
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 정보 수정")
+    class UpdateUserInfo {
+        private final Long userId = 1L;
+
+        @Mock
+        private User user;
+
+        @Mock
+        private User foundUser;
+
+        private UserInfoUpdateReq userInfoUpdateReq = UserInfoUpdateReq.builder()
+                .nickname("newNickname")
+                .email("newTest@test.com")
+                .build();
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            when(user.getNickname()).thenReturn("nickname");
+            when(user.getEmail()).thenReturn("test@test.com");
+            when(userService.readIncludeDeletedUserByNickname(eq("newNickname"))).thenReturn(Optional.empty());
+            when(userService.readById(eq(userId))).thenReturn(Optional.of(user));
+
+            // when
+            userManagementService.updateUserInfo(userId, userInfoUpdateReq);
+
+            // then
+            verify(user).updateUserInfo("newNickname", "newTest@test.com");
+
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 사용 중인 닉네임")
+        void failAlreadyUsedNickname() {
+            // given
+            when(foundUser.getId()).thenReturn(2L);
+            when(userService.readIncludeDeletedUserByNickname(eq("newNickname"))).thenReturn(Optional.of(foundUser));
+
+            // when
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> userManagementService.updateUserInfo(userId, userInfoUpdateReq));
+
+            // then
+            assertEquals(UserErrorType.ALREADY_USED_NICKNAME, exception.getErrorType());
+        }
+
+        @Test
+        @DisplayName("실패 - 기존과 동일한 닉네임")
+        void failSameNickname() {
+            // given
+            when(foundUser.getId()).thenReturn(1L);
+            when(user.getNickname()).thenReturn("newNickname");
+            when(userService.readIncludeDeletedUserByNickname(eq("newNickname"))).thenReturn(Optional.of(foundUser));
+            when(userService.readById(eq(userId))).thenReturn(Optional.of(user));
+
+            // when
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> userManagementService.updateUserInfo(userId, userInfoUpdateReq));
+
+            // then
+            assertEquals(UserErrorType.SAME_NICKNAME, exception.getErrorType());
+        }
+
+        @Test
+        @DisplayName("실패 - 기존과 동일한 이메일")
+        void failSameEmail() {
+            // given
+            when(foundUser.getId()).thenReturn(1L);
+            when(user.getNickname()).thenReturn("nickname");
+            when(user.getEmail()).thenReturn("newTest@test.com");
+            when(userService.readIncludeDeletedUserByNickname(eq("newNickname"))).thenReturn(Optional.of(foundUser));
+            when(userService.readById(eq(userId))).thenReturn(Optional.of(user));
+
+            // when
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> userManagementService.updateUserInfo(userId, userInfoUpdateReq));
+
+            // then
+            assertEquals(UserErrorType.SAME_EMAIL, exception.getErrorType());
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/application/user/service/UserManagementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/user/service/UserManagementServiceTest.java
@@ -232,12 +232,8 @@ public class UserManagementServiceTest {
         @Mock
         private User user;
 
-        @Mock
-        private User foundUser;
-
         private UserInfoUpdateReq userInfoUpdateReq = UserInfoUpdateReq.builder()
                 .nickname("newNickname")
-                .email("newTest@test.com")
                 .build();
 
         @Test
@@ -245,15 +241,14 @@ public class UserManagementServiceTest {
         void success() {
             // given
             when(user.getNickname()).thenReturn("nickname");
-            when(user.getEmail()).thenReturn("test@test.com");
-            when(userService.readIncludeDeletedUserByNickname(eq("newNickname"))).thenReturn(Optional.empty());
+            when(userService.existsIncludeDeletedByNickname(eq("newNickname"))).thenReturn(false);
             when(userService.readById(eq(userId))).thenReturn(Optional.of(user));
 
             // when
             userManagementService.updateUserInfo(userId, userInfoUpdateReq);
 
             // then
-            verify(user).updateUserInfo("newNickname", "newTest@test.com");
+            verify(user).updateNickname("newNickname");
 
         }
 
@@ -261,8 +256,9 @@ public class UserManagementServiceTest {
         @DisplayName("실패 - 이미 사용 중인 닉네임")
         void failAlreadyUsedNickname() {
             // given
-            when(foundUser.getId()).thenReturn(2L);
-            when(userService.readIncludeDeletedUserByNickname(eq("newNickname"))).thenReturn(Optional.of(foundUser));
+            when(user.getNickname()).thenReturn("nickname");
+            when(userService.readById(userId)).thenReturn(Optional.of(user));
+            when(userService.existsIncludeDeletedByNickname("newNickname")).thenReturn(true);
 
             // when
             CustomException exception = assertThrows(CustomException.class,
@@ -276,9 +272,7 @@ public class UserManagementServiceTest {
         @DisplayName("실패 - 기존과 동일한 닉네임")
         void failSameNickname() {
             // given
-            when(foundUser.getId()).thenReturn(1L);
             when(user.getNickname()).thenReturn("newNickname");
-            when(userService.readIncludeDeletedUserByNickname(eq("newNickname"))).thenReturn(Optional.of(foundUser));
             when(userService.readById(eq(userId))).thenReturn(Optional.of(user));
 
             // when
@@ -287,24 +281,6 @@ public class UserManagementServiceTest {
 
             // then
             assertEquals(UserErrorType.SAME_NICKNAME, exception.getErrorType());
-        }
-
-        @Test
-        @DisplayName("실패 - 기존과 동일한 이메일")
-        void failSameEmail() {
-            // given
-            when(foundUser.getId()).thenReturn(1L);
-            when(user.getNickname()).thenReturn("nickname");
-            when(user.getEmail()).thenReturn("newTest@test.com");
-            when(userService.readIncludeDeletedUserByNickname(eq("newNickname"))).thenReturn(Optional.of(foundUser));
-            when(userService.readById(eq(userId))).thenReturn(Optional.of(user));
-
-            // when
-            CustomException exception = assertThrows(CustomException.class,
-                    () -> userManagementService.updateUserInfo(userId, userInfoUpdateReq));
-
-            // then
-            assertEquals(UserErrorType.SAME_EMAIL, exception.getErrorType());
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/user/controller/UserControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/user/controller/UserControllerTest.java
@@ -36,7 +36,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;

--- a/src/test/java/kr/co/yeogiga/presentation/user/controller/UserControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/user/controller/UserControllerTest.java
@@ -341,7 +341,6 @@ public class UserControllerTest {
             // given
             UserInfoUpdateReq userInfoUpdateReq = UserInfoUpdateReq.builder()
                     .nickname("newNickname")
-                    .email("newTest@test.com")
                     .build();
             setUpUserDetails(Role.USER);
 
@@ -364,39 +363,11 @@ public class UserControllerTest {
         }
 
         @Test
-        @DisplayName("실패 - 이미 사용 중인 닉네임")
-        void failAlreadyUsedNickname() throws Exception {
-            // given
-            UserInfoUpdateReq userInfoUpdateReq = UserInfoUpdateReq.builder()
-                    .nickname("newNickname")
-                    .email("newTest@test.com")
-                    .build();
-            setUpUserDetails(Role.USER);
-
-            doThrow(new CustomException(UserErrorType.ALREADY_USED_NICKNAME)).when(userManagementService).updateUserInfo(any(), any());
-
-            // when
-            ResultActions resultActions = mockMvc.perform(
-                    put("/api/v1/users")
-                            .with(user(userDetails))
-                            .content(objectMapper.writeValueAsBytes(userInfoUpdateReq))
-                            .contentType(MediaType.APPLICATION_JSON)
-            );
-
-            // then
-            resultActions
-                    .andExpect(status().isConflict())
-                    .andExpect(jsonPath("$.code").value(UserErrorType.ALREADY_USED_NICKNAME.getCode()))
-                    .andExpect(jsonPath("$.message").value(UserErrorType.ALREADY_USED_NICKNAME.getMessage()));
-        }
-
-        @Test
         @DisplayName("실패 - 기존과 동일한 닉네임")
         void failSameNickname() throws Exception {
             // given
             UserInfoUpdateReq userInfoUpdateReq = UserInfoUpdateReq.builder()
                     .nickname("newNickname")
-                    .email("newTest@test.com")
                     .build();
             setUpUserDetails(Role.USER);
 
@@ -418,39 +389,11 @@ public class UserControllerTest {
         }
 
         @Test
-        @DisplayName("실패 - 기존과 동일한 이메일")
-        void failSameEmail() throws Exception {
-            // given
-            UserInfoUpdateReq userInfoUpdateReq = UserInfoUpdateReq.builder()
-                    .nickname("newNickname")
-                    .email("newTest@test.com")
-                    .build();
-            setUpUserDetails(Role.USER);
-
-            doThrow(new CustomException(UserErrorType.SAME_EMAIL)).when(userManagementService).updateUserInfo(any(), any());
-
-            // when
-            ResultActions resultActions = mockMvc.perform(
-                    put("/api/v1/users")
-                            .with(user(userDetails))
-                            .content(objectMapper.writeValueAsBytes(userInfoUpdateReq))
-                            .contentType(MediaType.APPLICATION_JSON)
-            );
-
-            // then
-            resultActions
-                    .andExpect(status().isConflict())
-                    .andExpect(jsonPath("$.code").value(UserErrorType.SAME_EMAIL.getCode()))
-                    .andExpect(jsonPath("$.message").value(UserErrorType.SAME_EMAIL.getMessage()));
-        }
-
-        @Test
         @DisplayName("실패 - 유효성 검증 실패")
         void failValidation() throws Exception {
             // given
             UserInfoUpdateReq userInfoUpdateReq = UserInfoUpdateReq.builder()
 //                    .nickname("newNickname")
-//                    .email("newTest@test.com")
                     .build();
             setUpUserDetails(Role.USER);
 
@@ -466,8 +409,7 @@ public class UserControllerTest {
             resultActions
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value(CommonErrorType.VALIDATION_ERROR.getCode()))
-                    .andExpect(jsonPath("$.errors.nickname").exists())
-                    .andExpect(jsonPath("$.errors.email").exists());
+                    .andExpect(jsonPath("$.errors.nickname").exists());
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/user/controller/UserControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/user/controller/UserControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.auth.constant.AuthConstants;
 import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
 import kr.co.yeogiga.application.user.dto.UserInfoRes;
+import kr.co.yeogiga.application.user.dto.UserInfoUpdateReq;
 import kr.co.yeogiga.application.user.service.UserManagementService;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.response.error.type.CommonErrorType;
@@ -45,6 +46,7 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -326,6 +328,146 @@ public class UserControllerTest {
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.code").value(UserErrorType.NOT_FOUND.getCode()))
                     .andExpect(jsonPath("$.message").value(UserErrorType.NOT_FOUND.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 정보 수정")
+    class UpdateUserInfo {
+
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            UserInfoUpdateReq userInfoUpdateReq = UserInfoUpdateReq.builder()
+                    .nickname("newNickname")
+                    .email("newTest@test.com")
+                    .build();
+            setUpUserDetails(Role.USER);
+
+            doNothing().when(userManagementService).updateUserInfo(userDetails.getUserId(), userInfoUpdateReq);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    put("/api/v1/users")
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsBytes(userInfoUpdateReq))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(SuccessResponse.ok().code()))
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 사용 중인 닉네임")
+        void failAlreadyUsedNickname() throws Exception {
+            // given
+            UserInfoUpdateReq userInfoUpdateReq = UserInfoUpdateReq.builder()
+                    .nickname("newNickname")
+                    .email("newTest@test.com")
+                    .build();
+            setUpUserDetails(Role.USER);
+
+            doThrow(new CustomException(UserErrorType.ALREADY_USED_NICKNAME)).when(userManagementService).updateUserInfo(any(), any());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    put("/api/v1/users")
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsBytes(userInfoUpdateReq))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value(UserErrorType.ALREADY_USED_NICKNAME.getCode()))
+                    .andExpect(jsonPath("$.message").value(UserErrorType.ALREADY_USED_NICKNAME.getMessage()));
+        }
+
+        @Test
+        @DisplayName("실패 - 기존과 동일한 닉네임")
+        void failSameNickname() throws Exception {
+            // given
+            UserInfoUpdateReq userInfoUpdateReq = UserInfoUpdateReq.builder()
+                    .nickname("newNickname")
+                    .email("newTest@test.com")
+                    .build();
+            setUpUserDetails(Role.USER);
+
+            doThrow(new CustomException(UserErrorType.SAME_NICKNAME)).when(userManagementService).updateUserInfo(any(), any());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    put("/api/v1/users")
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsBytes(userInfoUpdateReq))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value(UserErrorType.SAME_NICKNAME.getCode()))
+                    .andExpect(jsonPath("$.message").value(UserErrorType.SAME_NICKNAME.getMessage()));
+        }
+
+        @Test
+        @DisplayName("실패 - 기존과 동일한 이메일")
+        void failSameEmail() throws Exception {
+            // given
+            UserInfoUpdateReq userInfoUpdateReq = UserInfoUpdateReq.builder()
+                    .nickname("newNickname")
+                    .email("newTest@test.com")
+                    .build();
+            setUpUserDetails(Role.USER);
+
+            doThrow(new CustomException(UserErrorType.SAME_EMAIL)).when(userManagementService).updateUserInfo(any(), any());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    put("/api/v1/users")
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsBytes(userInfoUpdateReq))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value(UserErrorType.SAME_EMAIL.getCode()))
+                    .andExpect(jsonPath("$.message").value(UserErrorType.SAME_EMAIL.getMessage()));
+        }
+
+        @Test
+        @DisplayName("실패 - 유효성 검증 실패")
+        void failValidation() throws Exception {
+            // given
+            UserInfoUpdateReq userInfoUpdateReq = UserInfoUpdateReq.builder()
+//                    .nickname("newNickname")
+//                    .email("newTest@test.com")
+                    .build();
+            setUpUserDetails(Role.USER);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    put("/api/v1/users")
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsBytes(userInfoUpdateReq))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(CommonErrorType.VALIDATION_ERROR.getCode()))
+                    .andExpect(jsonPath("$.errors.nickname").exists())
+                    .andExpect(jsonPath("$.errors.email").exists());
         }
     }
 }


### PR DESCRIPTION
## 배경
- 회원 정보 수정

## 작업 사항
- 회원 정보 수정 로직 추가
   - 갱신 필드: `nickname`, ~`email`~
   - 예외 사항
      1) 동일한 닉네임을 가진 사용자가 존재하는 경우
      2) 기존과 동일한 닉네임
      ~3) 기존과 동일한 이메일~

## 🛠️ 변경사항

- 회원 정보 수정 시 이메일 값 제외
   - 그에 따른 차후 변경 소요
      - OAuth 로그인 시 이메일 값 저장 x
      - `User` 내 `email` 필드 유니크 설정 → 회원가입 시 이메일 중복 확인 필요 & email 중복 여부 조회 api 추가 필요
      => 해당 사항들 다음 PR에 포함하겠습니다.