### PR TITLE
Feature(IL-77): 이미지 및 여행 일차 요약 정보 조회 로직 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripDaySummaryRes.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripDaySummaryRes.java
@@ -1,0 +1,74 @@
+package kr.co.yeogiga.application.tripplace.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import kr.co.yeogiga.domain.tripplace.entity.Image;
+import kr.co.yeogiga.domain.tripplace.entity.Place;
+import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class TripDaySummaryRes {
+
+    public record DayDto(
+            String id,
+            Integer day,
+            List<PlaceDto> places,
+            List<ImageDto> unmatchedImages
+    ) {
+        public static DayDto from(TripDayPlace tripDayPlace) {
+            return new DayDto(
+                    tripDayPlace.getId(),
+                    tripDayPlace.getDay(),
+                    tripDayPlace.getPlaces().stream()
+                            .filter(p -> p.getId() != null)
+                            .map(PlaceDto::from)
+                            .toList(),
+                    tripDayPlace.getUnmatchedImages().stream()
+                            .map(ImageDto::from)
+                            .toList()
+            );
+        }
+    }
+
+    public record PlaceDto(
+            String id,
+            String name,
+            Double latitude,
+            Double longitude,
+            String type,
+            List<ImageDto> images
+    ) {
+        public static PlaceDto from(Place place) {
+            return new PlaceDto(
+                    place.getId(),
+                    place.getName(),
+                    place.getLatitude(),
+                    place.getLongitude(),
+                    place.getPlaceType(),
+                    place.getImages().stream()
+                            .map(ImageDto::from)
+                            .toList()
+            );
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record ImageDto(
+            String id,
+            String url,
+            Double latitude,
+            Double longitude,
+            LocalDateTime date
+    ) {
+        public static ImageDto from(Image image) {
+            return new ImageDto(
+                    image.getId(),
+                    image.getUrl(),
+                    image.getLatitude(),
+                    image.getLongitude(),
+                    image.getDate()
+            );
+        }
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripDaySummaryRes.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripDaySummaryRes.java
@@ -14,7 +14,7 @@ public class TripDaySummaryRes {
             String id,
             Integer day,
             List<PlaceDto> places,
-            List<ImageDto> unmatchedImages
+            ImageDto unmatchedImage
     ) {
         public static DayDto from(TripDayPlace tripDayPlace) {
             return new DayDto(
@@ -25,8 +25,9 @@ public class TripDaySummaryRes {
                             .map(PlaceDto::from)
                             .toList(),
                     tripDayPlace.getUnmatchedImages().stream()
+                            .findFirst()
                             .map(ImageDto::from)
-                            .toList()
+                            .orElse(null)
             );
         }
     }
@@ -37,7 +38,7 @@ public class TripDaySummaryRes {
             Double latitude,
             Double longitude,
             String type,
-            List<ImageDto> images
+            ImageDto image
     ) {
         public static PlaceDto from(Place place) {
             return new PlaceDto(
@@ -47,8 +48,9 @@ public class TripDaySummaryRes {
                     place.getLongitude(),
                     place.getPlaceType(),
                     place.getImages().stream()
+                            .findFirst()
                             .map(ImageDto::from)
-                            .toList()
+                            .orElse(null)
             );
         }
     }

--- a/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceRes.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceRes.java
@@ -24,11 +24,10 @@ public class TripPlaceRes {
     public record PlaceSummary(
             String id,
             String name,
-            String placeType,
-            double order
+            String placeType
     ) {
         public static PlaceSummary from(Place place) {
-            return new PlaceSummary(place.getId(), place.getName(), place.getPlaceType(), place.getOrder());
+            return new PlaceSummary(place.getId(), place.getName(), place.getPlaceType());
         }
     }
 
@@ -37,12 +36,11 @@ public class TripPlaceRes {
             String name,
             double latitude,
             double longitude,
-            String placeType,
-            double order
+            String placeType
     ) {
         public static PlaceDetails from(Place place) {
             return new PlaceDetails(place.getId(), place.getName(), place.getLatitude(),
-                    place.getLongitude(), place.getPlaceType(), place.getOrder());
+                    place.getLongitude(), place.getPlaceType());
         }
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/TripPlaceImageReq.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/TripPlaceImageReq.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public class TripPlaceImageReq {
 
-    @Schema(name = "TripPlaceImageDto.ImageMoveReq", description = "같은 날짜 내 이미지 이동 요청 DTO")
+    @Schema(name = "TripPlaceImageReq.ImageMove", description = "같은 날짜 내 이미지 이동 요청 DTO")
     public record ImageMove(
             @Schema(description = "이미지가 현재 속한 목적지 ID", example = "place1-id")
             String fromPlaceId,
@@ -14,7 +14,7 @@ public class TripPlaceImageReq {
             String imageId
     ) { }
 
-    @Schema(name = "TripPlaceImageDto.ImageCrossDayMoveReq", description = "다른 날짜 간 이미지 이동 요청 DTO")
+    @Schema(name = "TripPlaceImageReq.ImageCrossDayMove", description = "다른 날짜 간 이미지 이동 요청 DTO")
     public record ImageCrossDayMove(
             @Schema(description = "이미지가 속한 원본 TripDayPlace ID", example = "trip-day-1-id")
             String fromTripDayPlaceId,
@@ -28,7 +28,7 @@ public class TripPlaceImageReq {
             String imageId
     ) { }
 
-    @Schema(name = "TripPlaceImageDto.ImageUnmatchedMoveReq", description = "Unmatched <-> 목적지 이미지 이동 요청 DTO")
+    @Schema(name = "TripPlaceImageReq.ImageUnmatchedMove", description = "Unmatched <-> 목적지 이미지 이동 요청 DTO")
     public record ImageUnmatchedMove(
             @Schema(description = "대상 Place ID (Unmatched <-> Place 이동 시 Place ID)", example = "place1-id")
             String placeId,

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/TripPlaceImageReq.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/TripPlaceImageReq.java
@@ -2,10 +2,10 @@ package kr.co.yeogiga.application.tripplace.image.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public class TripPlaceImageDto {
+public class TripPlaceImageReq {
 
     @Schema(name = "TripPlaceImageDto.ImageMoveReq", description = "같은 날짜 내 이미지 이동 요청 DTO")
-    public record ImageMoveReq(
+    public record ImageMove(
             @Schema(description = "이미지가 현재 속한 목적지 ID", example = "place1-id")
             String fromPlaceId,
             @Schema(description = "이미지를 옮길 목적지 ID", example = "place2-id")
@@ -15,7 +15,7 @@ public class TripPlaceImageDto {
     ) { }
 
     @Schema(name = "TripPlaceImageDto.ImageCrossDayMoveReq", description = "다른 날짜 간 이미지 이동 요청 DTO")
-    public record ImageCrossDayMoveReq(
+    public record ImageCrossDayMove(
             @Schema(description = "이미지가 속한 원본 TripDayPlace ID", example = "trip-day-1-id")
             String fromTripDayPlaceId,
             @Schema(description = "이미지가 현재 속한 목적지 ID", example = "place1-id")
@@ -29,7 +29,7 @@ public class TripPlaceImageDto {
     ) { }
 
     @Schema(name = "TripPlaceImageDto.ImageUnmatchedMoveReq", description = "Unmatched <-> 목적지 이미지 이동 요청 DTO")
-    public record ImageUnmatchedMoveReq(
+    public record ImageUnmatchedMove(
             @Schema(description = "대상 Place ID (Unmatched <-> Place 이동 시 Place ID)", example = "place1-id")
             String placeId,
             @Schema(description = "이동할 이미지 ID", example = "image-id")

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/TripPlaceImageRes.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/TripPlaceImageRes.java
@@ -2,6 +2,7 @@ package kr.co.yeogiga.application.tripplace.image.dto;
 
 import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
+import lombok.Builder;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -9,6 +10,7 @@ import java.util.stream.Collectors;
 
 public class TripPlaceImageRes {
 
+    @Builder
     public record PlaceImageInfo(
             String id,
             String name,
@@ -31,6 +33,7 @@ public class TripPlaceImageRes {
         }
     }
 
+    @Builder
     public record UnmatchedImageInfo(
             List<ImageDto> images
     ) {
@@ -43,6 +46,7 @@ public class TripPlaceImageRes {
         }
     }
 
+    @Builder
     public record ImageDto(
             String id,
             String url,

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/TripPlaceImageRes.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/TripPlaceImageRes.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.application.tripplace.image.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import lombok.Builder;
@@ -47,6 +48,7 @@ public class TripPlaceImageRes {
     }
 
     @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public record ImageDto(
             String id,
             String url,

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/TripPlaceImageRes.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/TripPlaceImageRes.java
@@ -1,0 +1,63 @@
+package kr.co.yeogiga.application.tripplace.image.dto;
+
+import kr.co.yeogiga.domain.tripplace.entity.Image;
+import kr.co.yeogiga.domain.tripplace.entity.Place;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class TripPlaceImageRes {
+
+    public record PlaceImageInfo(
+            String id,
+            String name,
+            double latitude,
+            double longitude,
+            String placeType,
+            List<ImageDto> images
+    ) {
+        public static PlaceImageInfo from(Place place) {
+            return new PlaceImageInfo(
+                    place.getId(),
+                    place.getName(),
+                    place.getLatitude(),
+                    place.getLongitude(),
+                    place.getPlaceType(),
+                    place.getImages().stream()
+                            .map(ImageDto::from)
+                            .collect(Collectors.toList())
+            );
+        }
+    }
+
+    public record UnmatchedImageInfo(
+            List<ImageDto> images
+    ) {
+        public static UnmatchedImageInfo from(List<Image> unmatchedImages) {
+            return new UnmatchedImageInfo(
+                    unmatchedImages.stream()
+                            .map(ImageDto::from)
+                            .collect(Collectors.toList())
+            );
+        }
+    }
+
+    public record ImageDto(
+            String id,
+            String url,
+            Double latitude,
+            Double longitude,
+            LocalDateTime date
+    ) {
+        public static ImageDto from(Image image) {
+            return new ImageDto(
+                    image.getId(),
+                    image.getUrl(),
+                    image.getLatitude(),
+                    image.getLongitude(),
+                    image.getDate()
+            );
+        }
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageMovementService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageMovementService.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.application.tripplace.image.service;
 
-import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDto;
+import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageReq;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.entity.Image;
@@ -25,7 +25,7 @@ public class TripPlaceImageMovementService {
      * @param tripDayPlaceId TripDayPlace 문서 ID
      * @param imageReq       이미지 이동에 필요한 정보를 담은 요청 DTO
      */
-    public void moveImageToAnotherPlace(String tripDayPlaceId, TripPlaceImageDto.ImageMoveReq imageReq) {
+    public void moveImageToAnotherPlace(String tripDayPlaceId, TripPlaceImageReq.ImageMove imageReq) {
         Image image = getImageFromTripPlace(tripDayPlaceId, imageReq.fromPlaceId(), imageReq.imageId());
 
         tripDayPlaceService.deleteImage(tripDayPlaceId, imageReq.fromPlaceId(), imageReq.imageId());
@@ -37,7 +37,7 @@ public class TripPlaceImageMovementService {
      *
      * @param imageReq 이미지 이동에 필요한 정보를 담은 요청 DTO
      */
-    public void moveImageBetweenDayPlaces(TripPlaceImageDto.ImageCrossDayMoveReq imageReq) {
+    public void moveImageBetweenDayPlaces(TripPlaceImageReq.ImageCrossDayMove imageReq) {
         Image image = getImageFromTripPlace(imageReq.fromTripDayPlaceId(), imageReq.fromPlaceId(), imageReq.imageId());
 
         tripDayPlaceService.deleteImage(imageReq.fromTripDayPlaceId(), imageReq.fromPlaceId(), imageReq.imageId());
@@ -50,7 +50,7 @@ public class TripPlaceImageMovementService {
      * @param tripDayPlaceId TripDayPlace 문서 ID
      * @param imageReq       이미지 이동에 필요한 정보를 담은 요청 DTO
      */
-    public void moveImageToUnmatched(String tripDayPlaceId, TripPlaceImageDto.ImageUnmatchedMoveReq imageReq) {
+    public void moveImageToUnmatched(String tripDayPlaceId, TripPlaceImageReq.ImageUnmatchedMove imageReq) {
         Image image = getImageFromTripPlace(tripDayPlaceId, imageReq.placeId(), imageReq.imageId());
 
         tripDayPlaceService.deleteImage(tripDayPlaceId, imageReq.placeId(), imageReq.imageId());
@@ -63,7 +63,7 @@ public class TripPlaceImageMovementService {
      * @param tripDayPlaceId TripDayPlace 문서 ID
      * @param imageReq       이미지 이동에 필요한 정보를 담은 요청 DTO
      */
-    public void moveImageFromUnmatchedToPlace(String tripDayPlaceId, TripPlaceImageDto.ImageUnmatchedMoveReq imageReq) {
+    public void moveImageFromUnmatchedToPlace(String tripDayPlaceId, TripPlaceImageReq.ImageUnmatchedMove imageReq) {
         TripDayPlace tripDayPlace = getTripDayPlaceById(tripDayPlaceId);
 
         Image image = tripDayPlace.getUnmatchedImages().stream()

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageQueryService.java
@@ -1,0 +1,47 @@
+package kr.co.yeogiga.application.tripplace.image.service;
+
+import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageRes;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.tripplace.entity.Image;
+import kr.co.yeogiga.domain.tripplace.entity.Place;
+import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 여행 일차의 장소 이미지 관련 정보를 조회하는 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class TripPlaceImageQueryService {
+    private final TripDayPlaceService tripDayPlaceService;
+
+    /**
+     * 특정 TripDayPlace 내에서 지정된 Place의 정보와 해당 장소에 속한 이미지 목록을 조회 메서드
+     *
+     * @param tripDayPlaceId TripDayPlace(여행 일차) ID
+     * @param placeId        조회할 Place(장소) ID
+     * @return 해당 장소의 기본 정보와 이미지 목록이 포함된 응답 DTO
+     */
+    public TripPlaceImageRes.PlaceImageInfo getPlaceImageInfo(String tripDayPlaceId, String placeId) {
+        Place place = tripDayPlaceService.readPlaceByIdAndPlaceId(tripDayPlaceId, placeId)
+                .orElseThrow(() -> new CustomException(TripErrorType.PLACE_NOT_FOUND));
+
+        return TripPlaceImageRes.PlaceImageInfo.from(place);
+    }
+
+    /**
+     * TripDayPlace의 unmatchedImages (어느 장소에도 연결되지 않은 기타 이미지)를 조회 메서드
+     *
+     * @param tripDayPlaceId TripDayPlace(여행 일차) ID
+     * @return unmatchedImages 목록이 포함된 응답 DTO
+     */
+    public TripPlaceImageRes.UnmatchedImageInfo getUnmatchedImageInfo(String tripDayPlaceId) {
+        List<Image> images = tripDayPlaceService.readUnmatchedImagesById(tripDayPlaceId);
+
+        return TripPlaceImageRes.UnmatchedImageInfo.from(images);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceQueryService.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.application.tripplace.service;
 
+import kr.co.yeogiga.application.tripplace.dto.TripDaySummaryRes;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
@@ -43,6 +44,21 @@ public class TripPlaceQueryService {
 
         return tripDayPlace.getPlaces().stream()
                 .map(TripPlaceRes.PlaceDetails::from)
+                .toList();
+    }
+
+    /**
+     * 여행 ID로 해당 여행의 일차별 요약 정보 조회 메서드
+     * - 각 여행 일차(Day)마다 포함된 장소(Place)와 이미지(Image) 정보를 포함. (이미지는 1장. 썸네일용)
+     *
+     * @param tripId 조회할 여행 ID
+     * @return 일차 요약 정보 리스트
+     */
+    public List<TripDaySummaryRes.DayDto> getTripDaySummaries(Long tripId) {
+        List<TripDayPlace> tripDayPlaces = tripDayPlaceService.readTripDayPlaceSummariesByTripId(tripId);
+
+        return tripDayPlaces.stream()
+                .map(TripDaySummaryRes.DayDto::from)
                 .toList();
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
@@ -2,23 +2,25 @@ package kr.co.yeogiga.domain.tripplace.entity;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 public class Place {
+    @Field("id")
     private String id;
     private String name;
-    private double latitude;
-    private double longitude;
+    private Double latitude;
+    private Double longitude;
     private String placeType;
-    private double order;
+    private Double order;
     private List<Image> images;
 
     @Builder
-    public Place(String id, String name, double latitude,
-                 double longitude, String placeType, double order) {
+    public Place(String id, String name, Double latitude,
+                 Double longitude, String placeType, Double order) {
         this.id = id;
         this.name = name;
         this.latitude = latitude;

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
@@ -16,6 +16,7 @@ public interface CustomTripDayPlaceRepository {
     List<TripDayPlace> findByTripIdSorted(Long tripId);
     Optional<Place> findPlaceByIdAndPlaceId(String id, String placeId);
     List<Image> findUnmatchedImagesById(String id);
+    List<TripDayPlace> findTripDayPlaceSummariesByTripId(Long tripId);
     void deletePlace(String id, String placeId);
     void deleteImage(String id, String placeId, String imageId);
     void deleteImageFromUnMatched(String id, String imageId);

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
@@ -14,6 +14,8 @@ public interface CustomTripDayPlaceRepository {
     Double findOrderByIdAndPlaceId(String id, String placeId);
     Optional<TripDayPlace> findByIdSorted(String id);
     List<TripDayPlace> findByTripIdSorted(Long tripId);
+    Optional<Place> findPlaceByIdAndPlaceId(String id, String placeId);
+    List<Image> findUnmatchedImagesById(String id);
     void deletePlace(String id, String placeId);
     void deleteImage(String id, String placeId, String imageId);
     void deleteImageFromUnMatched(String id, String imageId);

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
@@ -99,6 +99,39 @@ public class CustomTripDayPlaceRepositoryImpl implements CustomTripDayPlaceRepos
     }
 
     @Override
+    public Optional<Place> findPlaceByIdAndPlaceId(String id, String placeId) {
+        Criteria criteria = Criteria.where("_id").is(id)
+                .and("places.id").is(placeId);
+
+        Query query = new Query(criteria);
+        query.fields().include("places.$");
+
+        TripDayPlace result = mongoTemplate.findOne(query, TripDayPlace.class);
+
+        if (result == null || result.getPlaces() == null || result.getPlaces().isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(result.getPlaces().get(0));
+    }
+
+    @Override
+    public List<Image> findUnmatchedImagesById(String id) {
+        Criteria criteria = Criteria.where("_id").is(id);
+
+        Query query = new Query(criteria);
+        query.fields().include("unmatchedImages");
+
+        TripDayPlace result = mongoTemplate.findOne(query, TripDayPlace.class);
+
+        if (result == null || result.getUnmatchedImages() == null) {
+            return List.of();
+        }
+
+        return result.getUnmatchedImages();
+    }
+
+    @Override
     public void deletePlace(String id, String placeId) {
         Query query = new Query(Criteria.where("_id").is(id));
         Update update = new Update().pull("places", Query.query(Criteria.where("id").is(placeId)));

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
@@ -4,10 +4,12 @@ import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import lombok.RequiredArgsConstructor;
+import org.bson.Document;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.data.mongodb.core.aggregation.ArrayOperators;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
@@ -129,6 +131,59 @@ public class CustomTripDayPlaceRepositoryImpl implements CustomTripDayPlaceRepos
         }
 
         return result.getUnmatchedImages();
+    }
+
+    @Override
+    public List<TripDayPlace> findTripDayPlaceSummariesByTripId(Long tripId) {
+        Aggregation aggregation = Aggregation.newAggregation(
+                // 해당 tripId에 해당하는 모든 TripDayPlace 조회
+                Aggregation.match(Criteria.where("tripId").is(tripId)),
+
+                // unmatchedImages 1장만
+                Aggregation.project("day")
+                        .and("_id").as("id")
+                        .and("places").as("places")
+                        .and(ArrayOperators.Slice.sliceArrayOf("unmatchedImages").itemCount(1)).as("unmatchedImage"),
+
+                // places 펼침 (null값 포함)
+                Aggregation.unwind("places", true),
+
+                // place 필드 정제 + 이미지 1장만
+                Aggregation.project("id", "day", "unmatchedImage")
+                        .and("places.id").as("placeId")
+                        .and("places.name").as("name")
+                        .and("places.latitude").as("latitude")
+                        .and("places.longitude").as("longitude")
+                        .and("places.placeType").as("placeType")
+                        .and("places.order").as("order")
+                        .and(ArrayOperators.Slice.sliceArrayOf("places.images").itemCount(1)).as("image"),
+
+                // order 정렬
+                Aggregation.sort(Sort.by(Sort.Direction.ASC, "order")),
+
+                // 다시 TripDayPlace 단위로 그룹화
+                Aggregation.group("_id")
+                        .first("day").as("day")
+                        .first("unmatchedImage").as("unmatchedImages")
+                        .push(
+                                new Document("id", "$placeId")
+                                        .append("name", "$name")
+                                        .append("latitude", "$latitude")
+                                        .append("longitude", "$longitude")
+                                        .append("placeType", "$placeType")
+                                        .append("order", "$order")
+                                        .append("images", "$image")
+                        ).as("places"),
+
+                // day 기준 정렬
+                Aggregation.sort(Sort.by(Sort.Direction.ASC, "day"))
+        );
+
+        AggregationResults<TripDayPlace> result = mongoTemplate.aggregate(
+                aggregation, "trip_day_place", TripDayPlace.class
+        );
+
+        return result.getMappedResults();
     }
 
     @Override

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
@@ -59,6 +59,10 @@ public class TripDayPlaceService {
         return tripDayPlaceRepository.findUnmatchedImagesById(id);
     }
 
+    public List<TripDayPlace> readTripDayPlaceSummariesByTripId(Long tripId) {
+        return tripDayPlaceRepository.findTripDayPlaceSummariesByTripId(tripId);
+    }
+
     public void deletePlace(String id, String placeId) {
         tripDayPlaceRepository.deletePlace(id, placeId);
     }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
@@ -51,6 +51,14 @@ public class TripDayPlaceService {
         return tripDayPlaceRepository.findOrderByIdAndPlaceId(id, placeId);
     }
 
+    public Optional<Place> readPlaceByIdAndPlaceId(String id, String placeId) {
+        return tripDayPlaceRepository.findPlaceByIdAndPlaceId(id, placeId);
+    }
+
+    public List<Image> readUnmatchedImagesById(String id) {
+        return tripDayPlaceRepository.findUnmatchedImagesById(id);
+    }
+
     public void deletePlace(String id, String placeId) {
         tripDayPlaceRepository.deletePlace(id, placeId);
     }

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/api/TripPlaceApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/api/TripPlaceApi.java
@@ -154,15 +154,13 @@ public interface TripPlaceApi {
                                                              "latitude": 0.0,
                                                              "longitude": 1.1,
                                                              "type": "식당",
-                                                             "images": [
-                                                                 {
+                                                             "image": {
                                                                      "id": "image1-id",
                                                                      "url": "https://image1.com",
                                                                      "latitude": 1.1,
                                                                      "longitude": 2.2,
                                                                      "date": "2025-04-13T21:53:57.445"
                                                                  }
-                                                             ]
                                                          },
                                                          {
                                                              "id": "place2-id",
@@ -170,15 +168,13 @@ public interface TripPlaceApi {
                                                              "latitude": 3.3,
                                                              "longitude": 4.4,
                                                              "type": "식당",
-                                                             "images": []
+                                                             "image": null
                                                          }
                                                      ],
-                                                     "unmatchedImages": [
-                                                         {
-                                                             "id": "image2-id",
-                                                             "url": "https://image2.com"
-                                                         }
-                                                     ]
+                                                     "unmatchedImage": {
+                                                         "id": "image2-id",
+                                                         "url": "https://image2.com"
+                                                     }
                                                 }
                                             ]
                                         }

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/api/TripPlaceApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/api/TripPlaceApi.java
@@ -134,6 +134,59 @@ public interface TripPlaceApi {
     ResponseEntity<?> getPlaceDetailsInfo(@PathVariable Long tripId,
                                           @PathVariable String tripDayPlaceId);
 
+    @TrackApi(description = "목적지 요약 정보 불러오기 (여행 회고 과정 중)")
+    @Operation(summary = "목적지 요약 정보 불러오기 (여행 회고 과정 중)", description = "여행 목적지 요약 정보를 불러오는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "여행 목적지 요약 정보 불러오기",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": [
+                                                {
+                                                     "id": "tripDayPlace-id",
+                                                     "day": 1,
+                                                     "places": [
+                                                         {
+                                                             "id": "place1-id",
+                                                             "name": "목적지1",
+                                                             "latitude": 0.0,
+                                                             "longitude": 1.1,
+                                                             "type": "식당",
+                                                             "images": [
+                                                                 {
+                                                                     "id": "image1-id",
+                                                                     "url": "https://image1.com",
+                                                                     "latitude": 1.1,
+                                                                     "longitude": 2.2,
+                                                                     "date": "2025-04-13T21:53:57.445"
+                                                                 }
+                                                             ]
+                                                         },
+                                                         {
+                                                             "id": "place2-id",
+                                                             "name": "목적지2",
+                                                             "latitude": 3.3,
+                                                             "longitude": 4.4,
+                                                             "type": "식당",
+                                                             "images": []
+                                                         }
+                                                     ],
+                                                     "unmatchedImages": [
+                                                         {
+                                                             "id": "image2-id",
+                                                             "url": "https://image2.com"
+                                                         }
+                                                     ]
+                                                }
+                                            ]
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getTripDaySummaries(@PathVariable Long tripId);
+
     @TrackApi(description = "여행 목적지 순서 변경")
     @Operation(summary = "여행 목적지 순서 변경", description = "여행 목적지 순서를 변경하는 API입니다.")
     @ApiResponses({

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceController.java
@@ -63,6 +63,7 @@ public class TripPlaceController implements TripPlaceApi {
         );
     }
 
+    @Override
     @GetMapping("/{tripId}/day-place")
     public ResponseEntity<?> getTripDaySummaries(@PathVariable Long tripId) {
         return ResponseEntity.ok(

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceController.java
@@ -63,6 +63,13 @@ public class TripPlaceController implements TripPlaceApi {
         );
     }
 
+    @GetMapping("/{tripId}/day-place")
+    public ResponseEntity<?> getTripDaySummaries(@PathVariable Long tripId) {
+        return ResponseEntity.ok(
+                SuccessResponse.from(tripPlaceQueryService.getTripDaySummaries(tripId))
+        );
+    }
+
     @Override
     @PutMapping("/{tripId}/day-place/{tripDayPlaceId}/places/order")
     public ResponseEntity<?> reorderPlaces(@PathVariable Long tripId,

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/api/TripPlaceImageApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/api/TripPlaceImageApi.java
@@ -18,6 +18,77 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "[이미지 매칭 후 이미지 API]", description = "이미지 매칭 후 이미지 관련 API")
 public interface TripPlaceImageApi {
 
+    @TrackApi(description = "목적지에 맞는 이미지 조회")
+    @Operation(summary = "목적지에 맞는 이미지 조회", description = "목적지에 맞는 이미지 조회하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "목적지에 맞는 이미지 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": {
+                                                "id": "place1-id",
+                                                "name": "목적지1",
+                                                "latitude": 0.0,
+                                                "longitude": 1.1,
+                                                "type": "식당",
+                                                "images": [
+                                                     {
+                                                         "id": "image1-id",
+                                                         "url": "https://image1.com",
+                                                         "latitude": 1.1,
+                                                         "longitude": 2.2,
+                                                         "date": "2025-04-13T21:53:57.445"
+                                                     }
+                                                ]
+                                            }
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "여행 일차 존재하지 않음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": "T005",
+                                            "message": "해당 목적지가 존재하지 않습니다"
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getPlaceInfo(
+            @PathVariable Long tripId,
+            @PathVariable String tripDayPlaceId,
+            @PathVariable String placeId
+    );
+
+    @TrackApi(description = "기타 이미지 조회")
+    @Operation(summary = "기타 이미지 조회", description = "기타 이미지 조회하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "기타 이미지 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": {
+                                                "images": [
+                                                     {
+                                                         "id": "image1-id",
+                                                         "url": "https://image1.com"
+                                                     }
+                                                ]
+                                            }
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getUnmatchedImageInfo(
+            @PathVariable Long tripId,
+            @PathVariable String tripDayPlaceId
+    );
+
+
     @TrackApi(description = "같은 날짜 목적지 to 목적지")
     @Operation(summary = "같은 날짜 목적지 to 목적지", description = "같은 날짜 목적지 to 목적지 이동하는 API입니다.")
     @ApiResponses({

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/api/TripPlaceImageApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/api/TripPlaceImageApi.java
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDeleteDto;
-import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDto;
+import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageReq;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -55,7 +55,7 @@ public interface TripPlaceImageApi {
     ResponseEntity<?> moveImageToAnotherPlace(
             @PathVariable Long tripId,
             @PathVariable String tripDayPlaceId,
-            @RequestBody TripPlaceImageDto.ImageMoveReq imageReq
+            @RequestBody TripPlaceImageReq.ImageMove imageReq
     );
 
     @TrackApi(description = "다른 날짜 목적지 to 목적지")
@@ -94,7 +94,7 @@ public interface TripPlaceImageApi {
     })
     ResponseEntity<?> moveImageBetweenDayPlaces(
             @PathVariable Long tripId,
-            @RequestBody TripPlaceImageDto.ImageCrossDayMoveReq imageReq
+            @RequestBody TripPlaceImageReq.ImageCrossDayMove imageReq
     );
 
     @TrackApi(description = "같은 날짜 목적지 to unmatched(기타)")
@@ -134,7 +134,7 @@ public interface TripPlaceImageApi {
     ResponseEntity<?> moveImageToUnmatched(
             @PathVariable Long tripId,
             @PathVariable String tripDayPlaceId,
-            @RequestBody TripPlaceImageDto.ImageUnmatchedMoveReq imageReq
+            @RequestBody TripPlaceImageReq.ImageUnmatchedMove imageReq
     );
 
     @TrackApi(description = "같은 날짜 unmatched(기타) to 목적지")
@@ -174,7 +174,7 @@ public interface TripPlaceImageApi {
     ResponseEntity<?> moveImageFromUnmatched(
             @PathVariable Long tripId,
             @PathVariable String tripDayPlaceId,
-            @RequestBody TripPlaceImageDto.ImageUnmatchedMoveReq imageReq
+            @RequestBody TripPlaceImageReq.ImageUnmatchedMove imageReq
     );
 
     @TrackApi(description = "이미지 단일 삭제")

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
@@ -1,7 +1,7 @@
 package kr.co.yeogiga.presentation.tripplace.image.controller;
 
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDeleteDto;
-import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDto;
+import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageReq;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageDeleteService;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageMovementService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
@@ -27,7 +27,7 @@ public class TripPlaceImageController implements TripPlaceImageApi {
     public ResponseEntity<?> moveImageToAnotherPlace(
             @PathVariable Long tripId,
             @PathVariable String tripDayPlaceId,
-            @RequestBody TripPlaceImageDto.ImageMoveReq imageReq
+            @RequestBody TripPlaceImageReq.ImageMove imageReq
     ) {
         tripPlaceImageMovementService.moveImageToAnotherPlace(tripDayPlaceId, imageReq);
         return ResponseEntity.ok(SuccessResponse.ok());
@@ -37,7 +37,7 @@ public class TripPlaceImageController implements TripPlaceImageApi {
     @PatchMapping("/{tripId}/images/move")
     public ResponseEntity<?> moveImageBetweenDayPlaces(
             @PathVariable Long tripId,
-            @RequestBody TripPlaceImageDto.ImageCrossDayMoveReq imageReq
+            @RequestBody TripPlaceImageReq.ImageCrossDayMove imageReq
     ) {
         tripPlaceImageMovementService.moveImageBetweenDayPlaces(imageReq);
         return ResponseEntity.ok(SuccessResponse.ok());
@@ -48,7 +48,7 @@ public class TripPlaceImageController implements TripPlaceImageApi {
     public ResponseEntity<?> moveImageToUnmatched(
             @PathVariable Long tripId,
             @PathVariable String tripDayPlaceId,
-            @RequestBody TripPlaceImageDto.ImageUnmatchedMoveReq imageReq
+            @RequestBody TripPlaceImageReq.ImageUnmatchedMove imageReq
     ) {
         tripPlaceImageMovementService.moveImageToUnmatched(tripDayPlaceId, imageReq);
         return ResponseEntity.ok(SuccessResponse.ok());
@@ -59,7 +59,7 @@ public class TripPlaceImageController implements TripPlaceImageApi {
     public ResponseEntity<?> moveImageFromUnmatched(
             @PathVariable Long tripId,
             @PathVariable String tripDayPlaceId,
-            @RequestBody TripPlaceImageDto.ImageUnmatchedMoveReq imageReq
+            @RequestBody TripPlaceImageReq.ImageUnmatchedMove imageReq
     ) {
         tripPlaceImageMovementService.moveImageFromUnmatchedToPlace(tripDayPlaceId, imageReq);
         return ResponseEntity.ok(SuccessResponse.ok());

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
@@ -4,11 +4,13 @@ import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDeleteDto;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageReq;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageDeleteService;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageMovementService;
+import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageQueryService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.presentation.tripplace.image.api.TripPlaceImageApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,6 +23,32 @@ import org.springframework.web.bind.annotation.RestController;
 public class TripPlaceImageController implements TripPlaceImageApi {
     private final TripPlaceImageMovementService tripPlaceImageMovementService;
     private final TripPlaceImageDeleteService tripPlaceImageDeleteService;
+    private final TripPlaceImageQueryService tripPlaceImageQueryService;
+
+    @GetMapping("/{tripId}/day-place/{tripDayPlaceId}/places/{placeId}/images")
+    public ResponseEntity<?> getPlaceInfo(
+            @PathVariable Long tripId,
+            @PathVariable String tripDayPlaceId,
+            @PathVariable String placeId
+    ) {
+        return ResponseEntity.ok(
+                SuccessResponse.from(
+                        tripPlaceImageQueryService.getPlaceImageInfo(tripDayPlaceId, placeId)
+                )
+        );
+    }
+
+    @GetMapping("/{tripId}/day-place/{tripDayPlaceId}/unmatched-images")
+    public ResponseEntity<?> getUnmatchedImageInfo(
+            @PathVariable Long tripId,
+            @PathVariable String tripDayPlaceId
+    ) {
+        return ResponseEntity.ok(
+                SuccessResponse.from(
+                        tripPlaceImageQueryService.getUnmatchedImageInfo(tripDayPlaceId)
+                )
+        );
+    }
 
     @Override
     @PatchMapping("/{tripId}/day-place/{tripDayPlaceId}/images/move")

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
@@ -25,6 +25,7 @@ public class TripPlaceImageController implements TripPlaceImageApi {
     private final TripPlaceImageDeleteService tripPlaceImageDeleteService;
     private final TripPlaceImageQueryService tripPlaceImageQueryService;
 
+    @Override
     @GetMapping("/{tripId}/day-place/{tripDayPlaceId}/places/{placeId}/images")
     public ResponseEntity<?> getPlaceInfo(
             @PathVariable Long tripId,
@@ -38,6 +39,7 @@ public class TripPlaceImageController implements TripPlaceImageApi {
         );
     }
 
+    @Override
     @GetMapping("/{tripId}/day-place/{tripDayPlaceId}/unmatched-images")
     public ResponseEntity<?> getUnmatchedImageInfo(
             @PathVariable Long tripId,

--- a/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageMovementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageMovementServiceTest.java
@@ -50,7 +50,7 @@ public class TripPlaceImageMovementServiceTest {
     private Place buildPlace(String id, String name, List<Image> images) {
         Place place = Place.builder()
                 .id(id).name(name).latitude(1.0).longitude(1.0)
-                .placeType("카페").order(1)
+                .placeType("카페")
                 .build();
         place.addImages(images);
         return place;

--- a/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageMovementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageMovementServiceTest.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.application.tripplace.image.service;
 
-import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDto;
+import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageReq;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.entity.Image;
@@ -67,8 +67,8 @@ public class TripPlaceImageMovementServiceTest {
     @DisplayName("같은 날짜 다른 목적지 이미지 이동 테스트")
     class MoveImageToAnotherPlaceTest {
 
-        private final TripPlaceImageDto.ImageMoveReq imageReq
-                = new TripPlaceImageDto.ImageMoveReq(fromPlaceId, toPlaceId, imageId);
+        private final TripPlaceImageReq.ImageMove imageReq
+                = new TripPlaceImageReq.ImageMove(fromPlaceId, toPlaceId, imageId);
 
         @Test
         @DisplayName("성공")
@@ -142,8 +142,8 @@ public class TripPlaceImageMovementServiceTest {
     @DisplayName("다른 날짜 간 이미지 이동 테스트")
     void moveImageBetweenDayPlacesTest() {
         // given
-        TripPlaceImageDto.ImageCrossDayMoveReq imageReq =
-                new TripPlaceImageDto.ImageCrossDayMoveReq(tripDayPlaceId1, fromPlaceId, tripDayPlaceId2, toPlaceId, imageId);
+        TripPlaceImageReq.ImageCrossDayMove imageReq =
+                new TripPlaceImageReq.ImageCrossDayMove(tripDayPlaceId1, fromPlaceId, tripDayPlaceId2, toPlaceId, imageId);
 
         Image image = buildImage();
         Place from = buildPlace(fromPlaceId, "목적지1", List.of(image));
@@ -164,8 +164,8 @@ public class TripPlaceImageMovementServiceTest {
     @DisplayName("이미지 Unmatched 영역으로 이동 테스트")
     void moveImageToUnmatchedTest() {
         // given
-        TripPlaceImageDto.ImageUnmatchedMoveReq imageReq =
-                new TripPlaceImageDto.ImageUnmatchedMoveReq(fromPlaceId, imageId);
+        TripPlaceImageReq.ImageUnmatchedMove imageReq =
+                new TripPlaceImageReq.ImageUnmatchedMove(fromPlaceId, imageId);
 
         Image image = buildImage();
         Place from = buildPlace(fromPlaceId, "목적지", List.of(image));
@@ -185,8 +185,8 @@ public class TripPlaceImageMovementServiceTest {
     @DisplayName("Unmatched 영역에서 Place로 이미지 이동 테스트")
     void MoveImageFromUnmatchedToPlaceTest() {
         // given
-        TripPlaceImageDto.ImageUnmatchedMoveReq imageReq =
-                new TripPlaceImageDto.ImageUnmatchedMoveReq(toPlaceId, imageId);
+        TripPlaceImageReq.ImageUnmatchedMove imageReq =
+                new TripPlaceImageReq.ImageUnmatchedMove(toPlaceId, imageId);
 
         Image image = buildImage();
         TripDayPlace tripDayPlace = buildTripDayPlace(List.of());

--- a/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageQueryServiceTest.java
@@ -1,0 +1,105 @@
+package kr.co.yeogiga.application.tripplace.image.service;
+
+import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageRes;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.tripplace.entity.Image;
+import kr.co.yeogiga.domain.tripplace.entity.Place;
+import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TripPlaceImageQueryServiceTest {
+
+    @Mock
+    private TripDayPlaceService tripDayPlaceService;
+
+    @InjectMocks
+    private TripPlaceImageQueryService tripPlaceImageQueryService;
+
+    private final String tripDayPlaceId = "tripDayPlace-id";
+    private final String placeId = "place-id";
+
+    private final Image image = Image.builder()
+            .url("https://image.com")
+            .latitude(0.0)
+            .longitude(1.1)
+            .date(LocalDateTime.of(2024, 5, 14, 12, 0))
+            .build();
+
+    private final Place place = Place.builder()
+            .id(placeId)
+            .name("카페")
+            .latitude(1.1)
+            .longitude(2.2)
+            .placeType("식당")
+            .order(10.0)
+            .build();
+
+    @Nested
+    @DisplayName("특정 여행 일차 및 목적지의 이미지 목록 조회 테스트")
+    class PlaceImageInfo {
+
+        @Test
+        @DisplayName("성공")
+        void getPlaceImageInfoSuccess() {
+            // given
+            place.addImages(List.of(image));
+
+            when(tripDayPlaceService.readPlaceByIdAndPlaceId(tripDayPlaceId, placeId))
+                    .thenReturn(Optional.of(place));
+
+            // when
+            TripPlaceImageRes.PlaceImageInfo result = tripPlaceImageQueryService.getPlaceImageInfo(tripDayPlaceId, placeId);
+
+            // then
+            assertEquals(placeId, result.id());
+            assertThat(result.images()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("실패 - 목적지 존재하지 않음")
+        void getPlaceImageInfoNotFound() {
+            // given
+            when(tripDayPlaceService.readPlaceByIdAndPlaceId(tripDayPlaceId, placeId))
+                    .thenReturn(Optional.empty());
+
+            // when
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> tripPlaceImageQueryService.getPlaceImageInfo(tripDayPlaceId, placeId));
+
+            // then
+            assertEquals(TripErrorType.PLACE_NOT_FOUND, exception.getErrorType());
+        }
+    }
+
+    @Test
+    @DisplayName("특정 여행 일차의 unmatched 이미지 목록 조회 테스트")
+    void getUnmatchedImageInfoTest() {
+        // given
+        when(tripDayPlaceService.readUnmatchedImagesById(tripDayPlaceId))
+                .thenReturn(List.of(image));
+
+        // when
+        TripPlaceImageRes.UnmatchedImageInfo result = tripPlaceImageQueryService.getUnmatchedImageInfo(tripDayPlaceId);
+
+        // then
+        assertEquals(image.getUrl(), result.images().get(0).url());
+        assertThat(result.images()).hasSize(1);
+    }
+}

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceQueryServiceTest.java
@@ -137,7 +137,6 @@ public class TripPlaceQueryServiceTest {
         // then
         assertThat(result).hasSize(1);
         assertThat(result.get(0).places()).hasSize(1);
-        assertThat(result.get(0).unmatchedImages()).hasSize(1);
         assertEquals(tripDayPlace.getId(), result.get(0).id());
         assertEquals(1, result.get(0).day());
     }

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceQueryServiceTest.java
@@ -1,8 +1,10 @@
 package kr.co.yeogiga.application.tripplace.service;
 
+import kr.co.yeogiga.application.tripplace.dto.TripDaySummaryRes;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
@@ -17,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
@@ -33,12 +36,13 @@ public class TripPlaceQueryServiceTest {
     private final Place place1 = Place.builder().id("id1").name("목적지1").latitude(0.0).longitude(1.1).placeType("카페").order(10.0).build();
     private final Place place2 = Place.builder().id("id2").name("목적지2").latitude(2.2).longitude(3.3).placeType("카페").order(20.0).build();
 
+    private final Long tripId = 1L;
+    private final String tripDayPlaceId = "day1";
+
     @Test
     @DisplayName("여행 일정 불러오기 테스트 성공")
     void getTripDayPlacesInfoSuccess() {
         // given
-        Long tripId = 1L;
-
         List<Place> places = List.of(place1, place2);
 
         TripDayPlace tripDayPlace = TripDayPlace.builder()
@@ -60,8 +64,6 @@ public class TripPlaceQueryServiceTest {
     @Nested
     @DisplayName("목적지 정보 불러오기 테스트")
     class GetPlaceDetailsInfo {
-
-        private final String tripDayPlaceId = "day1";
 
         @Test
         @DisplayName("성공")
@@ -99,5 +101,44 @@ public class TripPlaceQueryServiceTest {
 
             assertEquals(TripErrorType.TRIP_PLACE_NOT_FOUND, e.getErrorType());
         }
+    }
+
+    @Test
+    @DisplayName("일차별 요약 목록 조회 테스트")
+    void getTripDaySummariesTest() {
+        Image image = Image.builder()
+                .url("https://image.com")
+                .latitude(0.0)
+                .longitude(1.0)
+                .build();
+
+        Place place = Place.builder()
+                .id("place-id")
+                .name("목적지")
+                .latitude(1.0)
+                .longitude(2.0)
+                .placeType("음식")
+                .build();
+        place.addImages(List.of(image));
+
+        TripDayPlace tripDayPlace = TripDayPlace.builder()
+                .tripId(tripId)
+                .day(1)
+                .places(List.of(place))
+                .build();
+        tripDayPlace.addUnmatchedImages(List.of(image));
+
+        given(tripDayPlaceService.readTripDayPlaceSummariesByTripId(tripId))
+                .willReturn(List.of(tripDayPlace));
+
+        // when
+        List<TripDaySummaryRes.DayDto> result = tripPlaceQueryService.getTripDaySummaries(tripId);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).places()).hasSize(1);
+        assertThat(result.get(0).unmatchedImages()).hasSize(1);
+        assertEquals(tripDayPlace.getId(), result.get(0).id());
+        assertEquals(1, result.get(0).day());
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceControllerTest.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.presentation.tripplace.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.application.tripplace.dto.TripDaySummaryRes;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
 import kr.co.yeogiga.application.tripplace.service.TripPlaceCommandService;
@@ -24,6 +25,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.BDDMockito.given;
@@ -157,6 +159,37 @@ public class TripPlaceControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
+    }
+
+    @Test
+    @DisplayName("여행 ID로 여행 일차 요약 목록 조회에 성공한다")
+    void getTripDaySummaries_success() throws Exception {
+        // given
+        Long tripId = 1L;
+        TripDaySummaryRes.DayDto responseDto = new TripDaySummaryRes.DayDto(
+                "day-id",
+                1,
+                List.of(new TripDaySummaryRes.PlaceDto("place-id", "목적지", 0.0, 1.0, "음식", List.of())),
+                List.of(new TripDaySummaryRes.ImageDto("image-id", "url", 1.0, 2.0, LocalDateTime.now()))
+        );
+
+        given(tripPlaceQueryService.getTripDaySummaries(tripId)).willReturn(List.of(responseDto));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/trip/{tripId}/day-place", tripId)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].id").value("day-id"))
+                .andExpect(jsonPath("$.data[0].day").value(1))
+                .andExpect(jsonPath("$.data[0].places[0].id").value("place-id"))
+                .andExpect(jsonPath("$.data[0].unmatchedImages[0].id").value("image-id"));
     }
 
 

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceControllerTest.java
@@ -144,7 +144,7 @@ public class TripPlaceControllerTest {
     void getPlaceDetailsInfoSuccess() throws Exception {
         // given
         TripPlaceRes.PlaceDetails details =
-                new TripPlaceRes.PlaceDetails("place1", "목적지1", 0.0, 0.0, "카페", 10.0);
+                new TripPlaceRes.PlaceDetails("place1", "목적지1", 0.0, 0.0, "카페");
         given(tripPlaceQueryService.getPlaceDetailsInfo(tripDayPlaceId)).willReturn(List.of(details));
 
         // when

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceControllerTest.java
@@ -169,8 +169,8 @@ public class TripPlaceControllerTest {
         TripDaySummaryRes.DayDto responseDto = new TripDaySummaryRes.DayDto(
                 "day-id",
                 1,
-                List.of(new TripDaySummaryRes.PlaceDto("place-id", "목적지", 0.0, 1.0, "음식", List.of())),
-                List.of(new TripDaySummaryRes.ImageDto("image-id", "url", 1.0, 2.0, LocalDateTime.now()))
+                List.of(new TripDaySummaryRes.PlaceDto("place-id", "목적지", 0.0, 1.0, "음식", null)),
+                new TripDaySummaryRes.ImageDto("image-id", "url", 1.0, 2.0, LocalDateTime.now())
         );
 
         given(tripPlaceQueryService.getTripDaySummaries(tripId)).willReturn(List.of(responseDto));
@@ -189,7 +189,7 @@ public class TripPlaceControllerTest {
                 .andExpect(jsonPath("$.data[0].id").value("day-id"))
                 .andExpect(jsonPath("$.data[0].day").value(1))
                 .andExpect(jsonPath("$.data[0].places[0].id").value("place-id"))
-                .andExpect(jsonPath("$.data[0].unmatchedImages[0].id").value("image-id"));
+                .andExpect(jsonPath("$.data[0].unmatchedImage.id").value("image-id"));
     }
 
 

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
@@ -3,8 +3,10 @@ package kr.co.yeogiga.presentation.tripplace.image.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDeleteDto;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageReq;
+import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageRes;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageDeleteService;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageMovementService;
+import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageQueryService;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
@@ -25,11 +27,14 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -55,6 +60,9 @@ public class TripPlaceImageControllerTest {
     @MockBean
     private TripPlaceImageDeleteService tripPlaceImageDeleteService;
 
+    @MockBean
+    private TripPlaceImageQueryService tripPlaceImageQueryService;
+
     private final Long tripId = 1L;
     private final String tripDayPlaceId = "dayId";
     private final String fromPlaceId = "place1-id";
@@ -66,6 +74,75 @@ public class TripPlaceImageControllerTest {
         this.mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)
                 .build();
+    }
+
+    @Nested
+    @DisplayName("이미지 조회 테스트")
+    class GetImageInfoTest {
+
+        @Test
+        @DisplayName("특정 장소의 이미지 조회")
+        void getPlaceInfoSuccess() throws Exception {
+            // given
+            TripPlaceImageRes.PlaceImageInfo placeImageInfo = TripPlaceImageRes.PlaceImageInfo.builder()
+                    .id("place-id")
+                    .name("카페")
+                    .latitude(1.1)
+                    .longitude(2.2)
+                    .placeType("식당")
+                    .images(List.of())
+                    .build();
+
+            when(tripPlaceImageQueryService.getPlaceImageInfo(tripDayPlaceId, fromPlaceId))
+                    .thenReturn(placeImageInfo);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip/{tripId}/day-place/{tripDayPlaceId}/places/{placeId}/images", tripId, tripDayPlaceId, fromPlaceId)
+                            .accept(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."))
+                    .andExpect(jsonPath("$.data.id").value("place-id"))
+                    .andExpect(jsonPath("$.data.name").value("카페"));
+        }
+
+        @Test
+        @DisplayName("Unmatched 이미지 조회")
+        void getUnmatchedImageInfoSuccess() throws Exception {
+            // given
+            TripPlaceImageRes.UnmatchedImageInfo unmatchedImageInfo = TripPlaceImageRes.UnmatchedImageInfo.builder()
+                    .images(List.of(
+                            TripPlaceImageRes.ImageDto.builder()
+                                    .id("image-id")
+                                    .url("https://image.com")
+                                    .latitude(0.0)
+                                    .longitude(1.1)
+                                    .date(LocalDateTime.now())
+                                    .build()
+                    ))
+                    .build();
+
+            when(tripPlaceImageQueryService.getUnmatchedImageInfo(tripDayPlaceId))
+                    .thenReturn(unmatchedImageInfo);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip/{tripId}/day-place/{tripDayPlaceId}/unmatched-images", tripId, tripDayPlaceId)
+                            .accept(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."))
+                    .andExpect(jsonPath("$.data.images").isArray());
+        }
     }
 
     @Nested

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
@@ -2,7 +2,7 @@ package kr.co.yeogiga.presentation.tripplace.image.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDeleteDto;
-import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDto;
+import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageReq;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageDeleteService;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageMovementService;
 import kr.co.yeogiga.common.exception.CustomException;
@@ -72,8 +72,8 @@ public class TripPlaceImageControllerTest {
     @DisplayName("같은 날짜 내 이미지 이동 테스트")
     class MoveImageToAnotherPlaceControllerTest {
 
-        private final TripPlaceImageDto.ImageMoveReq req =
-                new TripPlaceImageDto.ImageMoveReq(fromPlaceId, toPlaceId, imageId);
+        private final TripPlaceImageReq.ImageMove req =
+                new TripPlaceImageReq.ImageMove(fromPlaceId, toPlaceId, imageId);
 
         @Test
         @DisplayName("성공")
@@ -166,8 +166,8 @@ public class TripPlaceImageControllerTest {
     @DisplayName("다른 날짜 간 이미지 이동 성공")
     void moveImageBetweenDayPlacesSuccess() throws Exception {
         // given
-        TripPlaceImageDto.ImageCrossDayMoveReq req =
-                new TripPlaceImageDto.ImageCrossDayMoveReq("day1", fromPlaceId, "day2", toPlaceId, imageId);
+        TripPlaceImageReq.ImageCrossDayMove req =
+                new TripPlaceImageReq.ImageCrossDayMove("day1", fromPlaceId, "day2", toPlaceId, imageId);
         doNothing().when(tripPlaceImageMovementService).moveImageBetweenDayPlaces(req);
 
         // when
@@ -188,7 +188,7 @@ public class TripPlaceImageControllerTest {
     @DisplayName("이미지를 Unmatched로 이동 성공")
     void moveImageToUnmatchedSuccess() throws Exception {
         // given
-        TripPlaceImageDto.ImageUnmatchedMoveReq req = new TripPlaceImageDto.ImageUnmatchedMoveReq(fromPlaceId, imageId);
+        TripPlaceImageReq.ImageUnmatchedMove req = new TripPlaceImageReq.ImageUnmatchedMove(fromPlaceId, imageId);
         doNothing().when(tripPlaceImageMovementService).moveImageToUnmatched(tripDayPlaceId, req);
 
         // when
@@ -209,7 +209,7 @@ public class TripPlaceImageControllerTest {
     @DisplayName("Unmatched에서 이미지 복원 성공")
     void moveImageFromUnmatchedToPlaceSuccess() throws Exception {
         // given
-        TripPlaceImageDto.ImageUnmatchedMoveReq req = new TripPlaceImageDto.ImageUnmatchedMoveReq(toPlaceId, imageId);
+        TripPlaceImageReq.ImageUnmatchedMove req = new TripPlaceImageReq.ImageUnmatchedMove(toPlaceId, imageId);
         doNothing().when(tripPlaceImageMovementService).moveImageFromUnmatchedToPlace(tripDayPlaceId, req);
 
         // when


### PR DESCRIPTION
## 배경
여행 회고 중, 이미지 (목적지, 기타) 조회 및 여행 요약 정보 (일차별 목적지, 각 목적지별 썸네일용 이미지 한 장) 조회 로직 필요

## 작업 사항
- 이미지 조회 로직 구현 (de064d6d202b25c46a810ec93cd4efe4c44dc983)
   - 목적지별 조회, 기타 이미지 조회로 분류
- Place 필드 수정 (91f4e60bec774cd28b46fdd90d0591de3d954d58)
   - MongoDB Query 작성 중, `Aggregation` 사용 과정에서 필드에 null값 적용 과정이 생김. 기본 자료형은 에러가 나기에 Wrapper 클래스로 변경.
   - `Place.id`가 인식하지 못하는 문제 발생 (아직 이유 모름..) `@Field`를 통해서 id로 지정해 수행
- 일차 요약 정보 로직 구현 (de9c28f37c32e07d4ddd7c7cd0c2cdf7a77c9cf7)
   - 복잡한 과정으로 과정별 주석 작성

## 추가 논의
최대한 상황에 맞게 필요한 정보들을 불러오도록 하였습니다.
MongoDB에 익숙하지 않다 보니깐 시간도 오래 걸리고 이것이 최적의 방법이 맞는지 모르겠는데, 지속적으로 확인하면서 생각해보겠습니다