### PR TITLE
Feature(IL-104): 여행 생성

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
@@ -1,0 +1,10 @@
+package kr.co.yeogiga.application.trip.dto;
+
+public class TripReq {
+
+    public record Creation(
+            String title,
+            String city
+    ) {
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
@@ -3,9 +3,11 @@ package kr.co.yeogiga.application.trip.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 
 public class TripReq {
 
+    @Builder
     @Schema(name = "TripReq.Creation", description = "여행 생성 DTO")
     public record Creation(
 

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
@@ -1,6 +1,8 @@
 package kr.co.yeogiga.application.trip.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public class TripReq {
 
@@ -8,9 +10,13 @@ public class TripReq {
     public record Creation(
 
             @Schema(description = "여행 제목", example = "여기가 여행")
+            @NotBlank(message = "제목은 필수 입력값입니다.")
+            @Size(max = 20, message = "제목은 최대 20글자까지 가능합니다.")
             String title,
 
             @Schema(description = "목적지 도시", example = "대구광역시")
+            @NotBlank(message = "여행 도시는 필수 입력값입니다.")
+            @Size(max = 20, message = "여행 도시는 최대 20글자까지 가능합니다.")
             String city
     ) {
     }

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
@@ -17,7 +17,6 @@ public class TripReq {
             String title,
 
             @Schema(description = "목적지 도시", example = "대구광역시")
-            @NotBlank(message = "여행 도시는 필수 입력값입니다.")
             @Size(max = 20, message = "여행 도시는 최대 20글자까지 가능합니다.")
             String city
     ) {

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
@@ -1,9 +1,16 @@
 package kr.co.yeogiga.application.trip.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public class TripReq {
 
+    @Schema(name = "TripReq.Creation", description = "여행 생성 DTO")
     public record Creation(
+
+            @Schema(description = "여행 제목", example = "여기가 여행")
             String title,
+
+            @Schema(description = "목적지 도시", example = "대구광역시")
             String city
     ) {
     }

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
@@ -1,0 +1,25 @@
+package kr.co.yeogiga.application.trip.service;
+
+import kr.co.yeogiga.application.trip.dto.TripReq;
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.service.TripService;
+import kr.co.yeogiga.domain.trip.type.TravelStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TripCommandService {
+    private final TripService tripService;
+
+    public void create(Long leaderId, TripReq.Creation creationRequest) {
+        Trip trip = Trip.builder()
+                .title(creationRequest.title())
+                .city(creationRequest.city())
+                .leaderId(leaderId)
+                .travelStatus(TravelStatus.PLANNED)
+                .build();
+
+        tripService.save(trip);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
@@ -1,17 +1,27 @@
 package kr.co.yeogiga.application.trip.service;
 
 import kr.co.yeogiga.application.trip.dto.TripReq;
+import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.entity.TripMember;
+import kr.co.yeogiga.domain.trip.service.TripMemberService;
 import kr.co.yeogiga.domain.trip.service.TripService;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.exception.UserErrorType;
+import kr.co.yeogiga.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class TripCommandService {
     private final TripService tripService;
+    private final TripMemberService tripMemberService;
+    private final UserService userService;
 
+    @Transactional
     public void create(Long leaderId, TripReq.Creation creationRequest) {
         Trip trip = Trip.builder()
                 .title(creationRequest.title())
@@ -20,6 +30,15 @@ public class TripCommandService {
                 .travelStatus(TravelStatus.PLANNED)
                 .build();
 
+        User leader = userService.readById(leaderId)
+                .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
+
+        TripMember tripMember = TripMember.builder()
+                .trip(trip)
+                .user(leader)
+                .build();
+
         tripService.save(trip);
+        tripMemberService.save(tripMember);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/entity/Trip.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/entity/Trip.java
@@ -29,7 +29,7 @@ public class Trip {
     @Column(name = "leader_id", nullable = false)
     private Long leaderId;
 
-    @Column(length = 20, nullable = false)
+    @Column(length = 20)
     private String city;
 
     @Column(name = "started_at")

--- a/src/main/java/kr/co/yeogiga/domain/trip/entity/Trip.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/entity/Trip.java
@@ -29,6 +29,9 @@ public class Trip {
     @Column(name = "leader_id", nullable = false)
     private Long leaderId;
 
+    @Column(length = 20, nullable = false)
+    private String city;
+
     @Column(name = "started_at")
     private LocalDateTime startedAt;
 
@@ -40,11 +43,10 @@ public class Trip {
     private TravelStatus travelStatus;
 
     @Builder
-    public Trip(String title, Long leaderId, LocalDateTime startedAt, LocalDateTime endedAt, TravelStatus travelStatus) {
+    public Trip(String title, Long leaderId, String city, TravelStatus travelStatus) {
         this.title = title;
         this.leaderId = leaderId;
-        this.startedAt = startedAt;
-        this.endedAt = endedAt;
+        this.city = city;
         this.travelStatus = travelStatus;
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/TripMemberRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/TripMemberRepository.java
@@ -1,0 +1,7 @@
+package kr.co.yeogiga.domain.trip.repository;
+
+import kr.co.yeogiga.domain.trip.entity.TripMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
+}

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/TripRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/TripRepository.java
@@ -1,0 +1,7 @@
+package kr.co.yeogiga.domain.trip.repository;
+
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripRepository extends JpaRepository<Trip, Long> {
+}

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
@@ -1,0 +1,16 @@
+package kr.co.yeogiga.domain.trip.service;
+
+import kr.co.yeogiga.domain.trip.entity.TripMember;
+import kr.co.yeogiga.domain.trip.repository.TripMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TripMemberService {
+    private final TripMemberRepository tripMemberRepository;
+
+    public void save(TripMember tripMember) {
+        tripMemberRepository.save(tripMember);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/TripService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/TripService.java
@@ -1,0 +1,16 @@
+package kr.co.yeogiga.domain.trip.service;
+
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.repository.TripRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TripService {
+    private final TripRepository tripRepository;
+
+    public void save(Trip trip) {
+        tripRepository.save(trip);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
@@ -29,6 +29,25 @@ public interface TripApi {
                                                  "message": "요청이 성공하였습니다."
                                              }
                                     """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "여행 생성 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "최대 글자수 초과", value = """
+                                             {
+                                                 "code": "G002",
+                                                 "errors": {
+                                                     "title": "제목은 최대 20글자까지 가능합니다."
+                                                 }
+                                             }
+                                    """),
+                            @ExampleObject(name = "필수 입력값 미입력", value = """
+                                             {
+                                                 "code": "G002",
+                                                 "errors": {
+                                                     "title": "제목은 필수 입력값입니다."
+                                                 }
+                                             }
+                                    """)
                     }))
     })
     ResponseEntity<?> createTrip(

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
@@ -1,0 +1,38 @@
+package kr.co.yeogiga.presentation.trip.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.yeogiga.application.trip.dto.TripReq;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@ApiGroup(value = "[여행 API]")
+@Tag(name = "[여행 API]", description = "여행 관련 API")
+public interface TripApi {
+
+    @TrackApi(description = "여행 생성")
+    @Operation(summary = "여행 생성", description = "여행 생성 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "여행 생성 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                             {
+                                                 "code": 201,
+                                                 "message": "요청이 성공하였습니다."
+                                             }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> createTrip(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody TripReq.Creation request
+    );
+}

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
@@ -4,7 +4,9 @@ import kr.co.yeogiga.application.trip.dto.TripReq;
 import kr.co.yeogiga.application.trip.service.TripCommandService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.presentation.trip.api.TripApi;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,15 +17,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/trip")
 @RequiredArgsConstructor
-public class TripController {
+public class TripController implements TripApi {
     private final TripCommandService tripCommandService;
 
+    @Override
     @PostMapping
     public ResponseEntity<?> createTrip(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody TripReq.Creation request
     ) {
         tripCommandService.create(userDetails.getUserId(), request);
-        return ResponseEntity.ok(SuccessResponse.ok());
+        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.presentation.trip.controller;
 
+import jakarta.validation.Valid;
 import kr.co.yeogiga.application.trip.dto.TripReq;
 import kr.co.yeogiga.application.trip.service.TripCommandService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
@@ -24,7 +25,7 @@ public class TripController implements TripApi {
     @PostMapping
     public ResponseEntity<?> createTrip(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody TripReq.Creation request
+            @Valid @RequestBody TripReq.Creation request
     ) {
         tripCommandService.create(userDetails.getUserId(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
@@ -1,0 +1,29 @@
+package kr.co.yeogiga.presentation.trip.controller;
+
+import kr.co.yeogiga.application.trip.dto.TripReq;
+import kr.co.yeogiga.application.trip.service.TripCommandService;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/trip")
+@RequiredArgsConstructor
+public class TripController {
+    private final TripCommandService tripCommandService;
+
+    @PostMapping
+    public ResponseEntity<?> createTrip(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody TripReq.Creation request
+    ) {
+        tripCommandService.create(userDetails.getUserId(), request);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+}

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripCommandServiceTest.java
@@ -2,8 +2,13 @@ package kr.co.yeogiga.application.trip.service;
 
 import kr.co.yeogiga.application.trip.dto.TripReq;
 import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.entity.TripMember;
+import kr.co.yeogiga.domain.trip.service.TripMemberService;
 import kr.co.yeogiga.domain.trip.service.TripService;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.service.UserService;
+import kr.co.yeogiga.domain.user.type.Role;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -14,15 +19,25 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class TripCommandServiceTest {
     @Mock
     private TripService tripService;
+
+    @Mock
+    private TripMemberService tripMemberService;
+
+    @Mock
+    private UserService userService;
 
     @InjectMocks
     private TripCommandService tripCommandService;
@@ -44,7 +59,18 @@ public class TripCommandServiceTest {
         @DisplayName("성공")
         void success() {
             // given
+            User user = User.builder()
+                    .username("username")
+                    .password("password")
+                    .nickname("nickname")
+                    .email("email")
+                    .role(Role.USER)
+                    .build();
+
+            when(userService.readById(any())).thenReturn(Optional.of(user));
             doNothing().when(tripService).save(any());
+            doNothing().when(tripMemberService).save(any());
+
 
             // when
             tripCommandService.create(leaderId, creationRequest);

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripCommandServiceTest.java
@@ -1,0 +1,62 @@
+package kr.co.yeogiga.application.trip.service;
+
+import kr.co.yeogiga.application.trip.dto.TripReq;
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.service.TripService;
+import kr.co.yeogiga.domain.trip.type.TravelStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class TripCommandServiceTest {
+    @Mock
+    private TripService tripService;
+
+    @InjectMocks
+    private TripCommandService tripCommandService;
+
+    @Nested
+    @DisplayName("여행 생성")
+    class TripCreation {
+        private final Long leaderId = 1L;
+
+        private TripReq.Creation creationRequest = TripReq.Creation.builder()
+                .title("test")
+                .city("대구광역시")
+                .build();
+
+        @Captor
+        private ArgumentCaptor<Trip> tripCaptor;
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            doNothing().when(tripService).save(any());
+
+            // when
+            tripCommandService.create(leaderId, creationRequest);
+
+            // then
+            verify(tripService).save(tripCaptor.capture());
+
+            Trip capturedTrip = tripCaptor.getValue();
+            assertEquals(creationRequest.title(), capturedTrip.getTitle());
+            assertEquals(creationRequest.city(), capturedTrip.getCity());
+            assertEquals(leaderId, capturedTrip.getLeaderId());
+            assertEquals(TravelStatus.PLANNED, capturedTrip.getTravelStatus());
+        }
+    }
+}

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
@@ -1,0 +1,151 @@
+package kr.co.yeogiga.presentation.trip.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.application.trip.dto.TripReq;
+import kr.co.yeogiga.application.trip.service.TripCommandService;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
+import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.type.Role;
+import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = TripController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthenticationFilter.class})
+        }
+)
+public class TripControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private TripCommandService tripCommandService;
+
+    private CustomUserDetails userDetails;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .alwaysDo(print())
+                .build();
+
+        User user = User.builder()
+                .username("username")
+                .password("password")
+                .nickname("nickname")
+                .email("email")
+                .role(Role.USER)
+                .build();
+
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        userDetails = new CustomUserDetailsImpl(user);
+    }
+
+    @Nested
+    @DisplayName("여행 생성")
+    class TripCreation {
+
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            TripReq.Creation creationRequest = TripReq.Creation.builder()
+                    .title("test")
+                    .city("대구광역시")
+                    .build();
+
+            doNothing().when(tripCommandService).create(any(), any());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/trip")
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsString(creationRequest))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.created().message()));
+        }
+
+        @Test
+        @DisplayName("유효성 검증 실패 - null")
+        void failValidationNull() throws Exception {
+            // given
+            TripReq.Creation creationRequest = TripReq.Creation.builder()
+//                    .title("test")
+                    .city("대구광역시")
+                    .build();
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/trip")
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsString(creationRequest))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors.title").exists());
+        }
+
+        @Test
+        @DisplayName("유효성 검증 실패 - 최대 길이 초과")
+        void failValidationLength() throws Exception {
+            // given
+            TripReq.Creation creationRequest = TripReq.Creation.builder()
+                    .title("test")
+                    .city("대구광역시대구광역시대구광역시대구광역시대구광역시대구광역시")
+                    .build();
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/trip")
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsString(creationRequest))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors.city").value("여행 도시는 최대 20글자까지 가능합니다."));
+        }
+    }
+}


### PR DESCRIPTION
## 배경
- 여행 생성 api

## 작업 사항
- 여행 생성 api 작성
- 여행 `Trip` 엔티티 컬럼 변경
    - 여행 생성 시 여행 도시 선택 기능 추가로 인한 도시 `city` 컬럼 추가
        - 도시가 많기 때문에 UI 상에서 여러 선택지 또는 기타 선택지(직접 입력) 방식을 제공할 것이라 생각하여 String 값으로 설정하였습니다. 
    - `started_at`, `ended_at` 빌더 내 제거
        - 차후, W2M 기능 후 방장이 시작, 종료 날짜 입력 시 해당 시작, 종료 날짜 설정으로 인한 제거

