### PR TITLE
Fix: TripRoute에 여행 관계 매핑 추가

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/route/service/TripLeaderCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/route/service/TripLeaderCommandService.java
@@ -1,6 +1,8 @@
 package kr.co.yeogiga.application.route.service;
 
 import kr.co.yeogiga.application.route.dto.RouteReq;
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.service.TripService;
 import kr.co.yeogiga.domain.triproute.entity.Route;
 import kr.co.yeogiga.domain.triproute.entity.TripRoute;
 import kr.co.yeogiga.domain.triproute.service.TripRouteService;
@@ -12,13 +14,18 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class TripLeaderCommandService {
     private final RedisRepository redisRepository;
     private final TripRouteService tripRouteService;
+    private final TripService tripService;
 
     // (위도/경도) 비교 시 같은 위치로 간주할 오차 범위 (약 10~14m 정도)
     private static final double LOCATION_THRESHOLD = 0.0001;
@@ -73,10 +80,18 @@ public class TripLeaderCommandService {
     public void persistAllTripRoutes() {
         Set<String> keys = redisRepository.getKeysByPattern(RouteConstant.TRIP_ROUTE_KEY_PATTERN);
 
+        Set<Long> tripIds = keys.stream()
+                .map(this::extractTripIdFromKey)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        Map<Long, Trip> tripMap = tripService.readAllByIds(tripIds).stream()
+                .collect(Collectors.toMap(Trip::getId, Function.identity()));
+
         List<TripRoute> tripRoutes = new ArrayList<>();
 
         for (String key : keys) {
-            TripRoute tripRoute = convertKeyToTripRoute(key);
+            TripRoute tripRoute = convertKeyToTripRoute(key, tripMap);
             if (tripRoute == null) continue;
 
             tripRoutes.add(tripRoute);
@@ -86,6 +101,11 @@ public class TripLeaderCommandService {
         redisRepository.deleteKeys(keys.stream().toList());
     }
 
+    private Long extractTripIdFromKey(String key) {
+        String[] parts = key.split(":");
+        return Long.parseLong(parts[2]);
+    }
+
     /**
      * Redis 키 문자열을 파싱하여 TripRoute 도메인 엔티티로 변환하는 메서드
      * - Redis에 저장된 StoredFormat 리스트를 Route 리스트로 매핑
@@ -93,7 +113,7 @@ public class TripLeaderCommandService {
      * @param key Redis에 저장된 경로 데이터 키
      * @return TripRoute 엔티티
      */
-    private TripRoute convertKeyToTripRoute(String key) {
+    private TripRoute convertKeyToTripRoute(String key, Map<Long, Trip> tripMap) {
         String[] parts = key.split(":");
         Long tripId = Long.parseLong(parts[2]);
         int day = Integer.parseInt(parts[3]);
@@ -112,10 +132,13 @@ public class TripLeaderCommandService {
                         .build())
                 .toList();
 
+        Trip trip = tripMap.get(tripId);
+        if (trip == null) return null;
+
         return TripRoute.builder()
-                .tripId(tripId)
                 .day(day)
                 .routes(routes)
+                .trip(trip)
                 .build();
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/TripRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/TripRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
 
 public interface TripRepository extends JpaRepository<Trip, Long> {
 
@@ -22,4 +24,5 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
             "WHERE travelStatus != 'COMPLETED' AND endedAt <= :time")
     void updateTravelStatusCompleted(@Param(value = "time") LocalDateTime time);
 
+    List<Trip> findAllByIdIn(Set<Long> ids);
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/TripService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/TripService.java
@@ -6,7 +6,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +21,10 @@ public class TripService {
 
     public Optional<Trip> readById(Long tripId) {
         return tripRepository.findById(tripId);
+    }
+
+    public List<Trip> readAllByIds(Set<Long> ids) {
+        return tripRepository.findAllByIdIn(ids);
     }
 
     public void updateAllTravelStatusToInProgress(LocalDateTime time) {

--- a/src/main/java/kr/co/yeogiga/domain/triproute/entity/TripRoute.java
+++ b/src/main/java/kr/co/yeogiga/domain/triproute/entity/TripRoute.java
@@ -3,9 +3,13 @@ package kr.co.yeogiga.domain.triproute.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.triproute.converter.RouteListConverter;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -22,19 +26,20 @@ public class TripRoute {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "trip_id")
-    private Long tripId;
-
     private int day;
 
     @Column(columnDefinition = "TEXT")
     @Convert(converter = RouteListConverter.class)
     private List<Route> routes;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id")
+    private Trip trip;
+
     @Builder
-    public TripRoute(Long tripId, int day, List<Route> routes) {
-        this.tripId = tripId;
+    public TripRoute(int day, List<Route> routes, Trip trip) {
         this.day = day;
         this.routes = routes;
+        this.trip = trip;
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/triproute/repository/CustomTripRouteRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/triproute/repository/CustomTripRouteRepositoryImpl.java
@@ -25,7 +25,7 @@ public class CustomTripRouteRepositoryImpl implements CustomTripRouteRepository 
                 tripRoutes,
                 BATCH_SIZE,
                 (PreparedStatement ps, TripRoute tripRoute) -> {
-                    ps.setLong(1, tripRoute.getTripId());
+                    ps.setLong(1, tripRoute.getTrip().getId());
                     ps.setInt(2, tripRoute.getDay());
                     ps.setString(3, routeListConverter.convertToDatabaseColumn(tripRoute.getRoutes()));
                 });

--- a/src/test/java/kr/co/yeogiga/application/route/service/TripRouteQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/route/service/TripRouteQueryServiceTest.java
@@ -35,13 +35,11 @@ public class TripRouteQueryServiceTest {
         Route route2 = Route.builder().latitude(2.2).longitude(3.3).build();
 
         TripRoute tripRoute1 = TripRoute.builder()
-                .tripId(tripId)
                 .day(1)
                 .routes(List.of(route1))
                 .build();
 
         TripRoute tripRoute2 = TripRoute.builder()
-                .tripId(tripId)
                 .day(2)
                 .routes(List.of(route2))
                 .build();


### PR DESCRIPTION
## 배경
여행 루트는 여행이 삭제되었을 때, 삭제되어야 하는 정보이므로 관계를 매핑해주어 처리해야함.

## 작업 사항
- TripRoute에서 tripId 필드 외래키 제약조건 추가 (210b5727a9179bef6deb1bd288fd858118df5510)
- TripRoute batch insert 과정 값 수정 (601464b4e065cd94d6ce5feae4388384d9227c11)
- 여행 루트 저장 과정 중, Trip 삽입 (d0bb44f4b92d99610db856dc2e0127cc9b163cec)

## 추가 논의
x