### PR TITLE
Featrue(IL-94): OAuth 로그인 사용자 이메일 미저장 및 회원가입 이메일 중복 로직 추가

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/auth/dto/UserInfoDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/UserInfoDto.java
@@ -1,10 +1,9 @@
 package kr.co.yeogiga.application.auth.dto;
 
 public record UserInfoDto(
-        String platformId,
-        String email
+        String platformId
 ) {
-    public static UserInfoDto of(String platformId, String email) {
-        return new UserInfoDto(platformId, email);
+    public static UserInfoDto of(String platformId) {
+        return new UserInfoDto(platformId);
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
@@ -40,6 +40,10 @@ public class AuthService {
             throw new CustomException(AuthErrorType.ALREADY_USED_NICKNAME);
         }
 
+        if (userService.existsIncludeDeletedByEmail(request.email())) {
+            throw new CustomException(AuthErrorType.ALREADY_USED_EMAIL);
+        }
+
         User newUser = request.toEntity(passwordEncoder.encode(request.password()));
 
         newUser.upgradeRoleToUser();

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -98,7 +98,6 @@ public class OAuthManagementService {
      */
     private User registerUser(OAuthPlatform platform, UserInfoDto userInfo) {
         User user = User.builder()
-                .email(userInfo.email())
                 .role(Role.GUEST)
                 .username(platform + " " + userInfo.platformId())
                 .nickname(platform + " " + userInfo.platformId())

--- a/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
@@ -23,7 +23,8 @@ public enum AuthErrorType implements BaseErrorType {
     AUTHENTICATION_FAIL(HttpStatus.BAD_REQUEST, "A010", "로그인에 실패하였습니다. 아이디 또는 비밀번호를 확인해주세요."),
 
     ALREADY_USED_USERNAME(HttpStatus.CONFLICT, "A011", "이미 사용 중인 아이디입니다."),
-    ALREADY_USED_NICKNAME(HttpStatus.CONFLICT, "A012", "이미 사용 중인 닉네임입니다.");
+    ALREADY_USED_NICKNAME(HttpStatus.CONFLICT, "A012", "이미 사용 중인 닉네임입니다."),
+    ALREADY_USED_EMAIL(HttpStatus.CONFLICT, "A013", "이미 사용 중인 이메일입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -24,12 +24,12 @@ public class User extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String username;
 
     private String password;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String email;
 
     @Column(nullable = false)

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
@@ -49,6 +49,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
                    "WHERE nickname = :nickname LIMIT 1", nativeQuery = true)
     Optional<Long> findUserIdIncludeDeletedByNickname(@Param(value = "nickname") String nickname);
 
+    @Query(value = "SELECT id " +
+            "FROM users " +
+            "WHERE email = :email LIMIT 1", nativeQuery = true)
+    Optional<Long> findUserIdIncludeDeletedByEmail(@Param(value = "email") String email);
+
     @Modifying
     @Query(value = "DELETE " +
             "FROM users " +

--- a/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
@@ -51,6 +51,10 @@ public class UserService {
         return userRepository.findUserIdIncludeDeletedByNickname(nickname).isPresent();
     }
 
+    public boolean existsIncludeDeletedByEmail(String email) {
+        return userRepository.findUserIdIncludeDeletedByEmail(email).isPresent();
+    }
+
     public void deleteById(Long userId) {
         userRepository.deleteById(userId);
     }

--- a/src/main/java/kr/co/yeogiga/infrastructure/oauth/KakaoClient.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/oauth/KakaoClient.java
@@ -71,9 +71,8 @@ public class KakaoClient extends OAuthClient {
 
             JsonNode root = objectMapper.readTree(response.getBody());
             String platformId = root.get("id").asText();
-            String email = root.path("kakao_account").get("email") .asText();
 
-            return UserInfoDto.of(platformId, email);
+            return UserInfoDto.of(platformId);
         } catch (Exception e) {
             log.error("[OAUTH ERROR:kakao] {}", e.getMessage());
             throw new CustomException(OAuthErrorType.OAUTH_ERROR);

--- a/src/main/java/kr/co/yeogiga/infrastructure/oauth/NaverClient.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/oauth/NaverClient.java
@@ -70,9 +70,8 @@ public class NaverClient extends OAuthClient {
 
             JsonNode root = objectMapper.readTree(response.getBody());
             String platformId = root.path("response").get("id").asText();
-            String email = root.path("response").get("email").asText();
 
-            return UserInfoDto.of(platformId, email);
+            return UserInfoDto.of(platformId);
         } catch (Exception e) {
             log.error("[OAUTH ERROR:naver] {}", e.getMessage());
             throw new CustomException(OAuthErrorType.OAUTH_ERROR);

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
@@ -62,7 +62,7 @@ public interface AuthApi {
                                             "message": "이미 사용 중인 닉네임입니다."
                                         }
                                     """),
-                            @ExampleObject(name = "회원가입 실패 - 이미 존재하는 아이디", value = """
+                            @ExampleObject(name = "회원가입 실패 - 이미 존재하는 닉네임", value = """
                                         {
                                             "code": "A013",
                                             "message": "이미 사용 중인 이메일입니다."

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
@@ -61,6 +61,12 @@ public interface AuthApi {
                                             "code": "A012",
                                             "message": "이미 사용 중인 닉네임입니다."
                                         }
+                                    """),
+                            @ExampleObject(name = "회원가입 실패 - 이미 존재하는 아이디", value = """
+                                        {
+                                            "code": "A013",
+                                            "message": "이미 사용 중인 이메일입니다."
+                                        }
                                     """)
                     }))
     })

--- a/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
@@ -119,6 +119,7 @@ public class AuthServiceTest {
 
             when(userService.existsIncludeDeletedByUsername(request.username())).thenReturn(false);
             when(userService.existsIncludeDeletedByNickname(request.nickname())).thenReturn(false);
+            when(userService.existsIncludeDeletedByEmail(request.email())).thenReturn(false);
             when(passwordEncoder.encode(request.password())).thenReturn("encodedPassword");
             doNothing().when(userService).save(any());
 
@@ -167,11 +168,34 @@ public class AuthServiceTest {
             when(userService.existsIncludeDeletedByUsername(request.username())).thenReturn(false);
             when(userService.existsIncludeDeletedByNickname(request.nickname())).thenReturn(true);
 
+
             // when
             CustomException exception = assertThrows(CustomException.class, () -> authService.signUp(request));
 
             // then
             assertEquals(exception.getErrorType(), AuthErrorType.ALREADY_USED_NICKNAME);
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 사용 중인 이메일")
+        void failAlreadyUsedEmail() {
+            // given
+            SignUpDto.Request request = SignUpDto.Request.builder()
+                    .username("testid")
+                    .email("test@test.com")
+                    .nickname("testnick")
+                    .password("testpw")
+                    .build();
+
+            when(userService.existsIncludeDeletedByUsername(request.username())).thenReturn(false);
+            when(userService.existsIncludeDeletedByNickname(request.nickname())).thenReturn(false);
+            when(userService.existsIncludeDeletedByEmail(request.email())).thenReturn(true);
+
+            // when
+            CustomException exception = assertThrows(CustomException.class, () -> authService.signUp(request));
+
+            // then
+            assertEquals(exception.getErrorType(), AuthErrorType.ALREADY_USED_EMAIL);
         }
     }
 

--- a/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
@@ -13,7 +13,6 @@ import kr.co.yeogiga.common.response.error.type.CommonErrorType;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
 import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
-import kr.co.yeogiga.domain.user.exception.UserErrorType;
 import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -34,7 +33,6 @@ import org.springframework.web.context.WebApplicationContext;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -327,6 +325,32 @@ public class AuthControllerTest {
                     .andExpect(status().isConflict())
                     .andExpect(jsonPath("$.code").value(AuthErrorType.ALREADY_USED_USERNAME.getCode()))
                     .andExpect(jsonPath("$.message").value(AuthErrorType.ALREADY_USED_USERNAME.getMessage()));
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 존재하는 이메일")
+        void failSignUpAlreadyExistsEmail() throws Exception {
+            // given
+            doThrow(new CustomException(AuthErrorType.ALREADY_USED_EMAIL)).when(authService).signUp(any());
+            SignUpDto.Request signUpDto = SignUpDto.Request.builder()
+                    .username("testid")
+                    .email("test@test.com")
+                    .password("testpw")
+                    .nickname("testnick")
+                    .build();
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/sign-up")
+                            .content(objectMapper.writeValueAsBytes(signUpDto))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value(AuthErrorType.ALREADY_USED_EMAIL.getCode()))
+                    .andExpect(jsonPath("$.message").value(AuthErrorType.ALREADY_USED_EMAIL.getMessage()));
         }
     }
 


### PR DESCRIPTION
## 배경
- OAuth 로그인 유저에 대한 이메일 값 저장 필요성 논의 → 이미 소셜 플랫폼을 통해 인증된 사용자이며, 차후 이메일 인증번호 발급 로직 불필요로 인한 이메일 값 미저장 로직 변경 요구
- 이메일 컬럼 유일성 보장 필요성 대두

## 작업 사항
- OAuth 로그인 시 이메일 값 미저장
- 회원가입 시 이메일 값 중복 확인 로직 추가

- 이메일 컬럼 유일성 보장을 위한 `@Column(unique = true)` 설정 추가
    - 아이디 `username` 컬럼에도 유일성 설정 추가

## 추가논의
- 이메일 값 제거로 인하여 `UserInfoDto` 내 필드가 1개(`platformId`)인 상황입니다. 또한, `platformId`는 null인 경우가 없기 때문에 일반 생성자를 쓸지 고민하였지만, 기존과 동일하게 정적 팩토리 메서드를 유지하기로 하였습니다.