### PR TITLE
Feature(IL-116): 여행 상태 갱신 스케줄링

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/trip/scheduler/TripScheduler.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/scheduler/TripScheduler.java
@@ -1,0 +1,19 @@
+package kr.co.yeogiga.application.trip.scheduler;
+
+import kr.co.yeogiga.application.trip.service.TripCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class TripScheduler {
+    private final TripCommandService tripCommandService;
+
+    @Scheduled(cron = "0 55 * * * *")
+    public void runUpdateTravelStatusJob() {
+        tripCommandService.updateTravelStatus(LocalDateTime.now().plusMinutes(5));
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
@@ -24,6 +24,12 @@ public class TripCommandService {
     private final TripMemberService tripMemberService;
     private final UserService userService;
 
+    /**
+     * 여행 생성 메서드
+     *
+     * @param leaderId          방장(여행 생성자) ID
+     * @param creationRequest   여행 생성 요청 DTO
+     */
     @Transactional
     public void create(Long leaderId, TripReq.Creation creationRequest) {
         Trip trip = Trip.builder()
@@ -45,6 +51,17 @@ public class TripCommandService {
         tripMemberService.save(tripMember);
     }
 
+    /**
+     * 여행 시간 수정 메서드
+     *
+     * @param tripId        여행 ID
+     * @param userId        요청자 ID
+     * @param time          여행 시간 수정 요청 DTO
+     *
+     * @throws CustomException  TripErrorType.TRIP_NOT_FOUND - 여행 조회 불가
+     * @throws CustomException  TripErrorType.INVALID_DATE_RANGE - 여행 시간 범위 오류 (종료 시각 <= 출발시각)
+     * @throws CustomException  TripErrorType.PERMISSION_DENIED_NOT_LEADER - 방장이 아닌 사용자
+     */
     @Transactional
     public void updateTime(Long tripId, Long userId, TripReq.Time time) {
         Trip trip = tripService.readById(tripId)
@@ -64,6 +81,11 @@ public class TripCommandService {
         trip.updateStatus(status);
     }
 
+    /**
+     * 여행 상태 갱신 메서드
+     *
+     * @param time      현재 시간
+     */
     @Transactional
     public void updateTravelStatus(LocalDateTime time) {
         tripService.updateAllTravelStatusToInProgress(time);

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
@@ -15,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class TripCommandService {
@@ -60,5 +62,11 @@ public class TripCommandService {
 
         trip.updateTime(time.start(), time.end());
         trip.updateStatus(status);
+    }
+
+    @Transactional
+    public void updateTravelStatus(LocalDateTime time) {
+        tripService.updateAllTravelStatusToInProgress(time);
+        tripService.updateAllTravelStatusToCompleted(time);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/TripRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/TripRepository.java
@@ -2,6 +2,24 @@ package kr.co.yeogiga.domain.trip.repository;
 
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
 
 public interface TripRepository extends JpaRepository<Trip, Long> {
+
+    @Modifying
+    @Query("UPDATE trip " +
+            "SET travelStatus = 'IN_PROGRESS' " +
+            "WHERE travelStatus != 'IN_PROGRESS' AND startedAt <= :time AND :time <= endedAt")
+    void updateTravelStatusInProgress(@Param(value = "time") LocalDateTime time);
+
+    @Modifying
+    @Query("UPDATE trip " +
+            "SET travelStatus = 'COMPLETED' " +
+            "WHERE travelStatus != 'COMPLETED' AND endedAt <= :time")
+    void updateTravelStatusCompleted(@Param(value = "time") LocalDateTime time);
+
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/TripService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/TripService.java
@@ -5,6 +5,7 @@ import kr.co.yeogiga.domain.trip.repository.TripRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Service
@@ -18,5 +19,13 @@ public class TripService {
 
     public Optional<Trip> readById(Long tripId) {
         return tripRepository.findById(tripId);
+    }
+
+    public void updateAllTravelStatusToInProgress(LocalDateTime time) {
+        tripRepository.updateTravelStatusInProgress(time);
+    }
+
+    public void updateAllTravelStatusToCompleted(LocalDateTime time) {
+        tripRepository.updateTravelStatusCompleted(time);
     }
 }


### PR DESCRIPTION
## 배경
- 매 시간마다 여행 상태 갱신 필요 

## 작업 사항
- 여행 상태 갱신 bulk update 쿼리 메서드 작성
- 여행 상태 갱신 스케줄링 - 1시간 단위 정각 5분전 상태 업데이트 수행
<br />

- `TripCommandService ` 내 주석 작성 - 전 작업에서 주석을 작성하지 않아서 현재 PR에 작성했네요. 죄송합니다 😅

## 테스트
스케줄러를 통한 작업 및 기타 도메인 서비스 직접 사용 외 비지니스 로직이  포함되지 않아 따로 테스트 코드 작성하지 않았습니다. 갱신 시 데이터베이스 변화 결과로 대체합니다.

<table>
	<tr>
        <td colspan=2>여행 전 PLANNED → 여행 중 IN_PROGRESS</td>
    </tr>
    <tr>
        <td>
			PLANNED
		</td>
		<td>
			IN_PROGRESS (5월 21일 설정 후 테스트)
		</td>
    </tr>
    <tr>
        <td>
			<img src="https://github.com/user-attachments/assets/b29dc311-40cf-458f-b40a-caffca49a9e9" />
		</td>
		<td>
			<img src="https://github.com/user-attachments/assets/6ea294f4-6b18-42e4-b5b4-85c7a908eafa" />
		</td>
    </tr>
</table>


<table>
	<tr>
        <td colspan=2>여행 중 IN_PROGRESS → 여행 종료 COMPLETED</td>
    </tr>
    <tr>
        <td>
			IN_PROGRESS
		</td>
		<td>
			COMPLETED (5월 20일 13시 설정 후 테스트)
		</td>
    </tr>
    <tr>
        <td>
			<img src="https://github.com/user-attachments/assets/8a72fca7-7c75-4457-97e5-09754ef66cba" />
		</td>
		<td>
			<img src="https://github.com/user-attachments/assets/1126365a-c555-447a-a8c9-41924402bd1a" />
		</td>
    </tr>
</table>


## 추가 논의 
- 여행 시작 시 알람 관련
여행 시작 시 알람이 사용자에게 전달되는 것도 좋을 것 같습니다. 차후 FCM 도입 시 팀원 분들 의견 여쭤보고 기능 추가되면 작업 진행하도록 하겠습니다.

- 스케줄링 시간 관련
현재 bulk update가 되도록 구성해야 100,000건의 데이터 업데이트를 테스트해본 결과 358ms가 소요(대체로 350초 내외)되었습니다. 
![image](https://github.com/user-attachments/assets/b253c341-43f2-42bb-b3ad-4abd3a1016cf)
따라서, 스케줄링 시간을 정각 5분 전이 아닌 1~2분 내외로 설정하여도 괜찮을 것 같다는 생각이 드는데 어떻게 생각하시나요?
