### PR TITLE
Feature(IL-113): 이미지 매핑 과정 중, 시간데이터를 통한 이동 경로의 GPS 매핑 로직 추가

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageAssignmentService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageAssignmentService.java
@@ -4,10 +4,16 @@ import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
+import kr.co.yeogiga.domain.triproute.entity.Route;
+import kr.co.yeogiga.domain.triproute.entity.TripRoute;
+import kr.co.yeogiga.domain.triproute.service.TripRouteService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -20,6 +26,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class TripPlaceImageAssignmentService {
     private final TripDayPlaceService tripDayPlaceService;
+    private final TripRouteService tripRouteService;
 
     /**
      * 이미지 메타데이터를 불러와 해당 TripDayPlace에 할당하는 메서드
@@ -30,12 +37,19 @@ public class TripPlaceImageAssignmentService {
      * @param images       처리하고자 하는 이미지 리스트
      */
     public void assignImageToTripDayPlace(TripDayPlace tripDayPlace, List<Image> images) {
+        TripRoute tripRoute = tripRouteService.readByTripIdAndDay(
+                tripDayPlace.getTripId(), tripDayPlace.getDay()
+        ).orElse(null);
+
+        List<Route> routes = (tripRoute != null) ? tripRoute.getRoutes() : Collections.emptyList();
+
         // GPS 정보를 기준으로 가장 가까운 장소별로 이미지 그룹핑
         List<Image> unmatchedImages = new ArrayList<>();
         Map<String, List<Image>> placeImageMap = groupImagesByNearestPlace(
                 tripDayPlace.getPlaces(),
                 images,
-                unmatchedImages
+                unmatchedImages,
+                routes
         );
 
         // 그룹핑된 이미지들을 실제 TripDayPlace에 할당
@@ -46,27 +60,41 @@ public class TripPlaceImageAssignmentService {
 
     /**
      * 이미지들을 가장 가까운 목적지별로 그룹핑하여 매핑하는 메서드
+     * - GPS가 존재하지 않지만 시간 데이터가 존재한다면, 매칭할 일정에 대한 이동 경로를 통해 GPS 정보를 매핑
      * - GPS 정보가 없으면 unmatchedImages에 추가
      * - 가장 가까운 장소가 없는 경우(목적지 존재 x)에도 unmatchedImages에 추가
      *
      * @param places          이미지와 매칭할 대상 장소 리스트
      * @param sourceImages    정렬할 이미지 리스트
      * @param unmatchedImages 매칭되지 않은 이미지를 저장할 리스트
+     * @param routes          매칭할 일정에 대한 이동 경로
      * @return 장소 ID를 키로 하고, 해당 장소에 할당될 이미지 리스트를 값으로 가지는 Map
      */
     private Map<String, List<Image>> groupImagesByNearestPlace(
             List<Place> places,
             List<Image> sourceImages,
-            List<Image> unmatchedImages
+            List<Image> unmatchedImages,
+            List<Route> routes
     ) {
         Map<String, List<Image>> placeImageMap = new HashMap<>();
 
         for (Image image : sourceImages) {
+
+            // GPS 정보는 없지만 이미지에 시간데이터는 있는 경우, 여행 루트를 통해 GPS 정보 탐색
+            if (!hasGpsInfo(image) && image.getDate() != null) {
+                Route nearestRoute = findNearestLocationFromRoutesByTime(routes, image.getDate());
+                if (nearestRoute != null) {
+                    image.updateGps(nearestRoute.getLatitude(), nearestRoute.getLongitude());
+                }
+            }
+
+            // GPS가 존재하지 않는 경우, 기타(unmatchedImages)에 저장
             if (!hasGpsInfo(image)) {
                 unmatchedImages.add(image);
                 continue;
             }
 
+            // 이미지의 GPS 정보를 통해 가까운 목적지를 탐색
             Place nearestPlace = findNearestPlace(places, image);
             if (nearestPlace != null) {
                 placeImageMap.computeIfAbsent(nearestPlace.getId(), k -> new ArrayList<>()).add(image);
@@ -100,6 +128,23 @@ public class TripPlaceImageAssignmentService {
         }
 
         tripDayPlace.addUnmatchedImages(unmatchedImages);
+    }
+
+    /**
+     * 이미지의 촬영 시간과 가장 가까운 시간 정보를 가진 이동 경로(Route)를 찾는 메서드
+     * - 이미지의 촬영 시간(imageTime)과의 시간 차이가 가장 작은 Route를 반환
+     * - 일치하는 Route가 없으면 null을 반환
+     *
+     * @param routes     비교 대상이 되는 이동 경로(Route) 리스트
+     * @param imageTime  이미지의 촬영 시간
+     * @return           가장 가까운 시간의 Route 객체, 없으면 null
+     */
+    private Route findNearestLocationFromRoutesByTime(List<Route> routes, LocalDateTime imageTime) {
+        return routes.stream()
+                .filter(route -> route.getTime() != null)
+                .min(Comparator.comparingLong(route ->
+                        Math.abs(Duration.between(imageTime, route.getTime()).toMillis())))
+                .orElse(null);
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Image.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Image.java
@@ -22,4 +22,9 @@ public class Image {
         this.longitude = longitude;
         this.date = date;
     }
+
+    public void updateGps(Double latitude, Double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/triproute/repository/TripRouteRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/triproute/repository/TripRouteRepository.java
@@ -3,5 +3,8 @@ package kr.co.yeogiga.domain.triproute.repository;
 import kr.co.yeogiga.domain.triproute.entity.TripRoute;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TripRouteRepository extends JpaRepository<TripRoute, Long>, CustomTripRouteRepository {
+    Optional<TripRoute> findByTripIdAndDay(Long tripId, int day);
 }

--- a/src/main/java/kr/co/yeogiga/domain/triproute/service/TripRouteService.java
+++ b/src/main/java/kr/co/yeogiga/domain/triproute/service/TripRouteService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,5 +15,9 @@ public class TripRouteService {
 
     public void saveAll(List<TripRoute> tripRoutes) {
         tripRouteRepository.saveAllInBatch(tripRoutes);
+    }
+
+    public Optional<TripRoute> readByTripIdAndDay(Long tripId, int day) {
+        return tripRouteRepository.findByTripIdAndDay(tripId, day);
     }
 }

--- a/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageAssignmentServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageAssignmentServiceTest.java
@@ -4,6 +4,7 @@ import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
+import kr.co.yeogiga.domain.triproute.service.TripRouteService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,9 @@ class TripPlaceImageAssignmentServiceTest {
 
     @Mock
     private TripDayPlaceService tripDayPlaceService;
+
+    @Mock
+    private TripRouteService tripRouteService;
 
     @InjectMocks
     private TripPlaceImageAssignmentService tripPlaceImageAssignmentService;


### PR DESCRIPTION
## 배경
이미지의 메타데이터 중, GPS 정보가 없는 경우가 존재.
여행의 이동경로를 위해 `trip_route`를 저장한다.
이미지에 시간 데이터가 존재한다면, 해당 이동 경로의 시간과 가장 근접한 GPS 정보와 매핑이 필요.

## 작업 사항
- 이동 경로(TripRoute) 조회 로직 구현 (5a0d2202ffc42a7db03b64208c747e0f482c3f28)
- 이미지 매핑 중, 시간 데이터를 통해 이동경로의 GPS 정보 매핑 추가 (491103e19bba7c933cffa46606e1596719cdc5ef)

## 추가 논의
x