### PR TITLE
Feature(IL-125): 목적지 방문 여부 로직 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceRes.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceRes.java
@@ -24,10 +24,11 @@ public class TripPlaceRes {
     public record PlaceSummary(
             String id,
             String name,
-            String placeType
+            String placeType,
+            boolean isVisited
     ) {
         public static PlaceSummary from(Place place) {
-            return new PlaceSummary(place.getId(), place.getName(), place.getPlaceType());
+            return new PlaceSummary(place.getId(), place.getName(), place.getPlaceType(), place.isVisited());
         }
     }
 
@@ -36,11 +37,12 @@ public class TripPlaceRes {
             String name,
             double latitude,
             double longitude,
-            String placeType
+            String placeType,
+            boolean isVisited
     ) {
         public static PlaceDetails from(Place place) {
             return new PlaceDetails(place.getId(), place.getName(), place.getLatitude(),
-                    place.getLongitude(), place.getPlaceType());
+                    place.getLongitude(), place.getPlaceType(), place.isVisited());
         }
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/tripplace/dto/VisitedMarkReq.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/dto/VisitedMarkReq.java
@@ -1,6 +1,10 @@
 package kr.co.yeogiga.application.tripplace.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "VisitedMarkReq", description = "목적지 방문 여부 체크 DTO")
 public record VisitedMarkReq(
+        @Schema(description = "목적지 방문 변경 상태", example = "true")
         boolean isVisited
 ) {
 }

--- a/src/main/java/kr/co/yeogiga/application/tripplace/dto/VisitedMarkReq.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/dto/VisitedMarkReq.java
@@ -1,0 +1,6 @@
+package kr.co.yeogiga.application.tripplace.dto;
+
+public record VisitedMarkReq(
+        boolean isVisited
+) {
+}

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandService.java
@@ -125,6 +125,17 @@ public class TripPlaceCommandService {
     }
 
     /**
+     * 특정 목적지의 방문 여부를 업데이트하는 메서드
+     *
+     * @param tripPlaceId 여행 일차 ID
+     * @param placeId     목적지 ID
+     * @param isVisited   변경할 상태
+     */
+    public void markPlaceAsVisited(String tripPlaceId, String placeId, boolean isVisited) {
+        tripDayPlaceService.updatePlaceVisited(tripPlaceId, placeId, isVisited);
+    }
+
+    /**
      * 여행 일차(TripDayPlace)에서 특정 목적지를 삭제하는 메서드
      *
      * @param tripPlaceId 여행 일차 ID

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandService.java
@@ -127,21 +127,21 @@ public class TripPlaceCommandService {
     /**
      * 특정 목적지의 방문 여부를 업데이트하는 메서드
      *
-     * @param tripPlaceId 여행 일차 ID
-     * @param placeId     목적지 ID
-     * @param isVisited   변경할 상태
+     * @param tripDayPlaceId 여행 일차 ID
+     * @param placeId        목적지 ID
+     * @param isVisited      변경할 상태
      */
