### PR TITLE
Feature(IL-122): W2M 쓰기 연산 로직 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/calendar/dto/CalendarReq.java
+++ b/src/main/java/kr/co/yeogiga/application/calendar/dto/CalendarReq.java
@@ -1,0 +1,21 @@
+package kr.co.yeogiga.application.calendar.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import kr.co.yeogiga.domain.calendar.entity.Calendar;
+import kr.co.yeogiga.domain.trip.entity.Trip;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record CalendarReq(
+        @NotEmpty(message = "가능한 날짜 목록은 비어 있을 수 없습니다.")
+        List<LocalDate> availableDates
+) {
+    public Calendar toEntity(Long userId, Trip trip) {
+        return Calendar.builder()
+                .userId(userId)
+                .trip(trip)
+                .availableDates(availableDates)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/calendar/dto/CalendarReq.java
+++ b/src/main/java/kr/co/yeogiga/application/calendar/dto/CalendarReq.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.application.calendar.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import kr.co.yeogiga.domain.calendar.entity.Calendar;
 import kr.co.yeogiga.domain.trip.entity.Trip;
@@ -7,7 +8,9 @@ import kr.co.yeogiga.domain.trip.entity.Trip;
 import java.time.LocalDate;
 import java.util.List;
 
+@Schema(name = "CalendarReq", description = "W2M 쓰기 연산 DTO")
 public record CalendarReq(
+        @Schema(description = "가능한 날짜 리스트", example = "[\"2025-07-01\", \"2025-07-02\", \"2025-07-10\"]")
         @NotEmpty(message = "가능한 날짜 목록은 비어 있을 수 없습니다.")
         List<LocalDate> availableDates
 ) {

--- a/src/main/java/kr/co/yeogiga/application/calendar/service/CalendarCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/calendar/service/CalendarCommandService.java
@@ -1,0 +1,58 @@
+package kr.co.yeogiga.application.calendar.service;
+
+import kr.co.yeogiga.application.calendar.dto.CalendarReq;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.calendar.entity.Calendar;
+import kr.co.yeogiga.domain.calendar.service.CalendarService;
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.trip.service.TripService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CalendarCommandService {
+    private final CalendarService calendarService;
+    private final TripService tripService;
+
+    /**
+     * 사용자의 여행 가능한 날짜를 생성하는 메서드
+     * - 하나의 Trip에 대해 한 사용자는 하나의 Calendar만 가질 수 있다.
+     *
+     * @param userId      로그인한 사용자 ID
+     * @param tripId      여행 ID
+     * @param calendarReq 사용자가 선택한 가능한 날짜 목록
+     * @throws CustomException TripErrorType.CALENDAR_ALREADY_EXISTS - 이미 가능한 날짜 등록
+     * @throws CustomException TripErrorType.TRIP_NOT_FOUND - 존재하지 않는 여행
+     */
+    @Transactional
+    public void create(Long userId, Long tripId, CalendarReq calendarReq) {
+        if (calendarService.existsByUserIdAndTripId(userId, tripId)) {
+            throw new CustomException(TripErrorType.CALENDAR_ALREADY_EXISTS);
+        }
+
+        Trip trip = tripService.readById(tripId)
+                .orElseThrow(() -> new CustomException(TripErrorType.TRIP_NOT_FOUND));
+
+        calendarService.save(calendarReq.toEntity(userId, trip));
+    }
+
+    /**
+     * 사용자의 가능한 날짜를 수정하는 메서드
+     * - 전달된 날짜 리스트로 기존 날짜를 교체
+     *
+     * @param userId      로그인한 사용자 ID
+     * @param tripId      여행 ID
+     * @param calendarReq 새로 선택한 가능한 날짜 목록
+     * @throws CustomException TripErrorType.CALENDAR_NOT_FOUND - 존재하지 않는 가능 날짜
+     */
+    @Transactional
+    public void updateAvailableDates(Long userId, Long tripId, CalendarReq calendarReq) {
+        Calendar calendar = calendarService.readByUserIdAndTripId(userId, tripId)
+                .orElseThrow(() -> new CustomException(TripErrorType.CALENDAR_NOT_FOUND));
+
+        calendar.updateAvailableDates(calendarReq.availableDates());
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/calendar/converter/LocalDateListConverter.java
+++ b/src/main/java/kr/co/yeogiga/domain/calendar/converter/LocalDateListConverter.java
@@ -1,0 +1,35 @@
+package kr.co.yeogiga.domain.calendar.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Converter
+@RequiredArgsConstructor
+public class LocalDateListConverter implements AttributeConverter<List<LocalDate>, String> {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public String convertToDatabaseColumn(List<LocalDate> dataList) {
+        try {
+            return objectMapper.writeValueAsString(dataList);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to serialize list to JSON", e);
+        }
+    }
+
+    @Override
+    public List<LocalDate> convertToEntityAttribute(String data) {
+        try {
+            return objectMapper.readValue(data, new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to deserialize JSON to list", e);
+        }
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/calendar/entity/Calendar.java
+++ b/src/main/java/kr/co/yeogiga/domain/calendar/entity/Calendar.java
@@ -1,0 +1,51 @@
+package kr.co.yeogiga.domain.calendar.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import kr.co.yeogiga.domain.calendar.converter.LocalDateListConverter;
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "calendar")
+public class Calendar {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "available_dates", columnDefinition = "TEXT")
+    @Convert(converter = LocalDateListConverter.class)
+    private List<LocalDate> availableDates;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id")
+    private Trip trip;
+
+    @Builder
+    public Calendar(Long userId, List<LocalDate> availableDates, Trip trip) {
+        this.userId = userId;
+        this.availableDates = availableDates;
+        this.trip = trip;
+    }
+
+    public void updateAvailableDates(List<LocalDate> availableDates) {
+        this.availableDates = availableDates;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/calendar/repository/CalendarRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/calendar/repository/CalendarRepository.java
@@ -1,0 +1,11 @@
+package kr.co.yeogiga.domain.calendar.repository;
+
+import kr.co.yeogiga.domain.calendar.entity.Calendar;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CalendarRepository extends JpaRepository<Calendar, Long> {
+    Optional<Calendar> findByUserIdAndTrip_Id(Long userId, Long tripId);
+    boolean existsByUserIdAndTrip_Id(Long userId, Long tripId);
+}

--- a/src/main/java/kr/co/yeogiga/domain/calendar/service/CalendarService.java
+++ b/src/main/java/kr/co/yeogiga/domain/calendar/service/CalendarService.java
@@ -1,0 +1,26 @@
+package kr.co.yeogiga.domain.calendar.service;
+
+import kr.co.yeogiga.domain.calendar.entity.Calendar;
+import kr.co.yeogiga.domain.calendar.repository.CalendarRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CalendarService {
+    private final CalendarRepository calendarRepository;
+
+    public void save(Calendar calendar) {
+        calendarRepository.save(calendar);
+    }
+
+    public Optional<Calendar> readByUserIdAndTripId(Long userId, Long tripId) {
+        return calendarRepository.findByUserIdAndTrip_Id(userId, tripId);
+    }
+
+    public boolean existsByUserIdAndTripId(Long userId, Long tripId) {
+        return calendarRepository.existsByUserIdAndTrip_Id(userId, tripId);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
@@ -18,7 +18,10 @@ public enum TripErrorType implements BaseErrorType {
 
     TRIP_NOT_FOUND(HttpStatus.NOT_FOUND, "T006", "해당 여행이 존재하지 않습니다."),
     PERMISSION_DENIED_NOT_LEADER(HttpStatus.FORBIDDEN, "T007", "여행 방장이 아닙니다."),
-    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "T008", "여행 시작 시간과 종료 시간을 확인하세요.");
+    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "T008", "여행 시작 시간과 종료 시간을 확인하세요."),
+
+    CALENDAR_NOT_FOUND(HttpStatus.NOT_FOUND, "T009", "사용자의 가능한 날짜 정보가 존재하지 않습니다."),
+    CALENDAR_ALREADY_EXISTS(HttpStatus.CONFLICT, "T010", "이미 가능한 날짜 정보가 등록되어 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/kr/co/yeogiga/presentation/calendar/api/CalendarApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/calendar/api/CalendarApi.java
@@ -1,0 +1,116 @@
+package kr.co.yeogiga.presentation.calendar.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.co.yeogiga.application.calendar.dto.CalendarReq;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@ApiGroup(value = "[W2M API]")
+@Tag(name = "[W2M API]", description = "W2M 관련 API")
+public interface CalendarApi {
+
+    @TrackApi(description = "W2M 생성")
+    @Operation(summary = "W2M 생성", description = "W2M 생성하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "W2M 생성 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 201,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "W2M 생성 유효성 검사 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                             {
+                                                 "code": "G002",
+                                                 "errors": {
+                                                     "availableDates": "가능한 날짜 목록은 비어 있을 수 없습니다."
+                                                 }
+                                             }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "찾을 수 없는 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                             "code": "T006",
+                                             "message": "해당 여행이 존재하지 않습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                             "code": "T010",
+                                             "message": "이미 가능한 날짜 정보가 등록되어 있습니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> createCalendar(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+
+            @Parameter(description = "여행 ID")
+            @PathVariable Long tripId,
+
+            @Valid @RequestBody CalendarReq calendarReq
+    );
+
+    @TrackApi(description = "W2M 수정")
+    @Operation(summary = "W2M 수정", description = "W2M 수정하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "W2M 수정 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "W2M 생성 유효성 검사 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                             {
+                                                 "code": "G002",
+                                                 "errors": {
+                                                     "availableDates": "가능한 날짜 목록은 비어 있을 수 없습니다."
+                                                 }
+                                             }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "찾을 수 없는 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                             "code": "T009",
+                                             "message": "사용자의 가능한 날짜 정보가 존재하지 않습니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> updateAvailableDates(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+
+            @Parameter(description = "여행 ID")
+            @PathVariable Long tripId,
+
+            @Valid @RequestBody CalendarReq calendarReq
+    );
+}

--- a/src/main/java/kr/co/yeogiga/presentation/calendar/controller/CalendarController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/calendar/controller/CalendarController.java
@@ -1,0 +1,43 @@
+package kr.co.yeogiga.presentation.calendar.controller;
+
+import jakarta.validation.Valid;
+import kr.co.yeogiga.application.calendar.dto.CalendarReq;
+import kr.co.yeogiga.application.calendar.service.CalendarCommandService;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/trip")
+@RequiredArgsConstructor
+public class CalendarController {
+    private final CalendarCommandService calendarCommandService;
+
+    @PostMapping("/{tripId}/calendars")
+    public ResponseEntity<?> createCalendar(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long tripId,
+            @Valid @RequestBody CalendarReq calendarReq
+    ) {
+        calendarCommandService.create(userDetails.getUserId(), tripId, calendarReq);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+
+    @PutMapping("/{tripId}/calendars")
+    public ResponseEntity<?> updateAvailableDates(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long tripId,
+            @Valid @RequestBody CalendarReq calendarReq
+    ) {
+        calendarCommandService.updateAvailableDates(userDetails.getUserId(), tripId, calendarReq);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/calendar/controller/CalendarController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/calendar/controller/CalendarController.java
@@ -5,7 +5,9 @@ import kr.co.yeogiga.application.calendar.dto.CalendarReq;
 import kr.co.yeogiga.application.calendar.service.CalendarCommandService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.presentation.calendar.api.CalendarApi;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,9 +20,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/trip")
 @RequiredArgsConstructor
-public class CalendarController {
+public class CalendarController implements CalendarApi {
     private final CalendarCommandService calendarCommandService;
 
+    @Override
     @PostMapping("/{tripId}/calendars")
     public ResponseEntity<?> createCalendar(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -28,9 +31,10 @@ public class CalendarController {
             @Valid @RequestBody CalendarReq calendarReq
     ) {
         calendarCommandService.create(userDetails.getUserId(), tripId, calendarReq);
-        return ResponseEntity.ok(SuccessResponse.ok());
+        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
     }
 
+    @Override
     @PutMapping("/{tripId}/calendars")
     public ResponseEntity<?> updateAvailableDates(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/test/java/kr/co/yeogiga/application/calendar/service/CalendarCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/calendar/service/CalendarCommandServiceTest.java
@@ -1,0 +1,136 @@
+package kr.co.yeogiga.application.calendar.service;
+
+import kr.co.yeogiga.application.calendar.dto.CalendarReq;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.calendar.entity.Calendar;
+import kr.co.yeogiga.domain.calendar.service.CalendarService;
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.trip.service.TripService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class CalendarCommandServiceTest {
+
+    @Mock
+    private CalendarService calendarService;
+
+    @Mock
+    private TripService tripService;
+
+    @InjectMocks
+    private CalendarCommandService calendarCommandService;
+
+    private final Long userId = 1L;
+    private final Long tripId = 10L;
+
+    @Nested
+    @DisplayName("W2M 생성 테스트")
+    class CreateCalendar {
+
+        @Test
+        @DisplayName("성공")
+        void Success() {
+            // given
+            CalendarReq request = new CalendarReq(List.of(LocalDate.of(2025, 7, 1)));
+            Trip trip = mock(Trip.class);
+
+            given(calendarService.existsByUserIdAndTripId(userId, tripId)).willReturn(false);
+            given(tripService.readById(tripId)).willReturn(Optional.of(trip));
+
+            // when
+            calendarCommandService.create(userId, tripId, request);
+
+            // then
+            verify(calendarService, times(1)).save(any());
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 등록된 Calendar 존재")
+        void AlreadyExists() {
+            // given
+            CalendarReq request = new CalendarReq(List.of(LocalDate.of(2025, 7, 1)));
+
+            given(calendarService.existsByUserIdAndTripId(userId, tripId)).willReturn(true);
+
+            // when
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> calendarCommandService.create(userId, tripId, request));
+
+            // then
+            assertEquals(TripErrorType.CALENDAR_ALREADY_EXISTS, exception.getErrorType());
+        }
+
+        @Test
+        @DisplayName("실패 - Trip이 존재하지 않음")
+        void TripNotFound() {
+            // given
+            CalendarReq request = new CalendarReq(List.of(LocalDate.of(2025, 7, 1)));
+
+            given(calendarService.existsByUserIdAndTripId(userId, tripId)).willReturn(false);
+            given(tripService.readById(tripId)).willReturn(Optional.empty());
+
+            // when
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> calendarCommandService.create(userId, tripId, request));
+
+            // then
+            assertEquals(TripErrorType.TRIP_NOT_FOUND, exception.getErrorType());
+        }
+    }
+
+    @Nested
+    @DisplayName("W2M 수정 테스트")
+    class UpdateAvailableDates {
+
+        @Test
+        @DisplayName("성공")
+        void Success() {
+            // given
+            CalendarReq request = new CalendarReq(List.of(LocalDate.of(2025, 7, 2)));
+            Calendar calendar = mock(Calendar.class);
+
+            given(calendarService.readByUserIdAndTripId(userId, tripId)).willReturn(Optional.of(calendar));
+
+            // when
+            calendarCommandService.updateAvailableDates(userId, tripId, request);
+
+            // then
+            verify(calendar, times(1)).updateAvailableDates(request.availableDates());
+        }
+
+        @Test
+        @DisplayName("실패 - 수정 대상 Calendar 없음")
+        void NotFoundCalendar() {
+            // given
+            CalendarReq request = new CalendarReq(List.of(LocalDate.of(2025, 7, 2)));
+
+            given(calendarService.readByUserIdAndTripId(userId, tripId)).willReturn(Optional.empty());
+
+            // when
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> calendarCommandService.updateAvailableDates(userId, tripId, request));
+
+            // then
+            assertEquals(TripErrorType.CALENDAR_NOT_FOUND, exception.getErrorType());
+        }
+    }
+}

--- a/src/test/java/kr/co/yeogiga/application/calendar/service/CalendarCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/calendar/service/CalendarCommandServiceTest.java
@@ -48,7 +48,7 @@ public class CalendarCommandServiceTest {
 
         @Test
         @DisplayName("성공")
-        void Success() {
+        void success() {
             // given
             CalendarReq request = new CalendarReq(List.of(LocalDate.of(2025, 7, 1)));
             Trip trip = mock(Trip.class);
@@ -65,7 +65,7 @@ public class CalendarCommandServiceTest {
 
         @Test
         @DisplayName("실패 - 이미 등록된 Calendar 존재")
-        void AlreadyExists() {
+        void alreadyExists() {
             // given
             CalendarReq request = new CalendarReq(List.of(LocalDate.of(2025, 7, 1)));
 
@@ -81,7 +81,7 @@ public class CalendarCommandServiceTest {
 
         @Test
         @DisplayName("실패 - Trip이 존재하지 않음")
-        void TripNotFound() {
+        void tripNotFound() {
             // given
             CalendarReq request = new CalendarReq(List.of(LocalDate.of(2025, 7, 1)));
 
@@ -103,7 +103,7 @@ public class CalendarCommandServiceTest {
 
         @Test
         @DisplayName("성공")
-        void Success() {
+        void success() {
             // given
             CalendarReq request = new CalendarReq(List.of(LocalDate.of(2025, 7, 2)));
             Calendar calendar = mock(Calendar.class);
@@ -119,7 +119,7 @@ public class CalendarCommandServiceTest {
 
         @Test
         @DisplayName("실패 - 수정 대상 Calendar 없음")
-        void NotFoundCalendar() {
+        void notFoundCalendar() {
             // given
             CalendarReq request = new CalendarReq(List.of(LocalDate.of(2025, 7, 2)));
 

--- a/src/test/java/kr/co/yeogiga/presentation/calendar/controller/CalendarControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/calendar/controller/CalendarControllerTest.java
@@ -105,8 +105,8 @@ public class CalendarControllerTest {
             // then
             resultActions
                     .andDo(print())
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.created().message()));
         }
 
         @Test

--- a/src/test/java/kr/co/yeogiga/presentation/calendar/controller/CalendarControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/calendar/controller/CalendarControllerTest.java
@@ -1,0 +1,179 @@
+package kr.co.yeogiga.presentation.calendar.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.application.calendar.dto.CalendarReq;
+import kr.co.yeogiga.application.calendar.service.CalendarCommandService;
+import kr.co.yeogiga.common.response.error.type.CommonErrorType;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
+import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.type.Role;
+import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = CalendarController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                SecurityConfig.class, JwtAuthenticationFilter.class
+        })
+)
+public class CalendarControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private CalendarCommandService calendarCommandService;
+
+    private CustomUserDetails userDetails;
+
+    private final Long tripId = 1L;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .defaultRequest(post("/**").with(csrf()))
+                .defaultRequest(put("/**").with(csrf()))
+                .build();
+
+        setUpUserDetails();
+    }
+
+    void setUpUserDetails() {
+        User user = User.builder()
+                .username("testuser")
+                .password("pass")
+                .email("test@example.com")
+                .nickname("nickname")
+                .role(Role.USER)
+                .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+        userDetails = new CustomUserDetailsImpl(user);
+    }
+
+    @Nested
+    @DisplayName("W2M 생성 테스트")
+    class CreateCalendar {
+
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            CalendarReq request = new CalendarReq(List.of(LocalDate.of(2025, 7, 1)));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/trip/{tripId}/calendars", tripId)
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsBytes(request))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
+
+        @Test
+        @DisplayName("실패 - 유효성 검증 (빈 날짜 리스트)")
+        void failValidation() throws Exception {
+            // given
+            CalendarReq request = new CalendarReq(List.of());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/trip/{tripId}/calendars", tripId)
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsBytes(request))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(CommonErrorType.VALIDATION_ERROR.getCode()))
+                    .andExpect(jsonPath("$.errors").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("W2M 수정 테스트")
+    class UpdateCalendar {
+
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            CalendarReq request = new CalendarReq(List.of(LocalDate.of(2025, 7, 2)));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    put("/api/v1/trip/{tripId}/calendars", tripId)
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsBytes(request))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
+
+        @Test
+        @DisplayName("실패 - 유효성 검증 (날짜 없음)")
+        void failValidation() throws Exception {
+            // given
+            CalendarReq request = new CalendarReq(List.of()); // 빈 리스트
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    put("/api/v1/trip/{tripId}/calendars", tripId)
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsBytes(request))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(CommonErrorType.VALIDATION_ERROR.getCode()))
+                    .andExpect(jsonPath("$.errors").exists());
+        }
+    }
+}


### PR DESCRIPTION
## 배경
여행 멤버들의 가능한 일정을 잡기 위해 W2M 로직 필요.

## 작업 사항
- W2M을 위한 캘린더 Entity 생성 (645af1ce4b63c2ec7dc063717819caff9dcd6688)
    - List는 컨버터를 통해 등록
- W2M 쓰기 연산 로직 구현 (e7484d07c071df4f2462b5de8972040d0cb8d4ad)

## 추가 논의
`Calendar`에서 userId의 경우, 이전에 얘기 했듯이 외래키 제약조건을 걸지 않았습니다. (사용자가 삭제되더라도 여행 일정 표시 유지시키기 위함)