### PR TITLE
Feature(IL-99): 매칭된 이미지 재정렬 로직 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/image/service/TempImageAssignProcessor.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/TempImageAssignProcessor.java
@@ -2,9 +2,12 @@ package kr.co.yeogiga.application.image.service;
 
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageAssignmentService;
 import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.entity.TempPlaceImages;
+import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import kr.co.yeogiga.domain.tripplace.exception.ImageErrorType;
 import kr.co.yeogiga.domain.tripplace.service.TempPlaceImagesService;
+import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,6 +15,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TempImageAssignProcessor {
     private final TempPlaceImagesService tempPlaceImagesService;
+    private final TripDayPlaceService tripDayPlaceService;
     private final TripPlaceImageAssignmentService tripPlaceImageAssignmentService;
 
     /**
@@ -24,7 +28,10 @@ public class TempImageAssignProcessor {
         TempPlaceImages tempPlaceImages = tempPlaceImagesService.readByTripDayPlaceId(tripDayPlaceId)
                 .orElseThrow(() -> new CustomException(ImageErrorType.TEMP_IMAGE_NOT_FOUND));
 
-        tripPlaceImageAssignmentService.assignImageToTripDayPlace(tripDayPlaceId, tempPlaceImages.getImages());
+        TripDayPlace tripDayPlace = tripDayPlaceService.readById(tripDayPlaceId)
+                .orElseThrow(() -> new CustomException(TripErrorType.TRIP_PLACE_NOT_FOUND));
+
+        tripPlaceImageAssignmentService.assignImageToTripDayPlace(tripDayPlace, tempPlaceImages.getImages());
 
         tempPlaceImagesService.deleteById(tempPlaceImages.getId());
     }

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageAssignmentService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageAssignmentService.java
@@ -28,12 +28,10 @@ public class TripPlaceImageAssignmentService {
      * - 위도/경도가 있을 경우 가장 가까운 목적지(Place)에 연결
      * - 위도/경도가 없거나 목적지가 없을 경우 기타(unmatchedImages)로 분류
      *
-     * @param tripDayPlaceId TripDayPlace의 ID
+     * @param tripDayPlace TripDayPlace 객체
+     * @param images       처리하고자 하는 이미지 리스트
      */
-    public void assignImageToTripDayPlace(String tripDayPlaceId, List<Image> images) {
-        TripDayPlace tripDayPlace = tripDayPlaceService.readById(tripDayPlaceId)
-                .orElseThrow(() -> new CustomException(TripErrorType.TRIP_PLACE_NOT_FOUND));
-
+    public void assignImageToTripDayPlace(TripDayPlace tripDayPlace, List<Image> images) {
         // GPS 정보를 기준으로 가장 가까운 장소별로 이미지 그룹핑
         List<Image> unmatchedImages = new ArrayList<>();
         Map<String, List<Image>> placeImageMap = groupImagesByNearestPlace(

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageAssignmentService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageAssignmentService.java
@@ -1,7 +1,5 @@
 package kr.co.yeogiga.application.tripplace.image.service;
 
-import kr.co.yeogiga.common.exception.CustomException;
-import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageReassignmentService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageReassignmentService.java
@@ -1,0 +1,49 @@
+package kr.co.yeogiga.application.tripplace.image.service;
+
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.tripplace.entity.Image;
+import kr.co.yeogiga.domain.tripplace.entity.Place;
+import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
+import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * TripDayPlace 내 이미지들을 재정렬하는 서비스 클래스
+ */
+@Service
+@RequiredArgsConstructor
+public class TripPlaceImageReassignmentService {
+    private final TripDayPlaceService tripDayPlaceService;
+    private final TripPlaceImageAssignmentService tripPlaceImageAssignmentService;
+
+    /**
+     * 주어진 TripDayPlace ID에 대해 이미지 재정렬을 수행하는 메서드
+     * - 기존 이미지들을 모두 수집한 후 삭제
+     * - 수집된 이미지를 기반으로 다시 GPS 기준으로 매핑
+     *
+     * @param tripDayPlaceId 재정렬 대상 TripDayPlace의 ID
+     */
+    public void reassignImagesToTripDayPlace(String tripDayPlaceId) {
+        TripDayPlace tripDayPlace = tripDayPlaceService.readById(tripDayPlaceId)
+                .orElseThrow(() -> new CustomException(TripErrorType.TRIP_PLACE_NOT_FOUND));
+
+        List<Image> images = new ArrayList<>();
+
+        // 모든 Place의 이미지 수집 후 초기화
+        for (Place place : tripDayPlace.getPlaces()) {
+            images.addAll(place.getImages());
+            place.clearImages();
+        }
+
+        // 매칭되지 않은 이미지 수집 및 초기화
+        images.addAll(tripDayPlace.getUnmatchedImages());
+        tripDayPlace.clearUnmatchedImages();
+
+        tripPlaceImageAssignmentService.assignImageToTripDayPlace(tripDayPlace, images);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
@@ -37,4 +37,8 @@ public class Place {
     public void addImages(List<Image> images) {
         this.images.addAll(images);
     }
+
+    public void clearImages() {
+        this.images.clear();
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/TripDayPlace.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/TripDayPlace.java
@@ -36,4 +36,8 @@ public class TripDayPlace {
     public void addUnmatchedImages(List<Image> images) {
         this.unmatchedImages.addAll(images);
     }
+
+    public void clearUnmatchedImages() {
+        this.unmatchedImages.clear();
+    }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/api/TripPlaceImageApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/api/TripPlaceImageApi.java
@@ -286,6 +286,36 @@ public interface TripPlaceImageApi {
             @RequestBody TripPlaceImageReq.ImageUnmatchedMove imageReq
     );
 
+    @TrackApi(description = "매칭된 이미지 목적지에 맞게 재정렬")
+    @Operation(summary = "매칭된 이미지 목적지에 맞게 재정렬", description = "매칭된 이미지 목적지에 맞게 재정렬하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이미지 재정렬 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "여행 일차 존재하지 않음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": "T003",
+                                            "message": "해당 여행 일차 정보가 존재하지 않습니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> reassignImages(
+            @Parameter(description = "여행 ID")
+            @PathVariable Long tripId,
+
+            @Parameter(description = "여행 일차 ID")
+            @PathVariable String tripDayPlaceId
+    );
+
     @TrackApi(description = "매칭된 이미지에 대해 단일 삭제")
     @Operation(summary = "매칭된 이미지에 대해 단일 삭제", description = "이미지 단일 삭제 API입니다." +
             " 목적지 내 삭제인지, 기타 항목 삭제인지 요청값 DeleteType를 적절히 적어주세요.")

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
@@ -5,6 +5,7 @@ import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageReq;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageDeleteService;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageMovementService;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageQueryService;
+import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageReassignmentService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.presentation.tripplace.image.api.TripPlaceImageApi;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ public class TripPlaceImageController implements TripPlaceImageApi {
     private final TripPlaceImageMovementService tripPlaceImageMovementService;
     private final TripPlaceImageDeleteService tripPlaceImageDeleteService;
     private final TripPlaceImageQueryService tripPlaceImageQueryService;
+    private final TripPlaceImageReassignmentService tripPlaceImageReassignmentService;
 
     @Override
     @GetMapping("/{tripId}/day-place/{tripDayPlaceId}/places/{placeId}/images")
@@ -92,6 +94,15 @@ public class TripPlaceImageController implements TripPlaceImageApi {
             @RequestBody TripPlaceImageReq.ImageUnmatchedMove imageReq
     ) {
         tripPlaceImageMovementService.moveImageFromUnmatchedToPlace(tripDayPlaceId, imageReq);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+
+    @PatchMapping("/{tripId}/day-place/{tripDayPlaceId}/images/re-assign")
+    public ResponseEntity<?> reassignImages(
+            @PathVariable Long tripId,
+            @PathVariable String tripDayPlaceId
+    ) {
+        tripPlaceImageReassignmentService.reassignImagesToTripDayPlace(tripDayPlaceId);
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
@@ -97,6 +97,7 @@ public class TripPlaceImageController implements TripPlaceImageApi {
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 
+    @Override
     @PatchMapping("/{tripId}/day-place/{tripDayPlaceId}/images/re-assign")
     public ResponseEntity<?> reassignImages(
             @PathVariable Long tripId,

--- a/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageAssignmentServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageAssignmentServiceTest.java
@@ -1,7 +1,5 @@
 package kr.co.yeogiga.application.tripplace.image.service;
 
-import kr.co.yeogiga.common.exception.CustomException;
-import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
@@ -17,12 +15,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -85,29 +79,13 @@ class TripPlaceImageAssignmentServiceTest {
         tempImages.add(imgWithGps);
         tempImages.add(imgWithoutGps);
 
-        given(tripDayPlaceService.readById(tripDayPlaceId)).willReturn(Optional.of(tripDayPlace));
-
         // when
-        tripPlaceImageAssignmentService.assignImageToTripDayPlace(tripDayPlaceId, tempImages);
+        tripPlaceImageAssignmentService.assignImageToTripDayPlace(tripDayPlace, tempImages);
 
         // then
         assertEquals(1, tripDayPlace.getPlaces().get(0).getImages().size());
         assertEquals(1, tripDayPlace.getUnmatchedImages().size());
         verify(tripDayPlaceService, times(1)).save(tripDayPlace);
-    }
-
-    @Test
-    @DisplayName("실패 - TripDayPlace 존재 x")
-    void assignImageFailDayPlaceNotFound() {
-        // given
-        given(tripDayPlaceService.readById(anyString())).willReturn(Optional.empty());
-
-        // when
-        CustomException exception = assertThrows(CustomException.class,
-                () -> tripPlaceImageAssignmentService.assignImageToTripDayPlace(tripDayPlaceId, tempImages));
-
-        // then
-        assertEquals(TripErrorType.TRIP_PLACE_NOT_FOUND, exception.getErrorType());
     }
 }
 

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageReassignmentServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceImageReassignmentServiceTest.java
@@ -1,0 +1,92 @@
+package kr.co.yeogiga.application.tripplace.service;
+
+import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageAssignmentService;
+import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageReassignmentService;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.tripplace.entity.Image;
+import kr.co.yeogiga.domain.tripplace.entity.Place;
+import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
+import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class TripPlaceImageReassignmentServiceTest {
+
+    @Mock
+    private TripDayPlaceService tripDayPlaceService;
+
+    @Mock
+    private TripPlaceImageAssignmentService tripPlaceImageAssignmentService;
+
+    @InjectMocks
+    private TripPlaceImageReassignmentService tripPlaceImageReassignmentService;
+
+    private final String tripDayPlaceId = "day-id";
+    @Test
+    @DisplayName("할당된 이미지 목적지에 재정렬 성공")
+    void reassignImagesToTripDayPlaceSuccess() {
+        // given
+
+        /* place1 */
+        Image image1 = Image.builder().url("https://image1.com").latitude(1.1).longitude(2.2).build();
+        Place place1 = Place.builder().name("목적지1").latitude(1.1).longitude(2.2).build();
+        place1.addImages(List.of(image1));
+
+        /* place2 */
+        Image image2 = Image.builder().url("https://image2.com").latitude(3.3).longitude(4.4).build();
+        Place place2 = Place.builder().name("목적지2").latitude(3.3).longitude(4.4).build();
+        place2.addImages(List.of(image2));
+
+        /* unmatched image */
+        Image unmatched = Image.builder().url("https://image3.com").build();
+
+        TripDayPlace tripDayPlace = TripDayPlace.builder()
+                .places(List.of(place1, place2))
+                .build();
+        tripDayPlace.addUnmatchedImages(List.of(unmatched));
+
+        given(tripDayPlaceService.readById(tripDayPlaceId)).willReturn(Optional.of(tripDayPlace));
+
+        // when
+        tripPlaceImageReassignmentService.reassignImagesToTripDayPlace(tripDayPlaceId);
+
+        // then
+        assertThat(place1.getImages()).isEmpty();
+        assertThat(place2.getImages()).isEmpty();
+        assertThat(tripDayPlace.getUnmatchedImages()).isEmpty();
+
+        verify(tripPlaceImageAssignmentService).assignImageToTripDayPlace(eq(tripDayPlace), anyList());
+    }
+
+    @Test
+    @DisplayName("할당된 이미지 목적지에 재정렬 실패 - 존재하지 않는 여행 일차")
+    void reassignImagesToTripDayPlaceFailNotFound() {
+        // given
+        given(tripDayPlaceService.readById(tripDayPlaceId)).willReturn(Optional.empty());
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () ->
+                tripPlaceImageReassignmentService.reassignImagesToTripDayPlace(tripDayPlaceId)
+        );
+
+        // then
+        assertEquals(TripErrorType.TRIP_PLACE_NOT_FOUND, exception.getErrorType());
+    }
+}

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
@@ -7,6 +7,7 @@ import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageRes;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageDeleteService;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageMovementService;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageQueryService;
+import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageReassignmentService;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
@@ -62,6 +63,9 @@ public class TripPlaceImageControllerTest {
 
     @MockBean
     private TripPlaceImageQueryService tripPlaceImageQueryService;
+
+    @MockBean
+    private TripPlaceImageReassignmentService tripPlaceImageReassignmentService;
 
     private final Long tripId = 1L;
     private final String tripDayPlaceId = "dayId";
@@ -299,6 +303,20 @@ public class TripPlaceImageControllerTest {
         // then
         resultActions
                 .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
+    }
+
+    @Test
+    @DisplayName("이미지 목적지에 맞게 재정렬 테스트")
+    void reassignImagesTest() throws Exception {
+        // given
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                patch("/api/v1/trip/{tripId}/day-place/{tripDayPlaceId}/images/re-assign", tripId, tripDayPlaceId)
+        );
+        resultActions
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
     }


### PR DESCRIPTION
## 배경
- 이미지가 매칭된 후, 새로운 이미지 추가 등과 같은 상황으로 인해 이미지 재정렬 필요

## 작업 사항
- TripDayPlace 조회 위치 변경 (927f5bb501ec3c72a8f8eda910e595df9ea12cf9)
    - 이미지 재정렬 과정 중, 여행 일정을 조회하여 이미지들을 리스트에 담아야함 (조회 필요)
    - 리스트에 담은 후, 기존에 저장되어 있던 이미지들을 삭제해줘야함
        - 기존 형식처럼, `TripPlaceImageAssignmentService. assignImageToTripDayPlace`에서 조회를 한다면, 재정렬 메서드에서 `save`한 후, 호출해야함. -> 조회 & 저장 I/O 각각 2번.
        - 조회 후, 보내주는 형식으로 변경 (조회 & 저장 I/O 각각 1번)
- 이미지 목적지에 맞게 재정렬 로직 추가 (f7a2cad4babc76e115f0ec322b49286db77a0a77)

## 추가 논의
추 후, 제한 횟수를 둘지 연속 요청에 대해 막을지 고민해볼 필요가 있을 것 같습니다