### PR TITLE
Feature(IL-96): JWT 클레임 내 아이디 제거

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
@@ -66,7 +66,7 @@ public class AuthService {
             throw new CustomException(AuthErrorType.AUTHENTICATION_FAIL);
         }
 
-        return jwtService.generateToken(user.getUsername(), user.getNickname(), user.getId(), LoginType.NORMAL);
+        return jwtService.generateToken(user.getNickname(), user.getId(), LoginType.NORMAL);
     }
 
     /**
@@ -85,7 +85,7 @@ public class AuthService {
         User user = userService.readById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
 
-        return jwtService.generateToken(user.getUsername(), user.getNickname(), user.getId(), LoginType.from(user.getPassword()));
+        return jwtService.generateToken(user.getNickname(), user.getId(), LoginType.from(user.getPassword()));
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/auth/service/JwtService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/JwtService.java
@@ -12,9 +12,9 @@ public class JwtService {
     private final JwtHelper jwtHelper;
     private final RefreshTokenService refreshTokenService;
 
-    public TokenDto generateToken(String username, String nickname, Long userId, LoginType loginType) {
-        String accessToken = jwtHelper.generateAccessToken(username, nickname, userId, loginType);
-        String refreshToken = jwtHelper.generateRefreshToken(username, nickname, userId, loginType);
+    public TokenDto generateToken(String nickname, Long userId, LoginType loginType) {
+        String accessToken = jwtHelper.generateAccessToken(nickname, userId, loginType);
+        String refreshToken = jwtHelper.generateRefreshToken(nickname, userId, loginType);
         refreshTokenService.save(userId, refreshToken);
 
         return TokenDto.of(accessToken, refreshToken);

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -124,11 +124,10 @@ public class OAuthManagementService {
      */
     private SignInDto.Response getSignInResponse(UserStatusDto userStatus) {
         User user = userStatus.user();
-        String username = user.getUsername();
         String nickname = user.getNickname();
         Long userId = user.getId();
 
-        TokenDto token = jwtService.generateToken(username, nickname, userId, LoginType.SOCIAL);
+        TokenDto token = jwtService.generateToken(nickname, userId, LoginType.SOCIAL);
 
         return SignInDto.Response.builder()
                 .token(token)

--- a/src/main/java/kr/co/yeogiga/common/jwt/JwtHelper.java
+++ b/src/main/java/kr/co/yeogiga/common/jwt/JwtHelper.java
@@ -16,12 +16,12 @@ public class JwtHelper {
     private final TokenParser tokenParser;
     private final JwtProperties jwtProperties;
 
-    public String generateAccessToken(String username, String nickname, Long userId, LoginType loginType) {
-        return tokenBuilder.build(username, generateClaims(nickname, userId, loginType), jwtProperties.getAccessTokenExpiration());
+    public String generateAccessToken(String nickname, Long userId, LoginType loginType) {
+        return tokenBuilder.build(String.valueOf(userId), generateClaims(nickname, userId, loginType), jwtProperties.getAccessTokenExpiration());
     }
 
-    public String generateRefreshToken(String username, String nickname, Long userId, LoginType loginType) {
-        return tokenBuilder.build(username, generateClaims(nickname, userId, loginType), jwtProperties.getRefreshTokenExpiration());
+    public String generateRefreshToken(String nickname, Long userId, LoginType loginType) {
+        return tokenBuilder.build(String.valueOf(userId), generateClaims(nickname, userId, loginType), jwtProperties.getRefreshTokenExpiration());
     }
 
     public JwtClaims parseClaims(String token) {
@@ -29,7 +29,6 @@ public class JwtHelper {
 
         return JwtClaims.builder()
                 .nickname(claims.get("nickname", String.class))
-                .username(claims.get("username", String.class))
                 .userId(claims.get("userId", Long.class))
                 .build();
     }

--- a/src/main/java/kr/co/yeogiga/common/jwt/dto/JwtClaims.java
+++ b/src/main/java/kr/co/yeogiga/common/jwt/dto/JwtClaims.java
@@ -4,7 +4,6 @@ import lombok.Builder;
 
 @Builder
 public record JwtClaims(
-        String username,
         String nickname,
         Long userId
 ) {

--- a/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
@@ -71,7 +71,7 @@ public class AuthServiceTest {
         when(jwtService.extractUserId(any())).thenReturn(userId);
         when(refreshTokenService.exists(userId)).thenReturn(true);
         when(userService.readById(userId)).thenReturn(Optional.ofNullable(user));
-        when(jwtService.generateToken(any(), any(), any(), any())).thenReturn(tokenDto);
+        when(jwtService.generateToken(any(), any(), any())).thenReturn(tokenDto);
 
         // when
         TokenDto reissuedToken = authService.reissueToken("old-refresh-token");
@@ -196,7 +196,7 @@ public class AuthServiceTest {
 
             when(userService.readIncludeDeletedUserByUsername(request.username())).thenReturn(Optional.of(newUser));
             when(passwordEncoder.matches(request.password(), newUser.getPassword())).thenReturn(true);
-            when(jwtService.generateToken(any(), any(), any(), any())).thenReturn(tokenDto);
+            when(jwtService.generateToken(any(), any(), any())).thenReturn(tokenDto);
 
             // when
             TokenDto token = authService.signIn(request);


### PR DESCRIPTION
## 배경
- 소셜 로그인 사용자의 경우 `username` 필드에 	`{platform} {platformId}` 값 저장
  → 소셜 로그인 플랫폼 고유 번호를 토큰 내 포함하는 것에 대한 우려 및 아이디값 불필요 의견 대두

## 작업 사항
- JWT 토큰 생성 및 파싱 시 `username` 값 제거
    - 그로 인한 코드 변경

## 추가 논의
- 현재 소셜 로그인 유저가 최초 로그인 시 발급되는 토큰에는 아직 닉네임이 설정되지 않아 닉네임 필드에 `{platform} {platformId}`가 전달됩니다. 해당 부분도 필요하면 최초 로그인 시에는 `nickname` 클레임 부분에 다른 값 삽입하도록 하겠습니다.