### PR TITLE
Feature(IL-114): 여행 시간 수정

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
@@ -49,6 +49,7 @@ public class TripReq {
     ) {
         @Schema(hidden = true)
         public boolean isValid() {
+            if (start == null || end == null) return false;
             return start.isBefore(end);
         }
     }

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
@@ -1,9 +1,16 @@
 package kr.co.yeogiga.application.trip.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
+
+import java.time.LocalDateTime;
 
 public class TripReq {
 
@@ -20,5 +27,22 @@ public class TripReq {
             @Size(max = 20, message = "여행 도시는 최대 20글자까지 가능합니다.")
             String city
     ) {
+    }
+
+    @Builder
+    public record Time(
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+            @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+            @JsonSerialize(using = LocalDateTimeSerializer.class)
+            LocalDateTime start,
+
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+            @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+            @JsonSerialize(using = LocalDateTimeSerializer.class)
+            LocalDateTime end
+    ) {
+        public boolean isValid() {
+            return start.isBefore(end);
+        }
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
@@ -34,12 +34,14 @@ public class TripReq {
     @Schema(name = "TripReq.Time", description = "여행 시간 수정 요청 DTO")
     public record Time(
             @Schema(description = "여행 시작 시각", example = "2025-01-01T12:00:00", type = "string")
+            @NotNull(message = "여행 시작 시각은 필수 입력값입니다.")
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
             @JsonDeserialize(using = LocalDateTimeDeserializer.class)
             @JsonSerialize(using = LocalDateTimeSerializer.class)
             LocalDateTime start,
 
             @Schema(description = "여행 종료 시각", example = "2025-01-05T12:00:00", type = "string")
+            @NotNull(message = "여행 종료 시각은 필수 입력값입니다.")
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
             @JsonDeserialize(using = LocalDateTimeDeserializer.class)
             @JsonSerialize(using = LocalDateTimeSerializer.class)

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
@@ -35,16 +35,10 @@ public class TripReq {
     public record Time(
             @Schema(description = "여행 시작 시각", example = "2025-01-01T12:00:00", type = "string")
             @NotNull(message = "여행 시작 시각은 필수 입력값입니다.")
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
-            @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-            @JsonSerialize(using = LocalDateTimeSerializer.class)
             LocalDateTime start,
 
             @Schema(description = "여행 종료 시각", example = "2025-01-05T12:00:00", type = "string")
             @NotNull(message = "여행 종료 시각은 필수 입력값입니다.")
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
-            @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-            @JsonSerialize(using = LocalDateTimeSerializer.class)
             LocalDateTime end
     ) {
         @Schema(hidden = true)

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -30,17 +31,21 @@ public class TripReq {
     }
 
     @Builder
+    @Schema(name = "TripReq.Time", description = "여행 시간 수정 요청 DTO")
     public record Time(
+            @Schema(description = "여행 시작 시각", example = "2025-01-01T12:00:00", type = "string")
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
             @JsonDeserialize(using = LocalDateTimeDeserializer.class)
             @JsonSerialize(using = LocalDateTimeSerializer.class)
             LocalDateTime start,
 
+            @Schema(description = "여행 종료 시각", example = "2025-01-05T12:00:00", type = "string")
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
             @JsonDeserialize(using = LocalDateTimeDeserializer.class)
             @JsonSerialize(using = LocalDateTimeSerializer.class)
             LocalDateTime end
     ) {
+        @Schema(hidden = true)
         public boolean isValid() {
             return start.isBefore(end);
         }

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
@@ -1,10 +1,5 @@
 package kr.co.yeogiga.application.trip.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
@@ -4,6 +4,7 @@ import kr.co.yeogiga.application.trip.dto.TripReq;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.entity.TripMember;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.service.TripMemberService;
 import kr.co.yeogiga.domain.trip.service.TripService;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
@@ -40,5 +41,24 @@ public class TripCommandService {
 
         tripService.save(trip);
         tripMemberService.save(tripMember);
+    }
+
+    @Transactional
+    public void updateTime(Long tripId, Long userId, TripReq.Time time) {
+        Trip trip = tripService.findById(tripId)
+                .orElseThrow(() -> new CustomException(TripErrorType.TRIP_NOT_FOUND));
+
+        if (!time.isValid()) {
+            throw new CustomException(TripErrorType.INVALID_DATA_RANGE);
+        }
+
+        if (!trip.getLeaderId().equals(userId)) {
+            throw new CustomException(TripErrorType.PERMISSION_DENIED_NOT_LEADER);
+        }
+
+        TravelStatus status = TravelStatus.resolveStatus(time.start(), time.end());
+
+        trip.updateTime(time.start(), time.end());
+        trip.updateStatus(status);
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
@@ -45,7 +45,7 @@ public class TripCommandService {
 
     @Transactional
     public void updateTime(Long tripId, Long userId, TripReq.Time time) {
-        Trip trip = tripService.findById(tripId)
+        Trip trip = tripService.readById(tripId)
                 .orElseThrow(() -> new CustomException(TripErrorType.TRIP_NOT_FOUND));
 
         if (!time.isValid()) {

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
@@ -49,7 +49,7 @@ public class TripCommandService {
                 .orElseThrow(() -> new CustomException(TripErrorType.TRIP_NOT_FOUND));
 
         if (!time.isValid()) {
-            throw new CustomException(TripErrorType.INVALID_DATA_RANGE);
+            throw new CustomException(TripErrorType.INVALID_DATE_RANGE);
         }
 
         if (!trip.getLeaderId().equals(userId)) {

--- a/src/main/java/kr/co/yeogiga/domain/trip/entity/Trip.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/entity/Trip.java
@@ -49,4 +49,13 @@ public class Trip {
         this.city = city;
         this.travelStatus = travelStatus;
     }
+
+    public void updateTime(LocalDateTime startedAt, LocalDateTime endedAt) {
+        this.startedAt = startedAt;
+        this.endedAt = endedAt;
+    }
+
+    public void updateStatus(TravelStatus status) {
+        this.travelStatus = status;
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
@@ -18,7 +18,7 @@ public enum TripErrorType implements BaseErrorType {
 
     TRIP_NOT_FOUND(HttpStatus.NOT_FOUND, "T006", "해당 여행이 존재하지 않습니다."),
     PERMISSION_DENIED_NOT_LEADER(HttpStatus.FORBIDDEN, "T007", "여행 방장이 아닙니다."),
-    INVALID_DATA_RANGE(HttpStatus.BAD_REQUEST, "T008", "여행 시작 시간과 종료 시간을 확인하세요.");
+    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "T008", "여행 시작 시간과 종료 시간을 확인하세요.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
@@ -14,8 +14,11 @@ public enum TripErrorType implements BaseErrorType {
     ALREADY_ADDED_PLACE(HttpStatus.CONFLICT, "T002", "이미 추가된 장소입니다."),
     TRIP_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "T003", "해당 여행 일차 정보가 존재하지 않습니다."),
     TEMP_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "T004", "임시 저장소에 해당 장소가 존재하지 않습니다."),
-    PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "T005", "해당 목적지가 존재하지 않습니다")
-    ;
+    PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "T005", "해당 목적지가 존재하지 않습니다"),
+
+    TRIP_NOT_FOUND(HttpStatus.NOT_FOUND, "T006", "해당 여행이 존재하지 않습니다."),
+    PERMISSION_DENIED_NOT_LEADER(HttpStatus.FORBIDDEN, "T007", "여행 방장이 아닙니다."),
+    INVALID_DATA_RANGE(HttpStatus.BAD_REQUEST, "T008", "여행 시작 시간과 종료 시간을 확인하세요.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/TripService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/TripService.java
@@ -16,7 +16,7 @@ public class TripService {
         tripRepository.save(trip);
     }
 
-    public Optional<Trip> findById(Long tripId) {
+    public Optional<Trip> readById(Long tripId) {
         return tripRepository.findById(tripId);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/TripService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/TripService.java
@@ -5,6 +5,8 @@ import kr.co.yeogiga.domain.trip.repository.TripRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class TripService {
@@ -12,5 +14,9 @@ public class TripService {
 
     public void save(Trip trip) {
         tripRepository.save(trip);
+    }
+
+    public Optional<Trip> findById(Long tripId) {
+        return tripRepository.findById(tripId);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/type/TravelStatus.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/type/TravelStatus.java
@@ -1,7 +1,27 @@
 package kr.co.yeogiga.domain.trip.type;
 
+import java.time.LocalDateTime;
+
 public enum TravelStatus {
     PLANNED,
     IN_PROGRESS,
-    COMPLETED
+    COMPLETED;
+
+    public static TravelStatus resolveStatus(LocalDateTime start, LocalDateTime end) {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isBefore(start)) {
+            return PLANNED;
+        }
+
+        if (start.isBefore(now) && end.isAfter(now)) {
+            return IN_PROGRESS;
+        }
+
+        if (now.isAfter(end)) {
+            return COMPLETED;
+        }
+
+        return PLANNED;
+    }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.presentation.trip.api;
 import api.link.checker.annotation.ApiGroup;
 import api.link.checker.annotation.TrackApi;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -12,6 +13,7 @@ import kr.co.yeogiga.application.trip.dto.TripReq;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @ApiGroup(value = "[여행 API]")
@@ -53,5 +55,54 @@ public interface TripApi {
     ResponseEntity<?> createTrip(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody TripReq.Creation request
+    );
+
+    @TrackApi(description = "여행 시간 수정")
+    @Operation(summary = "여행 시간 수정", description = "여행 시간 수정 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "여행 시간 수정 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                             {
+                                                 "code": 200,
+                                                 "message": "요청이 성공하였습니다."
+                                             }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "여행 시간 수정 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "여행 시작, 종료 시간 범위 에러 (종료 시각 <= 시작 시간)", value = """
+                                             {
+                                                 "code": "T008",
+                                                 "message": "여행 시작 시간과 종료 시간을 확인하세요."
+                                             }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "여행 시간 수정 실패 - 권한",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "방장이 아닌 사용자 수정 불가", value = """
+                                             {
+                                                 "code": "T007",
+                                                 "message": "여행 방장이 아닙니다."
+                                             }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "여행 시간 수정 실패 - 여행 존재 여부",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "존재하지 않는 여행", value = """
+                                             {
+                                                 "code": "T006",
+                                                 "message": "여행 시작 시간과 종료 시간을 확인하세요."
+                                             }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> updateTripTime(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+
+            @Parameter(description = "여행 ID")
+            @PathVariable Long tripId,
+
+            @RequestBody TripReq.Time request
     );
 }

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import kr.co.yeogiga.application.trip.dto.TripReq;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
@@ -103,6 +104,7 @@ public interface TripApi {
             @Parameter(description = "여행 ID")
             @PathVariable Long tripId,
 
+            @Valid
             @RequestBody TripReq.Time request
     );
 }

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
@@ -10,7 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,5 +31,16 @@ public class TripController implements TripApi {
     ) {
         tripCommandService.create(userDetails.getUserId(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
+    }
+
+    @PutMapping("/{tripId}/time")
+    public ResponseEntity<?> updateTripTime(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long tripId,
+            @RequestBody TripReq.Time request
+    ) {
+        tripCommandService.updateTime(tripId, userDetails.getUserId(), request);
+        return ResponseEntity.ok(SuccessResponse.ok());
+
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
@@ -33,11 +33,12 @@ public class TripController implements TripApi {
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
     }
 
+    @Override
     @PutMapping("/{tripId}/time")
     public ResponseEntity<?> updateTripTime(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long tripId,
-            @RequestBody TripReq.Time request
+            @Valid @RequestBody TripReq.Time request
     ) {
         tripCommandService.updateTime(tripId, userDetails.getUserId(), request);
         return ResponseEntity.ok(SuccessResponse.ok());

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripCommandServiceTest.java
@@ -1,8 +1,9 @@
 package kr.co.yeogiga.application.trip.service;
 
 import kr.co.yeogiga.application.trip.dto.TripReq;
+import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.entity.Trip;
-import kr.co.yeogiga.domain.trip.entity.TripMember;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.service.TripMemberService;
 import kr.co.yeogiga.domain.trip.service.TripService;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
@@ -17,13 +18,19 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -85,4 +92,158 @@ public class TripCommandServiceTest {
             assertEquals(TravelStatus.PLANNED, capturedTrip.getTravelStatus());
         }
     }
+
+    @Nested
+    @DisplayName("시간 수정")
+    class TimeModification {
+        private final Long tripId = 1L;
+        private final Long userId = 1L;
+
+        private Trip trip = Trip.builder()
+                .title("test")
+                .city("대구광역시")
+                .leaderId(userId)
+                .build();
+
+        @Test
+        @DisplayName("성공 - 여행 전")
+        void successBeforeTrip() {
+            // given
+            LocalDateTime startTime = LocalDateTime.of(2025, 4, 1, 12, 00);
+            LocalDateTime endTime = LocalDateTime.of(2025, 5, 2, 12, 00);
+            TripReq.Time time = TripReq.Time.builder()
+                    .start(startTime)
+                    .end(endTime)
+                    .build();
+
+            when(tripService.findById(tripId)).thenReturn(Optional.of(trip));
+
+            // LocalDateTime::now static 메서드에 대한 반환값 Stub
+            try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+                String date = "2025-03-01T12:00:00Z";
+                Clock clock = Clock.fixed(Instant.parse(date), ZoneId.of("UTC"));
+                LocalDateTime mockNow = LocalDateTime.now(clock);
+                mockedLocalDateTime.when(LocalDateTime::now).thenReturn(mockNow);
+
+                // when
+                tripCommandService.updateTime(tripId, userId, time);
+
+                // then
+                assertEquals(TravelStatus.PLANNED, trip.getTravelStatus());
+            }
+        }
+
+        @Test
+        @DisplayName("성공 - 여행 중")
+        void successOnTrip() {
+            // given
+            LocalDateTime startTime = LocalDateTime.of(2025, 2, 1, 12, 00);
+            LocalDateTime endTime = LocalDateTime.of(2025, 4, 2, 12, 00);
+            TripReq.Time time = TripReq.Time.builder()
+                    .start(startTime)
+                    .end(endTime)
+                    .build();
+
+            when(tripService.findById(tripId)).thenReturn(Optional.of(trip));
+
+            // LocalDateTime::now static 메서드에 대한 반환값 Stub
+            try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+                String date = "2025-03-01T12:00:00Z";
+                Clock clock = Clock.fixed(Instant.parse(date), ZoneId.of("UTC"));
+                LocalDateTime mockNow = LocalDateTime.now(clock);
+                mockedLocalDateTime.when(LocalDateTime::now).thenReturn(mockNow);
+
+                // when
+                tripCommandService.updateTime(tripId, userId, time);
+
+                // then
+                assertEquals(TravelStatus.IN_PROGRESS, trip.getTravelStatus());
+            }
+        }
+
+        @Test
+        @DisplayName("성공 - 여행 후")
+        void successAfterTrip() {
+            // given
+            LocalDateTime startTime = LocalDateTime.of(2025, 1, 1, 12, 00);
+            LocalDateTime endTime = LocalDateTime.of(2025, 2, 2, 12, 00);
+            TripReq.Time time = TripReq.Time.builder()
+                    .start(startTime)
+                    .end(endTime)
+                    .build();
+
+            when(tripService.findById(tripId)).thenReturn(Optional.of(trip));
+
+            // LocalDateTime::now static 메서드에 대한 반환값 Stub
+            try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+                String date = "2025-03-01T12:00:00Z";
+                Clock clock = Clock.fixed(Instant.parse(date), ZoneId.of("UTC"));
+                LocalDateTime mockNow = LocalDateTime.now(clock);
+                mockedLocalDateTime.when(LocalDateTime::now).thenReturn(mockNow);
+
+                // when
+                tripCommandService.updateTime(tripId, userId, time);
+
+                // then
+                assertEquals(TravelStatus.COMPLETED, trip.getTravelStatus());
+            }
+        }
+
+        @Test
+        @DisplayName("실패 - 여행 시각 오류 (종료 시각 <= 출발 시각")
+        void failInvalidDateRange() {
+            // given
+            LocalDateTime startTime = LocalDateTime.of(2025, 3, 1, 12, 00);
+            LocalDateTime endTime = LocalDateTime.of(2025, 2, 2, 12, 00);
+            TripReq.Time time = TripReq.Time.builder()
+                    .start(startTime)
+                    .end(endTime)
+                    .build();
+
+            when(tripService.findById(tripId)).thenReturn(Optional.of(trip));
+
+            // LocalDateTime::now static 메서드에 대한 반환값 Stub
+            try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+                String date = "2025-03-01T12:00:00Z";
+                Clock clock = Clock.fixed(Instant.parse(date), ZoneId.of("UTC"));
+                LocalDateTime mockNow = LocalDateTime.now(clock);
+                mockedLocalDateTime.when(LocalDateTime::now).thenReturn(mockNow);
+
+                // when
+                CustomException exception = assertThrows(CustomException.class, () -> tripCommandService.updateTime(tripId, userId, time));
+
+                // then
+                assertEquals(TripErrorType.INVALID_DATE_RANGE, exception.getErrorType());
+            }
+        }
+
+        @Test
+        @DisplayName("실패 - 방장 아닌 사용자 요청")
+        void failForbidden() {
+            // given
+            LocalDateTime startTime = LocalDateTime.of(2025, 1, 1, 12, 00);
+            LocalDateTime endTime = LocalDateTime.of(2025, 2, 2, 12, 00);
+            TripReq.Time time = TripReq.Time.builder()
+                    .start(startTime)
+                    .end(endTime)
+                    .build();
+
+            when(tripService.findById(tripId)).thenReturn(Optional.of(trip));
+
+            // LocalDateTime::now static 메서드에 대한 반환값 Stub
+            try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+                String date = "2025-03-01T12:00:00Z";
+                Clock clock = Clock.fixed(Instant.parse(date), ZoneId.of("UTC"));
+                LocalDateTime mockNow = LocalDateTime.now(clock);
+                mockedLocalDateTime.when(LocalDateTime::now).thenReturn(mockNow);
+
+                // when
+                CustomException exception = assertThrows(CustomException.class, () -> tripCommandService.updateTime(tripId, 2L, time));
+
+                // then
+                assertEquals(TripErrorType.PERMISSION_DENIED_NOT_LEADER, exception.getErrorType());
+            }
+        }
+    }
 }
+

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripCommandServiceTest.java
@@ -116,7 +116,7 @@ public class TripCommandServiceTest {
                     .end(endTime)
                     .build();
 
-            when(tripService.findById(tripId)).thenReturn(Optional.of(trip));
+            when(tripService.readById(tripId)).thenReturn(Optional.of(trip));
 
             // LocalDateTime::now static 메서드에 대한 반환값 Stub
             try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
@@ -144,7 +144,7 @@ public class TripCommandServiceTest {
                     .end(endTime)
                     .build();
 
-            when(tripService.findById(tripId)).thenReturn(Optional.of(trip));
+            when(tripService.readById(tripId)).thenReturn(Optional.of(trip));
 
             // LocalDateTime::now static 메서드에 대한 반환값 Stub
             try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
@@ -172,7 +172,7 @@ public class TripCommandServiceTest {
                     .end(endTime)
                     .build();
 
-            when(tripService.findById(tripId)).thenReturn(Optional.of(trip));
+            when(tripService.readById(tripId)).thenReturn(Optional.of(trip));
 
             // LocalDateTime::now static 메서드에 대한 반환값 Stub
             try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
@@ -200,7 +200,7 @@ public class TripCommandServiceTest {
                     .end(endTime)
                     .build();
 
-            when(tripService.findById(tripId)).thenReturn(Optional.of(trip));
+            when(tripService.readById(tripId)).thenReturn(Optional.of(trip));
 
             // LocalDateTime::now static 메서드에 대한 반환값 Stub
             try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
@@ -228,7 +228,7 @@ public class TripCommandServiceTest {
                     .end(endTime)
                     .build();
 
-            when(tripService.findById(tripId)).thenReturn(Optional.of(trip));
+            when(tripService.readById(tripId)).thenReturn(Optional.of(trip));
 
             // LocalDateTime::now static 메서드에 대한 반환값 Stub
             try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
@@ -26,10 +26,13 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.time.LocalDateTime;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -146,6 +149,65 @@ public class TripControllerTest {
             resultActions
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.errors.city").value("여행 도시는 최대 20글자까지 가능합니다."));
+        }
+    }
+
+    @Nested
+    @DisplayName("여행 시간 수정")
+    class TimeModification {
+
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            LocalDateTime startTime = LocalDateTime.of(2025, 4, 1, 12, 00);
+            LocalDateTime endTime = LocalDateTime.of(2025, 5, 2, 12, 00);
+            TripReq.Time request = TripReq.Time.builder()
+                    .start(startTime)
+                    .end(endTime)
+                    .build();
+
+            doNothing().when(tripCommandService).updateTime(any(), any(), any());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    put("/api/v1/trip/{tripId}/time", 1L)
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsBytes(request))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
+
+        @Test
+        @DisplayName("실패 - 유효성 검증 실패")
+        void failValidation() throws Exception {
+            // given
+            LocalDateTime startTime = LocalDateTime.of(2025, 4, 1, 12, 00);
+            LocalDateTime endTime = LocalDateTime.of(2025, 5, 2, 12, 00);
+            TripReq.Time request = TripReq.Time.builder()
+                    .start(startTime)
+//                    .end(endTime)
+                    .build();
+
+            doNothing().when(tripCommandService).updateTime(any(), any(), any());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    put("/api/v1/trip/{tripId}/time", 1L)
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsBytes(request))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors.end").exists());
         }
     }
 }


### PR DESCRIPTION
## 배경
- 여행 시간(시작, 종료) 수정 로직 필요

## 작업 사항
- 여행 시간 수정 로직 추가
   - 여행 시간 수정 시, 현재 날짜와 시작, 종료 시각을 비교하여 여행 상태 값도 수정

## 기타
- `TripCommandService.TimeModification` 테스트 코드 작성 시
`LocalDateTime.now()`를 통한 날짜 확인 로직이 있습니다. 차후 날짜가 변경되면 문제가 발생할 것 같아, `MockedStatic<T>`를 활용하여 `LocalDateTime.now()` static 메서드에 대한 stub 설정 후 테스트 진행하였습니다.

## 추가 논의
- `TripReq.Time.isValid()` 메서드가 스웨거 문서 내 RequestBody로 출력되는 현상이 발생하여 `@Schema(hidden = true)` 설정을 통하여 제외시켰습니다.