### PR TITLE
Fix: User 엔티티 내 이메일 값 NOT NULL 제약 해제

### DIFF
--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -29,7 +29,7 @@ public class User extends BaseTimeEntity {
 
     private String password;
 
-    @Column(nullable = false, unique = true)
+    @Column(unique = true)
     private String email;
 
     @Column(nullable = false)


### PR DESCRIPTION
## 배경
- User 엔티티 내 이메일 값 NOT NULL 제약 해제 미적용에 따른 수정

## 작업 사항
- User 엔티티 내 이메일 값 NOT NULL 제약 해제