-    public void markPlaceAsVisited(String tripPlaceId, String placeId, boolean isVisited) {
-        tripDayPlaceService.updatePlaceVisited(tripPlaceId, placeId, isVisited);
+    public void markPlaceAsVisited(String tripDayPlaceId, String placeId, boolean isVisited) {
+        tripDayPlaceService.updatePlaceVisited(tripDayPlaceId, placeId, isVisited);
     }
 
     /**
      * 여행 일차(TripDayPlace)에서 특정 목적지를 삭제하는 메서드
      *
-     * @param tripPlaceId 여행 일차 ID
-     * @param placeId     삭제할 목적지 ID
+     * @param tripDayPlaceId 여행 일차 ID
+     * @param placeId        삭제할 목적지 ID
      */
-    public void deletePlace(String tripPlaceId, String placeId) {
-        tripDayPlaceService.deletePlace(tripPlaceId, placeId);
+    public void deletePlace(String tripDayPlaceId, String placeId) {
+        tripDayPlaceService.deletePlace(tripDayPlaceId, placeId);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
@@ -17,6 +17,7 @@ public class Place {
     private String placeType;
     private Double order;
     private List<Image> images;
+    private boolean isVisited;
 
     @Builder
     public Place(String id, String name, Double latitude,
@@ -28,6 +29,7 @@ public class Place {
         this.placeType = placeType;
         this.order = order;
         this.images = new ArrayList<>();
+        this.isVisited = false;
     }
 
     public void updateOrder(double order) {

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
@@ -17,6 +17,7 @@ public interface CustomTripDayPlaceRepository {
     Optional<Place> findPlaceByIdAndPlaceId(String id, String placeId);
     List<Image> findUnmatchedImagesById(String id);
     List<TripDayPlace> findTripDayPlaceSummariesByTripId(Long tripId);
+    void updatePlaceVisited(String id, String placeId, boolean isVisited);
     void deletePlace(String id, String placeId);
     void deleteImage(String id, String placeId, String imageId);
     void deleteImageFromUnMatched(String id, String imageId);

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
@@ -187,6 +187,16 @@ public class CustomTripDayPlaceRepositoryImpl implements CustomTripDayPlaceRepos
     }
 
     @Override
+    public void updatePlaceVisited(String id, String placeId, boolean isVisited) {
+        Query query = Query.query(
+                Criteria.where("_id").is(id)
+                        .and("places.id").is(placeId)
+        );
+        Update update = new Update().set("places.$.isVisited", isVisited);
+        mongoTemplate.updateFirst(query, update, TripDayPlace.class);
+    }
+
+    @Override
     public void deletePlace(String id, String placeId) {
         Query query = new Query(Criteria.where("_id").is(id));
         Update update = new Update().pull("places", Query.query(Criteria.where("id").is(placeId)));

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
@@ -66,8 +66,20 @@ public class CustomTripDayPlaceRepositoryImpl implements CustomTripDayPlaceRepos
     public Optional<TripDayPlace> findByIdSorted(String id) {
         Aggregation aggregation = Aggregation.newAggregation(
                 Aggregation.match(Criteria.where("_id").is(id)),
+
                 Aggregation.unwind("places", true),
+
+                Aggregation.project("tripId", "day")
+                        .and("places.id").as("places.id")
+                        .and("places.name").as("places.name")
+                        .and("places.latitude").as("places.latitude")
+                        .and("places.longitude").as("places.longitude")
+                        .and("places.placeType").as("places.placeType")
+                        .and("places.order").as("places.order")
+                        .and("places.isVisited").as("places.isVisited"),
+
                 Aggregation.sort(Sort.by(Sort.Direction.ASC, "places.order")),
+
                 Aggregation.group("_id")
                         .first("tripId").as("tripId")
                         .first("day").as("day")
@@ -80,19 +92,30 @@ public class CustomTripDayPlaceRepositoryImpl implements CustomTripDayPlaceRepos
         return results.getMappedResults().stream().findFirst();
     }
 
-
     @Override
     public List<TripDayPlace> findByTripIdSorted(Long tripId) {
         Aggregation aggregation = Aggregation.newAggregation(
                 Aggregation.match(Criteria.where("tripId").is(tripId)),
+
                 Aggregation.unwind("places", true),
+
+                Aggregation.project("tripId", "day")
+                        .and("places.id").as("places.id")
+                        .and("places.name").as("places.name")
+                        .and("places.placeType").as("places.placeType")
+                        .and("places.order").as("places.order")
+                        .and("places.isVisited").as("places.isVisited"),
+
                 Aggregation.sort(Sort.by(Sort.Direction.ASC, "places.order")),
+
                 Aggregation.group("_id")
                         .first("tripId").as("tripId")
                         .first("day").as("day")
                         .push("places").as("places"),
+
                 Aggregation.sort(Sort.by(Sort.Direction.ASC, "day"))
         );
+
 
         AggregationResults<TripDayPlace> results =
                 mongoTemplate.aggregate(aggregation, "trip_day_place", TripDayPlace.class);

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
@@ -63,6 +63,10 @@ public class TripDayPlaceService {
         return tripDayPlaceRepository.findTripDayPlaceSummariesByTripId(tripId);
     }
 
+    public void updatePlaceVisited(String id, String placeId, boolean isVisited) {
+        tripDayPlaceRepository.updatePlaceVisited(id, placeId, isVisited);
+    }
+
     public void deletePlace(String id, String placeId) {
         tripDayPlaceRepository.deletePlace(id, placeId);
     }

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/api/TripPlaceApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/api/TripPlaceApi.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.VisitedMarkReq;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -80,12 +81,14 @@ public interface TripPlaceApi {
                                                             {
                                                                 "id": "place1-id",
                                                                 "name": "목적지1",
-                                                                "placeType": "식당"
+                                                                "placeType": "식당",
+                                                                "isVisited": true
                                                             },
                                                             {
                                                                 "id": "place2-id",
                                                                 "name": "목적지2",
-                                                                "placeType": "식당"
+                                                                "placeType": "식당",
+                                                                "isVisited": false
                                                             }
                                                         ]
                                                     },
@@ -96,12 +99,14 @@ public interface TripPlaceApi {
                                                             {
                                                                 "id": "place3-id",
                                                                 "name": "목적지3",
-                                                                "placeType": "식당"
+                                                                "placeType": "식당",
+                                                                "isVisited": false
                                                             },
                                                             {
                                                                 "id": "place4-id",
                                                                 "name": "목적지4",
-                                                                "placeType": "식당"
+                                                                "placeType": "식당",
+                                                                "isVisited": false
                                                             }
                                                         ]
                                                     }
@@ -130,14 +135,16 @@ public interface TripPlaceApi {
                                                         "name": "목적지1",
                                                         "latitude": 11.22,
                                                         "longitude": 33.44,
-                                                        "placeType": "식당"
+                                                        "placeType": "식당",
+                                                        "isVisited": true
                                                     },
                                                     {
                                                         "id": "place2-id",
                                                         "name": "목적지 2",
                                                         "latitude": 55.66,
                                                         "longitude": 77.88,
-                                                        "placeType": "식당"
+                                                        "placeType": "식당",
+                                                        "isVisited": false
                                                     }
                                                 ]
                                         }
@@ -245,6 +252,32 @@ public interface TripPlaceApi {
 
             @Parameter(description = "목적지 순서 변경을 위한 정보")
             @RequestBody TripPlaceReq.ReorderRequest reorderRequest
+    );
+
+    @TrackApi(description = "여행 목적지 방문 여부 체크 (여행 목적지 지정 확정 후)")
+    @Operation(summary = "여행 목적지 방문 여부 체크 (여행 목적지 지정 확정 후)", description = "여행 목적지 방문 여부 체크하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "여행 목적지 방문 여부 체크 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> markPlaceAsVisited(
+            @Parameter(description = "여행 ID")
+            @PathVariable Long tripId,
+
+            @Parameter(description = "여행 일차 ID")
+            @PathVariable String tripDayPlaceId,
+
+            @Parameter(description = "목적지  ID")
+            @PathVariable String placeId,
+
+            @RequestBody VisitedMarkReq visitedMarkReq
     );
 
     @TrackApi(description = "특정 일차 여행 목적지 삭제 (여행 목적지 지정 확정 후)")

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceController.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.presentation.tripplace.controller;
 
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.VisitedMarkReq;
 import kr.co.yeogiga.application.tripplace.service.TripPlaceCommandService;
 import kr.co.yeogiga.application.tripplace.service.TripPlaceQueryService;
 import kr.co.yeogiga.application.tripplace.service.TripPlaceSavingService;
@@ -11,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -77,6 +79,15 @@ public class TripPlaceController implements TripPlaceApi {
                                            @PathVariable String tripDayPlaceId,
                                            @RequestBody TripPlaceReq.ReorderRequest reorderRequest) {
         tripPlaceCommandService.reorderPlaces(tripDayPlaceId, reorderRequest);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+
+    @PatchMapping("/{tripId}/day-place/{tripDayPlaceId}/places/{placeId}/mark")
+    public ResponseEntity<?> markPlaceAsVisited(@PathVariable Long tripId,
+                                                @PathVariable String tripDayPlaceId,
+                                                @PathVariable String placeId,
+                                                @RequestBody VisitedMarkReq visitedMarkReq) {
+        tripPlaceCommandService.markPlaceAsVisited(tripDayPlaceId, placeId, visitedMarkReq.isVisited());
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceController.java
@@ -82,6 +82,7 @@ public class TripPlaceController implements TripPlaceApi {
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 
+    @Override
     @PatchMapping("/{tripId}/day-place/{tripDayPlaceId}/places/{placeId}/mark")
     public ResponseEntity<?> markPlaceAsVisited(@PathVariable Long tripId,
                                                 @PathVariable String tripDayPlaceId,

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandServiceTest.java
@@ -186,6 +186,20 @@ public class TripPlaceCommandServiceTest {
     }
 
     @Test
+    @DisplayName("목적지 방문 여부 변경 성공")
+    void markPlaceAsVisitedSuccess() {
+        // given
+        String placeId = "place-id";
+        boolean isVisited = true;
+
+        // when
+        tripPlaceCommandService.markPlaceAsVisited(tripDayPlaceId, placeId, isVisited);
+
+        // then
+        verify(tripDayPlaceService, times(1)).updatePlaceVisited(tripDayPlaceId, placeId, isVisited);
+    }
+
+    @Test
     @DisplayName("삭제 성공")
     void deletePlaceSuccess() {
         // given

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.tripplace.dto.TripDaySummaryRes;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
+import kr.co.yeogiga.application.tripplace.dto.VisitedMarkReq;
 import kr.co.yeogiga.application.tripplace.service.TripPlaceCommandService;
 import kr.co.yeogiga.application.tripplace.service.TripPlaceQueryService;
 import kr.co.yeogiga.application.tripplace.service.TripPlaceSavingService;
@@ -33,6 +34,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -146,7 +148,7 @@ public class TripPlaceControllerTest {
     void getPlaceDetailsInfoSuccess() throws Exception {
         // given
         TripPlaceRes.PlaceDetails details =
-                new TripPlaceRes.PlaceDetails("place1", "목적지1", 0.0, 0.0, "카페");
+                new TripPlaceRes.PlaceDetails("place1", "목적지1", 0.0, 0.0, "카페", true);
         given(tripPlaceQueryService.getPlaceDetailsInfo(tripDayPlaceId)).willReturn(List.of(details));
 
         // when
@@ -235,6 +237,26 @@ public class TripPlaceControllerTest {
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(TripErrorType.TRIP_PLACE_NOT_FOUND.getCode()))
                 .andExpect(jsonPath("$.message").value(TripErrorType.TRIP_PLACE_NOT_FOUND.getMessage()));
+    }
+
+    @Test
+    @DisplayName("목적지 방문 여부 수정 성공")
+    void markPlaceAsVisitedSuccess() throws Exception {
+        // given
+        VisitedMarkReq request = new VisitedMarkReq(true);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                patch("/api/v1/trip/{tripId}/day-place/{tripDayPlaceId}/places/{placeId}/mark", tripId, tripDayPlaceId, placeId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
     }
 
     @Test


### PR DESCRIPTION
## 배경
여행 중, 방문한 목적지에 대해 체크하기 위한 로직 구현
++ 여행일정 조회 시, 불필요한 데이터 (단순 조회의 경우 이미지 데이터 불필요) 제거 후 조회 추가

## 작업 사항
- 목적지에 방문여부 필드 추가 (059b19e2928902e7cee75008f862251ec4ca1f4c)
- 방문 여부 변경 로직 구현 (1053dae58ba21b2a886591e4137bcdfadf12e0da)
    - DB내 방문여부 업데이트 쿼리 작성 (96d289f05fd2e24b1ccc5e7b8440aad4b8bd4eaa)
- TripDayPlace 조회 중, 불필요한 필드 제거 후 조회 (37d77779c3268ecad3d896e7a4a08c0a53f2105a)

## 추가 논의
처음에는 전체 일정 목적지 조회만 방문여부를 체크하고자 하였지만, 일정에 대한 목적지 조회에도 추가하였습니다.