### PR TITLE
Feature(IL-106): 여행 방장 루트 저장 로직 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/route/dto/RouteReq.java
+++ b/src/main/java/kr/co/yeogiga/application/route/dto/RouteReq.java
@@ -1,0 +1,31 @@
+package kr.co.yeogiga.application.route.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
+import java.time.LocalDateTime;
+
+public class RouteReq {
+
+    public record Request(
+            double latitude,
+            double longitude
+    ) {
+        public StoredFormat toStoredFormat() {
+            return new StoredFormat(latitude, longitude, LocalDateTime.now());
+        }
+    }
+
+    public record StoredFormat(
+            double latitude,
+            double longitude,
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+            @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+            @JsonSerialize(using = LocalDateTimeSerializer.class)
+            LocalDateTime time
+    ) {
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/route/dto/RouteReq.java
+++ b/src/main/java/kr/co/yeogiga/application/route/dto/RouteReq.java
@@ -5,13 +5,17 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
 public class RouteReq {
 
+    @Schema(name = "RouteReq.Request", description = "방장 루트 DTO")
     public record Request(
+            @Schema(description = "방장 위치 위도", example = "11.11")
             double latitude,
+            @Schema(description = "방장 위치 경도", example = "22.22")
             double longitude
     ) {
         public StoredFormat toStoredFormat() {

--- a/src/main/java/kr/co/yeogiga/application/route/service/TripLeaderCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/route/service/TripLeaderCommandService.java
@@ -1,0 +1,56 @@
+package kr.co.yeogiga.application.route.service;
+
+import kr.co.yeogiga.application.route.dto.RouteReq;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import kr.co.yeogiga.infrastructure.redis.constant.RouteConstant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TripLeaderCommandService {
+    private final RedisRepository redisRepository;
+
+    // (위도/경도) 비교 시 같은 위치로 간주할 오차 범위 (약 10~14m 정도)
+    private static final double LOCATION_THRESHOLD = 0.0001;
+
+    /**
+     * 방장(TripLeader)의 이동 경로를 Redis에 저장하는 메서드
+     * - 직전 저장 위치와 현재 위치가 거의 같으면 덮어쓰기 수행
+     * - 위치가 다르면 새로운 위치로 추가 저장
+     *
+     * @param tripId   여행 ID
+     * @param day      여행 일차
+     * @param routeReq 클라이언트에서 보낸 위치 정보 (위도, 경도)
+     */
+    public void storeLeaderRouteInRedis(Long tripId, int day, RouteReq.Request routeReq) {
+        String tripRouteKey = RouteConstant.TripRouteKey(tripId, day);
+
+        RouteReq.StoredFormat routeStoredFormat = routeReq.toStoredFormat();
+
+        RouteReq.StoredFormat lastRoute =
+                redisRepository.getLastFromList(tripRouteKey, RouteReq.StoredFormat.class);
+
+        // 마지막 위치와 현재 위치가 거의 같다면 → 시간만 갱신해서 덮어쓰기
+        if (lastRoute != null && isSimilarLocation(lastRoute, routeStoredFormat)) {
+            redisRepository.setValueInList(tripRouteKey, -1, routeStoredFormat);
+            return;
+        }
+
+        redisRepository.setList(tripRouteKey, routeStoredFormat);
+    }
+
+    /**
+     * 두 위치가 LOCATION_THRESHOLD 이내로 유사한지 판단하는 메서드
+     *
+     * @param prevRoute 이전 위치
+     * @param nowRoute  현재 위치
+     * @return 동일한 위치인지 판단 값
+     */
+    private boolean isSimilarLocation(RouteReq.StoredFormat prevRoute, RouteReq.StoredFormat nowRoute) {
+        double latDiff = Math.abs(prevRoute.latitude() - nowRoute.latitude());
+        double lonDiff = Math.abs(prevRoute.longitude() - nowRoute.longitude());
+
+        return latDiff < LOCATION_THRESHOLD && lonDiff < LOCATION_THRESHOLD;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/redis/RedisRepository.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/redis/RedisRepository.java
@@ -35,6 +35,10 @@ public class RedisRepository {
         redisTemplate.opsForList().rightPush(key, value);
     }
 
+    public void setValueInList(String key, long index, Object value) {
+        redisTemplate.opsForList().set(key, index, value);
+    }
+
     public <T> List<T> getList(String key, Class<T> clazz) {
         List<Object> objects = redisTemplate.opsForList().range(key, 0, -1);
         if (objects == null || objects.isEmpty()) {
@@ -44,6 +48,14 @@ public class RedisRepository {
         return objects.stream()
                 .map(clazz::cast)
                 .collect(Collectors.toList());
+    }
+
+    public <T> T getLastFromList(String key, Class<T> clazz) {
+        List<Object> objects = redisTemplate.opsForList().range(key, -1, -1);
+        if (objects == null || objects.isEmpty()) {
+            return null;
+        }
+        return clazz.cast(objects.get(0));
     }
 
     public void removeFromList(String key, Object value) {

--- a/src/main/java/kr/co/yeogiga/infrastructure/redis/constant/RouteConstant.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/redis/constant/RouteConstant.java
@@ -1,0 +1,12 @@
+package kr.co.yeogiga.infrastructure.redis.constant;
+
+public final class RouteConstant {
+
+    private RouteConstant() { }
+
+    private static final String TRIP_ROUTE_KEY_PREFIX = "trip:route:%d:%d";
+
+    public static String TripRouteKey(Long tripId, int day) {
+        return String.format(TRIP_ROUTE_KEY_PREFIX, tripId, day);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/route/api/RouteApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/route/api/RouteApi.java
@@ -1,0 +1,38 @@
+package kr.co.yeogiga.presentation.route.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.yeogiga.application.route.dto.RouteReq;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@ApiGroup(value = "[여행 루트(GPS) 정보 API]")
+@Tag(name = "[여행 루트(GPS) 정보 API]", description = "여행 루트(GPS) 정보 관련 API")
+public interface RouteApi {
+
+    @TrackApi(description = "방장의 위치 저장 (주기적 요청)")
+    @Operation(summary = "방장의 위치 저장 (주기적 요청)", description = "방장의 위치를 저장하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "방장 위치 저장 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 201,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> storeLeaderRoute(
+            @PathVariable Long tripId,
+            @PathVariable int day,
+            @RequestBody RouteReq.Request routeReq
+    );
+}

--- a/src/main/java/kr/co/yeogiga/presentation/route/controller/RouteController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/route/controller/RouteController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class RouteController implements RouteApi {
     private final TripLeaderCommandService tripLeaderCommandService;
 
+    @Override
     @PostMapping("/{tripId}/days/{day}/routes")
     public ResponseEntity<?> storeLeaderRoute(
             @PathVariable Long tripId,

--- a/src/main/java/kr/co/yeogiga/presentation/route/controller/RouteController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/route/controller/RouteController.java
@@ -1,0 +1,29 @@
+package kr.co.yeogiga.presentation.route.controller;
+
+import kr.co.yeogiga.application.route.dto.RouteReq;
+import kr.co.yeogiga.application.route.service.TripLeaderCommandService;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/trip")
+@RequiredArgsConstructor
+public class RouteController {
+    private final TripLeaderCommandService tripLeaderCommandService;
+
+    @PostMapping("/{tripId}/days/{day}/routes")
+    public ResponseEntity<?> storeLeaderRoute(
+            @PathVariable Long tripId,
+            @PathVariable int day,
+            @RequestBody RouteReq.Request routeReq
+    ) {
+        tripLeaderCommandService.storeLeaderRouteInRedis(tripId, day, routeReq);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/route/controller/RouteController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/route/controller/RouteController.java
@@ -3,7 +3,9 @@ package kr.co.yeogiga.presentation.route.controller;
 import kr.co.yeogiga.application.route.dto.RouteReq;
 import kr.co.yeogiga.application.route.service.TripLeaderCommandService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.presentation.route.api.RouteApi;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/trip")
 @RequiredArgsConstructor
-public class RouteController {
+public class RouteController implements RouteApi {
     private final TripLeaderCommandService tripLeaderCommandService;
 
     @PostMapping("/{tripId}/days/{day}/routes")
@@ -24,6 +26,6 @@ public class RouteController {
             @RequestBody RouteReq.Request routeReq
     ) {
         tripLeaderCommandService.storeLeaderRouteInRedis(tripId, day, routeReq);
-        return ResponseEntity.ok(SuccessResponse.ok());
+        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
     }
 }

--- a/src/test/java/kr/co/yeogiga/application/route/TripLeaderCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/route/TripLeaderCommandServiceTest.java
@@ -1,0 +1,71 @@
+package kr.co.yeogiga.application.route;
+
+import kr.co.yeogiga.application.route.dto.RouteReq;
+import kr.co.yeogiga.application.route.service.TripLeaderCommandService;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class TripLeaderCommandServiceTest {
+
+    @Mock
+    private RedisRepository redisRepository;
+
+    @InjectMocks
+    private TripLeaderCommandService tripLeaderCommandService;
+
+    private final Long tripId = 1L;
+    private final int day = 1;
+
+    private final RouteReq.Request request =
+            new RouteReq.Request(35.000000, 129.000000);
+
+    @Test
+    @DisplayName("이전 위치와 다르면 새로운 위치 추가")
+    void storeLeaderRouteAddNewWhenLocationIsDifferent() {
+        // given
+        RouteReq.StoredFormat last = new RouteReq.StoredFormat(37.000000, 127.000000, LocalDateTime.now());
+
+        given(redisRepository.getLastFromList(anyString(), eq(RouteReq.StoredFormat.class)))
+                .willReturn(last);
+
+        // when
+        tripLeaderCommandService.storeLeaderRouteInRedis(tripId, day, request);
+
+        // then
+        verify(redisRepository).setList(anyString(), any());
+        verify(redisRepository, never()).setValueInList(anyString(), anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("이전 위치와 거의 같으면 덮어쓰기 수행")
+    void storeLeaderRouteUpdateLastWhenLocationIsSimilar() {
+        // given
+        RouteReq.StoredFormat last = new RouteReq.StoredFormat(35.000000, 129.000000, LocalDateTime.now());
+
+        given(redisRepository.getLastFromList(anyString(), eq(RouteReq.StoredFormat.class)))
+                .willReturn(last);
+
+        // when
+        tripLeaderCommandService.storeLeaderRouteInRedis(tripId, day, request);
+
+        // then
+        verify(redisRepository).setValueInList(anyString(), eq(-1L), any());
+        verify(redisRepository, never()).setList(anyString(), any());
+    }
+}

--- a/src/test/java/kr/co/yeogiga/application/route/service/TripLeaderCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/route/service/TripLeaderCommandServiceTest.java
@@ -1,7 +1,6 @@
-package kr.co.yeogiga.application.route;
+package kr.co.yeogiga.application.route.service;
 
 import kr.co.yeogiga.application.route.dto.RouteReq;
-import kr.co.yeogiga.application.route.service.TripLeaderCommandService;
 import kr.co.yeogiga.infrastructure.redis.RedisRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/kr/co/yeogiga/presentation/route/controller/RouteControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/route/controller/RouteControllerTest.java
@@ -68,8 +68,7 @@ public class RouteControllerTest {
         // then
         resultActions
                 .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/route/controller/RouteControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/route/controller/RouteControllerTest.java
@@ -1,0 +1,75 @@
+package kr.co.yeogiga.presentation.route.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.application.route.dto.RouteReq;
+import kr.co.yeogiga.application.route.service.TripLeaderCommandService;
+import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = RouteController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthenticationFilter.class})
+        }
+)
+public class RouteControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private TripLeaderCommandService tripLeaderCommandService;
+
+    private final Long tripId = 1L;
+    private final int day = 1;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .build();
+    }
+
+    @Test
+    @DisplayName("방장 경로 저장 테스트")
+    void storeLeaderRouteTest() throws Exception {
+        // given
+        RouteReq.Request routeReq =
+                new RouteReq.Request(37.123456, 127.123456);
+
+        // whe
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/trip/{tripId}/days/{day}/routes", tripId, day)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(routeReq))
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
+    }
+}


### PR DESCRIPTION
## 배경
여행 종료 후, 이동한 위치를 파악하기 위해 방장의 루트를 저장해야함.

## 작업 사항
- Redis 내 List형식으로 방장의 루트 저장 (b58790b8f00945c2aedaf7b1b336e1b9fc655446)
    - Redis에 이미 저장된 List의 마지막 값을 가져오고 덮어쓰기 위한 메서드 작성 (4955a20720aba17d001ca0506e178fabb577cc4d)
        - 인근 위치를 돌아다니면 저장을 하지 않고, 최신 시간으로 업데이트만 수행하기 위함.

## 추가 논의
x