### PR TITLE
Feature(IL-107): Redis에 저장된 여행 루트 RDB 로드 로직 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/route/schedule/RouteSchedule.java
+++ b/src/main/java/kr/co/yeogiga/application/route/schedule/RouteSchedule.java
@@ -1,0 +1,20 @@
+package kr.co.yeogiga.application.route.schedule;
+
+import kr.co.yeogiga.application.route.service.TripLeaderCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RouteSchedule {
+    private final TripLeaderCommandService tripLeaderCommandService;
+
+    /**
+     * Redis 내 여행 루트를 RDB로 로드하기 위한 스케쥴러
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    public void persistTripRoutesDailyJob() {
+        tripLeaderCommandService.persistAllTripRoutes();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/route/scheduler/RouteScheduler.java
+++ b/src/main/java/kr/co/yeogiga/application/route/scheduler/RouteScheduler.java
@@ -1,4 +1,4 @@
-package kr.co.yeogiga.application.route.schedule;
+package kr.co.yeogiga.application.route.scheduler;
 
 import kr.co.yeogiga.application.route.service.TripLeaderCommandService;
 import lombok.RequiredArgsConstructor;
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class RouteSchedule {
+public class RouteScheduler {
     private final TripLeaderCommandService tripLeaderCommandService;
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/route/service/TripLeaderCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/route/service/TripLeaderCommandService.java
@@ -1,15 +1,23 @@
 package kr.co.yeogiga.application.route.service;
 
 import kr.co.yeogiga.application.route.dto.RouteReq;
+import kr.co.yeogiga.domain.triproute.entity.Route;
+import kr.co.yeogiga.domain.triproute.entity.TripRoute;
+import kr.co.yeogiga.domain.triproute.service.TripRouteService;
 import kr.co.yeogiga.infrastructure.redis.RedisRepository;
 import kr.co.yeogiga.infrastructure.redis.constant.RouteConstant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
 @Service
 @RequiredArgsConstructor
 public class TripLeaderCommandService {
     private final RedisRepository redisRepository;
+    private final TripRouteService tripRouteService;
 
     // (위도/경도) 비교 시 같은 위치로 간주할 오차 범위 (약 10~14m 정도)
     private static final double LOCATION_THRESHOLD = 0.0001;
@@ -52,5 +60,60 @@ public class TripLeaderCommandService {
         double lonDiff = Math.abs(prevRoute.longitude() - nowRoute.longitude());
 
         return latDiff < LOCATION_THRESHOLD && lonDiff < LOCATION_THRESHOLD;
+    }
+
+    /**
+     * Redis에 버퍼링된 TripRoute 데이터를 RDB에 로드하는 메서드.
+     * - TRIP_ROUTE_KEY_PATTERN을 통한 Redis 내 키 패턴 조회
+     * - 각 키의 루트 데이터를 TripRoute 엔티티로 변환
+     * - RDB에 일괄 저장 후, 관련 Redis 키들을 삭제
+     */
+    public void persistAllTripRoutes() {
+        Set<String> keys = redisRepository.getKeysByPattern(RouteConstant.TRIP_ROUTE_KEY_PATTERN);
+
+        List<TripRoute> tripRoutes = new ArrayList<>();
+
+        for (String key : keys) {
+            TripRoute tripRoute = convertKeyToTripRoute(key);
+            if (tripRoute == null) continue;
+
+            tripRoutes.add(tripRoute);
+        }
+
+        tripRouteService.saveAll(tripRoutes);
+        redisRepository.deleteKeys(keys.stream().toList());
+    }
+
+    /**
+     * Redis 키 문자열을 파싱하여 TripRoute 도메인 엔티티로 변환하는 메서드
+     * - Redis에 저장된 StoredFormat 리스트를 Route 리스트로 매핑
+     *
+     * @param key Redis에 저장된 경로 데이터 키
+     * @return TripRoute 엔티티
+     */
+    private TripRoute convertKeyToTripRoute(String key) {
+        String[] parts = key.split(":");
+        Long tripId = Long.parseLong(parts[2]);
+        int day = Integer.parseInt(parts[3]);
+
+        List<RouteReq.StoredFormat> storedRoutes = redisRepository.getList(key, RouteReq.StoredFormat.class);
+
+        if (storedRoutes == null || storedRoutes.isEmpty()) {
+            return null;
+        }
+
+        List<Route> routes = storedRoutes.stream()
+                .map(r -> Route.builder()
+                        .latitude(r.latitude())
+                        .longitude(r.longitude())
+                        .time(r.time())
+                        .build())
+                .toList();
+
+        return TripRoute.builder()
+                .tripId(tripId)
+                .day(day)
+                .routes(routes)
+                .build();
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/triproute/converter/RouteListConverter.java
+++ b/src/main/java/kr/co/yeogiga/domain/triproute/converter/RouteListConverter.java
@@ -1,0 +1,37 @@
+package kr.co.yeogiga.domain.triproute.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import kr.co.yeogiga.domain.triproute.entity.Route;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Converter
+@Component
+@RequiredArgsConstructor
+public class RouteListConverter implements AttributeConverter<List<Route>, String> {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public String convertToDatabaseColumn(List<Route> dataList) {
+        try {
+            return objectMapper.writeValueAsString(dataList);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to serialize list to JSON", e);
+        }
+    }
+
+    @Override
+    public List<Route> convertToEntityAttribute(String data) {
+        try {
+            return objectMapper.readValue(data, new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to deserialize JSON to list", e);
+        }
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/triproute/entity/Route.java
+++ b/src/main/java/kr/co/yeogiga/domain/triproute/entity/Route.java
@@ -1,0 +1,20 @@
+package kr.co.yeogiga.domain.triproute.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class Route {
+    private double latitude;
+    private double longitude;
+    private LocalDateTime time;
+
+    @Builder
+    public Route(double latitude, double longitude, LocalDateTime time) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.time = time;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/triproute/entity/TripRoute.java
+++ b/src/main/java/kr/co/yeogiga/domain/triproute/entity/TripRoute.java
@@ -1,0 +1,40 @@
+package kr.co.yeogiga.domain.triproute.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import kr.co.yeogiga.domain.triproute.converter.RouteListConverter;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "trip_route")
+public class TripRoute {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "trip_id")
+    private Long tripId;
+
+    private int day;
+
+    @Column(columnDefinition = "TEXT")
+    @Convert(converter = RouteListConverter.class)
+    private List<Route> routes;
+
+    @Builder
+    public TripRoute(Long tripId, int day, List<Route> routes) {
+        this.tripId = tripId;
+        this.day = day;
+        this.routes = routes;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/triproute/repository/CustomTripRouteRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/triproute/repository/CustomTripRouteRepository.java
@@ -1,0 +1,9 @@
+package kr.co.yeogiga.domain.triproute.repository;
+
+import kr.co.yeogiga.domain.triproute.entity.TripRoute;
+
+import java.util.List;
+
+public interface CustomTripRouteRepository {
+    void saveAllInBatch(List<TripRoute> tripRoutes);
+}

--- a/src/main/java/kr/co/yeogiga/domain/triproute/repository/CustomTripRouteRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/triproute/repository/CustomTripRouteRepositoryImpl.java
@@ -1,0 +1,33 @@
+package kr.co.yeogiga.domain.triproute.repository;
+
+import kr.co.yeogiga.domain.triproute.converter.RouteListConverter;
+import kr.co.yeogiga.domain.triproute.entity.TripRoute;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.PreparedStatement;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomTripRouteRepositoryImpl implements CustomTripRouteRepository {
+    private final JdbcTemplate jdbcTemplate;
+    private final RouteListConverter routeListConverter;
+
+    private final static int BATCH_SIZE = 100;
+
+    @Override
+    public void saveAllInBatch(List<TripRoute> tripRoutes) {
+        String sql = "INSERT INTO trip_route (trip_id, day, routes) " +
+                "VALUES (?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(
+                sql,
+                tripRoutes,
+                BATCH_SIZE,
+                (PreparedStatement ps, TripRoute tripRoute) -> {
+                    ps.setLong(1, tripRoute.getTripId());
+                    ps.setInt(2, tripRoute.getDay());
+                    ps.setString(3, routeListConverter.convertToDatabaseColumn(tripRoute.getRoutes()));
+                });
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/triproute/repository/TripRouteRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/triproute/repository/TripRouteRepository.java
@@ -1,0 +1,7 @@
+package kr.co.yeogiga.domain.triproute.repository;
+
+import kr.co.yeogiga.domain.triproute.entity.TripRoute;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripRouteRepository extends JpaRepository<TripRoute, Long>, CustomTripRouteRepository {
+}

--- a/src/main/java/kr/co/yeogiga/domain/triproute/service/TripRouteService.java
+++ b/src/main/java/kr/co/yeogiga/domain/triproute/service/TripRouteService.java
@@ -1,0 +1,18 @@
+package kr.co.yeogiga.domain.triproute.service;
+
+import kr.co.yeogiga.domain.triproute.entity.TripRoute;
+import kr.co.yeogiga.domain.triproute.repository.TripRouteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TripRouteService {
+    private final TripRouteRepository tripRouteRepository;
+
+    public void saveAll(List<TripRoute> tripRoutes) {
+        tripRouteRepository.saveAllInBatch(tripRoutes);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/redis/RedisRepository.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/redis/RedisRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -76,5 +77,15 @@ public class RedisRepository {
 
     public boolean existsInSet(String key, Object value) {
         return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(key, value));
+    }
+
+    public Set<String> getKeysByPattern(String pattern) {
+        return redisTemplate.keys(pattern);
+    }
+
+    public void deleteKeys(Collection<String> keys) {
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
     }
 }

--- a/src/main/java/kr/co/yeogiga/infrastructure/redis/constant/RouteConstant.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/redis/constant/RouteConstant.java
@@ -5,6 +5,7 @@ public final class RouteConstant {
     private RouteConstant() { }
 
     private static final String TRIP_ROUTE_KEY_PREFIX = "trip:route:%d:%d";
+    public static final String TRIP_ROUTE_KEY_PATTERN = "trip:route:*:*";
 
     public static String TripRouteKey(Long tripId, int day) {
         return String.format(TRIP_ROUTE_KEY_PREFIX, tripId, day);

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${DATABASE_HOST:localhost}:${DATABASE_PORT:3306}/${DATABASE_NAME:yeogiga}
+    url: jdbc:mysql://${DATABASE_HOST:localhost}:${DATABASE_PORT:3306}/${DATABASE_NAME:yeogiga}?rewriteBatchedStatements=true
     username: ${DATABASE_USER:root}
     password: ${DATABASE_PASS:password}
 

--- a/src/test/java/kr/co/yeogiga/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/kr/co/yeogiga/domain/user/repository/UserRepositoryTest.java
@@ -2,9 +2,11 @@ package kr.co.yeogiga.domain.user.repository;
 
 import kr.co.yeogiga.domain.oauth.entity.OAuth;
 import kr.co.yeogiga.domain.oauth.repository.OAuthRepository;
-import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
+import kr.co.yeogiga.domain.triproute.converter.RouteListConverter;
+import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.type.Role;
+import kr.co.yeogiga.infrastructure.TestObjectMapperConfig;
 import kr.co.yeogiga.infrastructure.config.JpaConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @TestPropertySource(locations = "classpath:application-test.yml")
-@Import(JpaConfig.class)
+@Import({JpaConfig.class, TestObjectMapperConfig.class})
 public class UserRepositoryTest {
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/kr/co/yeogiga/infrastructure/TestObjectMapperConfig.java
+++ b/src/test/java/kr/co/yeogiga/infrastructure/TestObjectMapperConfig.java
@@ -1,0 +1,19 @@
+package kr.co.yeogiga.infrastructure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.domain.triproute.converter.RouteListConverter;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestObjectMapperConfig {
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper().findAndRegisterModules();
+    }
+
+    @Bean
+    public RouteListConverter routeListConverter(ObjectMapper objectMapper) {
+        return new RouteListConverter(objectMapper);
+    }
+}


### PR DESCRIPTION
## 배경
I/O 속도 및 연산 로직을 줄이기 위해 Redis 내 저장했던 여행 루트를 RDB에 저장하는 로직이 필요.
자정마다 수행해야 함.

## 작업 사항
- 여행 루트 기록을 위한 Entity 생성 (315979b09ac3dd41b267b9c56996a9c808f3a035)
    - 루트는 List로 담기 위해 컨버터 설정 (5ad3560d11adcc4ddee0900dc867eefae6ec0715)
- 여행 루트를 RDB에 저장하는 과정은 IO 연산이 많이 발생하기에 배치 처리 적용 (24e8041a03180d6383d632f3b01b40f1413d9b7c)
- 여행 루트를 RDB에 로드하는 로직 구현 (075fdbbaace9dd22394dd27f7122f10e4e0a49dd)
- 스케쥴러 설정 (c1215dc83ced9906a1c0d15f6d0357d1a05b2e7b)

## 추가 논의
현재 `Route`라는 객체를 `triproute.entity`에 넣었습니다. TripRoute 필드에 포함되는 내역이라 해당 패키지 위치에 넣었는데, 기영님은 이 위치가 적절한가에 대해 궁금합니다