### PR TITLE
Feature(IL-126): 이미지 즐겨찾기 로직 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/FavoriteImageReq.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/FavoriteImageReq.java
@@ -2,8 +2,8 @@ package kr.co.yeogiga.application.tripplace.image.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "ImageFavoriteReq", description = "이미지 즐겨찾기 DTO")
-public record ImageFavoriteReq(
+@Schema(name = "FavoriteImageReq", description = "이미지 즐겨찾기 DTO")
+public record FavoriteImageReq(
         @Schema(description = "목적지 ID (unmatched 이미지이면 placeId를 보내지 말아주세요 - null로 인식 예정)", example = "place-id")
         String placeId,
         @Schema(description = "이미지 즐겨찾기 상태 변경 여부", example = "true")

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/FavoriteImageRes.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/FavoriteImageRes.java
@@ -1,0 +1,27 @@
+package kr.co.yeogiga.application.tripplace.image.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import kr.co.yeogiga.domain.tripplace.entity.Image;
+
+import java.time.LocalDateTime;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record FavoriteImageRes(
+        String id,
+        String url,
+        Double latitude,
+        Double longitude,
+        LocalDateTime date,
+        boolean favorite
+) {
+    public static FavoriteImageRes from(Image image) {
+        return new FavoriteImageRes(
+                image.getId(),
+                image.getUrl(),
+                image.getLatitude(),
+                image.getLongitude(),
+                image.getDate(),
+                image.isFavorite()
+        );
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/ImageFavoriteReq.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/ImageFavoriteReq.java
@@ -1,0 +1,7 @@
+package kr.co.yeogiga.application.tripplace.image.dto;
+
+public record ImageFavoriteReq(
+        String placeId,
+        boolean favorite
+) {
+}

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/ImageFavoriteReq.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/ImageFavoriteReq.java
@@ -1,7 +1,12 @@
 package kr.co.yeogiga.application.tripplace.image.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "ImageFavoriteReq", description = "이미지 즐겨찾기 DTO")
 public record ImageFavoriteReq(
+        @Schema(description = "목적지 ID (unmatched 이미지이면 placeId를 보내지 말아주세요 - null로 인식 예정)", example = "place-id")
         String placeId,
+        @Schema(description = "이미지 즐겨찾기 상태 변경 여부", example = "true")
         boolean favorite
 ) {
 }

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/TripPlaceImageRes.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/TripPlaceImageRes.java
@@ -54,7 +54,8 @@ public class TripPlaceImageRes {
             String url,
             Double latitude,
             Double longitude,
-            LocalDateTime date
+            LocalDateTime date,
+            boolean favorite
     ) {
         public static ImageDto from(Image image) {
             return new ImageDto(
@@ -62,7 +63,8 @@ public class TripPlaceImageRes {
                     image.getUrl(),
                     image.getLatitude(),
                     image.getLongitude(),
-                    image.getDate()
+                    image.getDate(),
+                    image.isFavorite()
             );
         }
     }

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageCommandService.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.application.tripplace.image.service;
 
 import kr.co.yeogiga.application.image.service.ImageDeleteProcessor;
+import kr.co.yeogiga.application.tripplace.image.dto.ImageFavoriteReq;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDeleteDto;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,17 @@ import java.util.List;
 public class TripPlaceImageCommandService {
     private final TripDayPlaceService tripDayPlaceService;
     private final ImageDeleteProcessor imageDeleteProcessor;
+
+    /**
+     * 특정 TripDayPlace 문서 내의 Place에 포함된 Image의 즐겨찾기(favorite) 상태 업데이트 메서드
+     *
+     * @param tripDayPlaceId 여행 ID
+     * @param imageId        이미지 ID
+     * @param favoriteReq    목적지 ID 및 즐겨찾기 상태
+     */
+    public void updateImageFavoriteStatus(String tripDayPlaceId, String imageId, ImageFavoriteReq favoriteReq) {
+        tripDayPlaceService.updateImageFavorite(tripDayPlaceId, favoriteReq.placeId(), imageId, favoriteReq.favorite());
+    }
 
     /**
      * 단일 이미지를 삭제 메서드

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageCommandService.java
@@ -9,11 +9,11 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 
 /**
- * TripDayPlace 내 이미지 삭제 기능을 담당하는 서비스 클래스
+ * TripDayPlace 내 이미지 쓰기 연산을 담당하는 서비스 클래스
  */
 @Service
 @RequiredArgsConstructor
-public class TripPlaceImageDeleteService {
+public class TripPlaceImageCommandService {
     private final TripDayPlaceService tripDayPlaceService;
     private final ImageDeleteProcessor imageDeleteProcessor;
 

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageCommandService.java
@@ -1,7 +1,7 @@
 package kr.co.yeogiga.application.tripplace.image.service;
 
 import kr.co.yeogiga.application.image.service.ImageDeleteProcessor;
-import kr.co.yeogiga.application.tripplace.image.dto.ImageFavoriteReq;
+import kr.co.yeogiga.application.tripplace.image.dto.FavoriteImageReq;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDeleteDto;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +25,7 @@ public class TripPlaceImageCommandService {
      * @param imageId        이미지 ID
      * @param favoriteReq    목적지 ID 및 즐겨찾기 상태
      */
-    public void updateImageFavoriteStatus(String tripDayPlaceId, String imageId, ImageFavoriteReq favoriteReq) {
+    public void updateImageFavoriteStatus(String tripDayPlaceId, String imageId, FavoriteImageReq favoriteReq) {
         tripDayPlaceService.updateImageFavorite(tripDayPlaceId, favoriteReq.placeId(), imageId, favoriteReq.favorite());
     }
 

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageQueryService.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.application.tripplace.image.service;
 
+import kr.co.yeogiga.application.tripplace.image.dto.FavoriteImageRes;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageRes;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
@@ -43,5 +44,18 @@ public class TripPlaceImageQueryService {
         List<Image> images = tripDayPlaceService.readUnmatchedImagesById(tripDayPlaceId);
 
         return TripPlaceImageRes.UnmatchedImageInfo.from(images);
+    }
+
+    /**
+     * TripDayPlace에서 즐겨찾기(favorite)로 표시된 이미지 목록 조회 메서드
+     * - 목적지에 매핑된 이미지 & 기타 이미지(unmatchedImages) 중 favorite == true 인 이미지만 포함
+     *
+     * @param tripDayPlaceId TripDayPlace(여행 일차) ID
+     * @return 즐겨찾기된 이미지 목록 (FavoriteImageRes DTO 리스트)
+     */
+    public List<FavoriteImageRes> getFavoriteImages(String tripDayPlaceId) {
+        return tripDayPlaceService.readFavoriteImages(tripDayPlaceId).stream()
+                .map(FavoriteImageRes::from)
+                .toList();
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Image.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Image.java
@@ -13,6 +13,7 @@ public class Image {
     private Double latitude;
     private Double longitude;
     private LocalDateTime date;
+    private boolean favorite;
 
     @Builder
     public Image(String url, Double latitude, Double longitude, LocalDateTime date) {
@@ -21,6 +22,7 @@ public class Image {
         this.latitude = latitude;
         this.longitude = longitude;
         this.date = date;
+        this.favorite = false;
     }
 
     public void updateGps(Double latitude, Double longitude) {

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
@@ -17,6 +17,7 @@ public interface CustomTripDayPlaceRepository {
     Optional<Place> findPlaceByIdAndPlaceId(String id, String placeId);
     List<Image> findUnmatchedImagesById(String id);
     List<TripDayPlace> findTripDayPlaceSummariesByTripId(Long tripId);
+    void updateImageFavorite(String id, String placeId, String imageId, boolean favorite);
     void deletePlace(String id, String placeId);
     void deleteImage(String id, String placeId, String imageId);
     void deleteImageFromUnMatched(String id, String imageId);

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
@@ -17,6 +17,7 @@ public interface CustomTripDayPlaceRepository {
     Optional<Place> findPlaceByIdAndPlaceId(String id, String placeId);
     List<Image> findUnmatchedImagesById(String id);
     List<TripDayPlace> findTripDayPlaceSummariesByTripId(Long tripId);
+    List<Image> findFavoriteImages(String id);
     void updateImageFavorite(String id, String placeId, String imageId, boolean favorite);
     void deletePlace(String id, String placeId);
     void deleteImage(String id, String placeId, String imageId);

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
@@ -187,6 +187,25 @@ public class CustomTripDayPlaceRepositoryImpl implements CustomTripDayPlaceRepos
     }
 
     @Override
+    public void updateImageFavorite(String id, String placeId, String imageId, boolean favorite) {
+        Query query = Query.query(Criteria.where("_id").is(id));
+        Update update;
+
+        if (placeId != null) {
+            update = new Update()
+                    .set("places.$[p].images.$[i].favorite", favorite)
+                    .filterArray(Criteria.where("p.id").is(placeId))
+                    .filterArray(Criteria.where("i._id").is(imageId));
+        } else {
+            update = new Update()
+                    .set("unmatchedImages.$[i].favorite", favorite)
+                    .filterArray(Criteria.where("i._id").is(imageId));
+        }
+
+        mongoTemplate.updateFirst(query, update, TripDayPlace.class);
+    }
+
+    @Override
     public void deletePlace(String id, String placeId) {
         Query query = new Query(Criteria.where("_id").is(id));
         Update update = new Update().pull("places", Query.query(Criteria.where("id").is(placeId)));

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
@@ -187,6 +187,50 @@ public class CustomTripDayPlaceRepositoryImpl implements CustomTripDayPlaceRepos
     }
 
     @Override
+    public List<Image> findFavoriteImages(String id) {
+        // 목적지에 매핑된 이미지 중 favorite == true
+        Aggregation placesImages = Aggregation.newAggregation(
+                Aggregation.match(Criteria.where("_id").is(id)),
+                Aggregation.unwind("places"),
+                Aggregation.unwind("places.images"),
+                Aggregation.match(Criteria.where("places.images.favorite").is(true)),
+                Aggregation.project()
+                        .and("places.images._id").as("_id")
+                        .and("places.images.url").as("url")
+                        .and("places.images.latitude").as("latitude")
+                        .and("places.images.longitude").as("longitude")
+                        .and("places.images.date").as("date")
+                        .and("places.images.favorite").as("favorite")
+        );
+
+        List<Image> favoriteFromPlaces = mongoTemplate
+                .aggregate(placesImages, "trip_day_place", Image.class)
+                .getMappedResults();
+
+        // 2. unmatchedImages 중 favorite == true
+        Aggregation unmatchedImages = Aggregation.newAggregation(
+                Aggregation.match(Criteria.where("_id").is(id)),
+                Aggregation.unwind("unmatchedImages"),
+                Aggregation.match(Criteria.where("unmatchedImages.favorite").is(true)),
+                Aggregation.project()
+                        .and("unmatchedImages._id").as("_id")
+                        .and("unmatchedImages.url").as("url")
+                        .and("unmatchedImages.latitude").as("latitude")
+                        .and("unmatchedImages.longitude").as("longitude")
+                        .and("unmatchedImages.date").as("date")
+                        .and("unmatchedImages.favorite").as("favorite")
+        );
+
+        List<Image> favoriteFromUnmatched = mongoTemplate
+                .aggregate(unmatchedImages, "trip_day_place", Image.class)
+                .getMappedResults();
+
+        return List.of(favoriteFromPlaces, favoriteFromUnmatched).stream()
+                .flatMap(List::stream)
+                .toList();
+    }
+
+    @Override
     public void updateImageFavorite(String id, String placeId, String imageId, boolean favorite) {
         Query query = Query.query(Criteria.where("_id").is(id));
         Update update;

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
@@ -269,6 +269,10 @@ public class CustomTripDayPlaceRepositoryImpl implements CustomTripDayPlaceRepos
                     .filterArray(Criteria.where("i._id").is(imageId));
         }
 
+        mongoTemplate.updateFirst(query, update, TripDayPlace.class);
+    }
+
+    @Override
     public void updatePlaceVisited(String id, String placeId, boolean isVisited) {
         Query query = Query.query(
                 Criteria.where("_id").is(id)

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
@@ -63,6 +63,10 @@ public class TripDayPlaceService {
         return tripDayPlaceRepository.findTripDayPlaceSummariesByTripId(tripId);
     }
 
+    public void updateImageFavorite(String id, String placeId, String imageId, boolean favorite) {
+        tripDayPlaceRepository.updateImageFavorite(id, placeId, imageId, favorite);
+    }
+
     public void deletePlace(String id, String placeId) {
         tripDayPlaceRepository.deletePlace(id, placeId);
     }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
@@ -69,6 +69,7 @@ public class TripDayPlaceService {
 
     public void updateImageFavorite(String id, String placeId, String imageId, boolean favorite) {
         tripDayPlaceRepository.updateImageFavorite(id, placeId, imageId, favorite);
+    }
       
     public void updatePlaceVisited(String id, String placeId, boolean isVisited) {
         tripDayPlaceRepository.updatePlaceVisited(id, placeId, isVisited);

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
@@ -63,6 +63,10 @@ public class TripDayPlaceService {
         return tripDayPlaceRepository.findTripDayPlaceSummariesByTripId(tripId);
     }
 
+    public List<Image> readFavoriteImages(String id) {
+        return tripDayPlaceRepository.findFavoriteImages(id);
+    }
+
     public void updateImageFavorite(String id, String placeId, String imageId, boolean favorite) {
         tripDayPlaceRepository.updateImageFavorite(id, placeId, imageId, favorite);
     }

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/api/TripPlaceImageApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/api/TripPlaceImageApi.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.yeogiga.application.tripplace.image.dto.ImageFavoriteReq;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDeleteDto;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageReq;
 import org.springframework.http.ResponseEntity;
@@ -40,14 +41,16 @@ public interface TripPlaceImageApi {
                                                          "url": "https://image1.com",
                                                          "latitude": 1.1,
                                                          "longitude": 2.2,
-                                                         "date": "2025-04-13T21:53:57.445"
+                                                         "date": "2025-04-13T21:53:57.445",
+                                                         "favorite": true
                                                      },
                                                      {
                                                          "id": "image2-id",
                                                          "url": "https://image2.com",
                                                          "latitude": 3.3,
                                                          "longitude": 4.4,
-                                                         "date": "2025-04-13T21:53:57.445"
+                                                         "date": "2025-04-13T21:53:57.445",
+                                                         "favorite": false
                                                      }
                                                 ]
                                             }
@@ -88,11 +91,13 @@ public interface TripPlaceImageApi {
                                                 "images": [
                                                      {
                                                          "id": "image1-id",
-                                                         "url": "https://image1.com"
+                                                         "url": "https://image1.com",
+                                                         "favorite": true
                                                      },
                                                      {
                                                          "id": "image2-id",
-                                                         "url": "https://image2.com"
+                                                         "url": "https://image2.com",
+                                                         "favorite": false
                                                      }
                                                 ]
                                             }
@@ -314,6 +319,33 @@ public interface TripPlaceImageApi {
 
             @Parameter(description = "여행 일차 ID")
             @PathVariable String tripDayPlaceId
+    );
+
+    @TrackApi(description = "이미지 즐겨찾기 선택")
+    @Operation(summary = "이미지 즐겨찾기 선택", description = "이미지 즐겨찾기 선택하는 API입니다." +
+            "<br/> 목적지에 매핑된 이미지의 경우 body에 placeId를 넣어주시고, 기타(unmatched)의 경우에는 placeId를 넣지 말아 주세요.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이미지 즐겨찾기 선택 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+    })
+    ResponseEntity<?> updateImageFavoriteStatus(
+            @Parameter(description = "여행 ID")
+            @PathVariable Long tripId,
+
+            @Parameter(description = "여행 일차 ID")
+            @PathVariable String tripDayPlaceId,
+
+            @Parameter(description = "이미지 ID")
+            @PathVariable String imageId,
+
+            @RequestBody ImageFavoriteReq imageFavoriteReq
     );
 
     @TrackApi(description = "매칭된 이미지에 대해 단일 삭제")

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/api/TripPlaceImageApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/api/TripPlaceImageApi.java
@@ -113,6 +113,46 @@ public interface TripPlaceImageApi {
             @PathVariable String tripDayPlaceId
     );
 
+    @TrackApi(description = "즐겨찾기한 이미지 조회")
+    @Operation(summary = "즐겨찾기한 이미지 조회", description = "즐겨찾기한 이미지 조회하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "즐겨찾기 이미지 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": {
+                                                "images": [
+                                                     {
+                                                         "id": "image1-id",
+                                                         "url": "https://image1.com",
+                                                         "latitude": 1.1,
+                                                         "longitude": 2.2,
+                                                         "date": "2025-04-13T21:53:57.445",
+                                                         "favorite": true
+                                                     },
+                                                     {
+                                                         "id": "image2-id",
+                                                         "url": "https://image2.com",
+                                                         "latitude": 3.3,
+                                                         "longitude": 4.4,
+                                                         "date": "2025-04-13T21:53:57.445",
+                                                         "favorite": false
+                                                     }
+                                                ]
+                                            }
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getFavoriteImages(
+            @Parameter(description = "여행 ID")
+            @PathVariable Long tripId,
+
+            @Parameter(description = "여행 일차 ID")
+            @PathVariable String tripDayPlaceId
+    );
 
     @TrackApi(description = "매칭된 이미지 이동 (같은 날짜에 대한 목적지 to 목적지)")
     @Operation(summary = "매칭된 이미지 이동 (같은 날짜에 대한 목적지 to 목적지)", description = "매칭된 이미지를 같은 날짜 목적지 to 목적지 이동하는 API입니다.")

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/api/TripPlaceImageApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/api/TripPlaceImageApi.java
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import kr.co.yeogiga.application.tripplace.image.dto.ImageFavoriteReq;
+import kr.co.yeogiga.application.tripplace.image.dto.FavoriteImageReq;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDeleteDto;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageReq;
 import org.springframework.http.ResponseEntity;
@@ -345,7 +345,7 @@ public interface TripPlaceImageApi {
             @Parameter(description = "이미지 ID")
             @PathVariable String imageId,
 
-            @RequestBody ImageFavoriteReq imageFavoriteReq
+            @RequestBody FavoriteImageReq favoriteImageReq
     );
 
     @TrackApi(description = "매칭된 이미지에 대해 단일 삭제")

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
@@ -2,7 +2,7 @@ package kr.co.yeogiga.presentation.tripplace.image.controller;
 
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDeleteDto;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageReq;
-import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageDeleteService;
+import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageCommandService;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageMovementService;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageQueryService;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageReassignmentService;
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class TripPlaceImageController implements TripPlaceImageApi {
     private final TripPlaceImageMovementService tripPlaceImageMovementService;
-    private final TripPlaceImageDeleteService tripPlaceImageDeleteService;
+    private final TripPlaceImageCommandService tripPlaceImageCommandService;
     private final TripPlaceImageQueryService tripPlaceImageQueryService;
     private final TripPlaceImageReassignmentService tripPlaceImageReassignmentService;
 
@@ -115,7 +115,7 @@ public class TripPlaceImageController implements TripPlaceImageApi {
             @PathVariable String imageId,
             @RequestBody TripPlaceImageDeleteDto.SingleDeleteReq deleteReq
     ) {
-        tripPlaceImageDeleteService.deleteSingleImage(tripDayPlaceId, imageId, deleteReq);
+        tripPlaceImageCommandService.deleteSingleImage(tripDayPlaceId, imageId, deleteReq);
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 
@@ -125,7 +125,7 @@ public class TripPlaceImageController implements TripPlaceImageApi {
             @PathVariable Long tripId,
             @RequestBody TripPlaceImageDeleteDto.MultiDeleteReq deleteReq
     ) {
-        tripPlaceImageDeleteService.deleteMultipleImages(tripId, deleteReq);
+        tripPlaceImageCommandService.deleteMultipleImages(tripId, deleteReq);
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.presentation.tripplace.image.controller;
 
-import kr.co.yeogiga.application.tripplace.image.dto.ImageFavoriteReq;
+import kr.co.yeogiga.application.tripplace.image.dto.FavoriteImageReq;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDeleteDto;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageReq;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageCommandService;
@@ -114,9 +114,9 @@ public class TripPlaceImageController implements TripPlaceImageApi {
             @PathVariable Long tripId,
             @PathVariable String tripDayPlaceId,
             @PathVariable String imageId,
-            @RequestBody ImageFavoriteReq imageFavoriteReq
+            @RequestBody FavoriteImageReq favoriteImageReq
     ) {
-        tripPlaceImageCommandService.updateImageFavoriteStatus(tripDayPlaceId, imageId, imageFavoriteReq);
+        tripPlaceImageCommandService.updateImageFavoriteStatus(tripDayPlaceId, imageId, favoriteImageReq);
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
@@ -108,6 +108,7 @@ public class TripPlaceImageController implements TripPlaceImageApi {
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 
+    @Override
     @PatchMapping("/{tripId}/day-place/{tripDayPlaceId}/images/{imageId}/favorite")
     public ResponseEntity<?> updateImageFavoriteStatus(
             @PathVariable Long tripId,

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
@@ -55,6 +55,7 @@ public class TripPlaceImageController implements TripPlaceImageApi {
         );
     }
 
+    @Override
     @GetMapping("/{tripId}/day-place/{tripDayPlaceId}/images/favorite")
     public ResponseEntity<?> getFavoriteImages(
             @PathVariable Long tripId,

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.presentation.tripplace.image.controller;
 
+import kr.co.yeogiga.application.tripplace.image.dto.ImageFavoriteReq;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDeleteDto;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageReq;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageCommandService;
@@ -104,6 +105,17 @@ public class TripPlaceImageController implements TripPlaceImageApi {
             @PathVariable String tripDayPlaceId
     ) {
         tripPlaceImageReassignmentService.reassignImagesToTripDayPlace(tripDayPlaceId);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+
+    @PatchMapping("/{tripId}/day-place/{tripDayPlaceId}/images/{imageId}/favorite")
+    public ResponseEntity<?> updateImageFavoriteStatus(
+            @PathVariable Long tripId,
+            @PathVariable String tripDayPlaceId,
+            @PathVariable String imageId,
+            @RequestBody ImageFavoriteReq imageFavoriteReq
+    ) {
+        tripPlaceImageCommandService.updateImageFavoriteStatus(tripDayPlaceId, imageId, imageFavoriteReq);
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
@@ -55,6 +55,18 @@ public class TripPlaceImageController implements TripPlaceImageApi {
         );
     }
 
+    @GetMapping("/{tripId}/day-place/{tripDayPlaceId}/images/favorite")
+    public ResponseEntity<?> getFavoriteImages(
+            @PathVariable Long tripId,
+            @PathVariable String tripDayPlaceId
+    ) {
+        return ResponseEntity.ok(
+                SuccessResponse.from(
+                        tripPlaceImageQueryService.getFavoriteImages(tripDayPlaceId)
+                )
+        );
+    }
+
     @Override
     @PatchMapping("/{tripId}/day-place/{tripDayPlaceId}/images/move")
     public ResponseEntity<?> moveImageToAnotherPlace(

--- a/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageCommandServiceTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class TripPlaceImageDeleteServiceTest {
+public class TripPlaceImageCommandServiceTest {
 
     @Mock
     private TripDayPlaceService tripDayPlaceService;
@@ -26,7 +26,7 @@ public class TripPlaceImageDeleteServiceTest {
     private ImageDeleteProcessor imageDeleteProcessor;
 
     @InjectMocks
-    private TripPlaceImageDeleteService tripPlaceImageDeleteService;
+    private TripPlaceImageCommandService tripPlaceImageCommandService;
 
     private final String tripDayPlaceId = "day-1";
     private final String placeId = "place-1";
@@ -46,7 +46,7 @@ public class TripPlaceImageDeleteServiceTest {
                     );
 
             // when
-            tripPlaceImageDeleteService.deleteSingleImage(tripDayPlaceId, imageId, req);
+            tripPlaceImageCommandService.deleteSingleImage(tripDayPlaceId, imageId, req);
 
             // then
             verify(tripDayPlaceService, times(1)).deleteImage(tripDayPlaceId, placeId, imageId);
@@ -63,7 +63,7 @@ public class TripPlaceImageDeleteServiceTest {
                     );
 
             // when
-            tripPlaceImageDeleteService.deleteSingleImage(tripDayPlaceId, imageId, req);
+            tripPlaceImageCommandService.deleteSingleImage(tripDayPlaceId, imageId, req);
 
             // then
             verify(tripDayPlaceService, times(1)).deleteImageFromUnMatched(tripDayPlaceId, imageId);
@@ -82,7 +82,7 @@ public class TripPlaceImageDeleteServiceTest {
                 new TripPlaceImageDeleteDto.MultiDeleteReq(imageIds, urls);
 
         // when
-        tripPlaceImageDeleteService.deleteMultipleImages(tripId, req);
+        tripPlaceImageCommandService.deleteMultipleImages(tripId, req);
 
         // then
         verify(tripDayPlaceService, times(1)).deleteImagesByTripId(tripId, imageIds);

--- a/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageCommandServiceTest.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.application.tripplace.image.service;
 
 import kr.co.yeogiga.application.image.service.ImageDeleteProcessor;
+import kr.co.yeogiga.application.tripplace.image.dto.ImageFavoriteReq;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDeleteDto;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import org.junit.jupiter.api.DisplayName;
@@ -31,6 +32,20 @@ public class TripPlaceImageCommandServiceTest {
     private final String tripDayPlaceId = "day-1";
     private final String placeId = "place-1";
     private final String imageId = "image-123";
+
+    @Test
+    @DisplayName("이미지 즐겨찾기 테스트")
+    void updateImageFavoriteStatusTest() {
+        // given
+        ImageFavoriteReq imageFavoriteReq = new ImageFavoriteReq(placeId, true);
+
+        // when
+        tripPlaceImageCommandService.updateImageFavoriteStatus(tripDayPlaceId, imageId, imageFavoriteReq);
+
+        // then
+        verify(tripDayPlaceService, times(1))
+                .updateImageFavorite(tripDayPlaceId, placeId, imageId, true);
+    }
 
     @Nested
     @DisplayName("단일 이미지 삭제 테스트")

--- a/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageCommandServiceTest.java
@@ -1,7 +1,7 @@
 package kr.co.yeogiga.application.tripplace.image.service;
 
 import kr.co.yeogiga.application.image.service.ImageDeleteProcessor;
-import kr.co.yeogiga.application.tripplace.image.dto.ImageFavoriteReq;
+import kr.co.yeogiga.application.tripplace.image.dto.FavoriteImageReq;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDeleteDto;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import org.junit.jupiter.api.DisplayName;
@@ -37,10 +37,10 @@ public class TripPlaceImageCommandServiceTest {
     @DisplayName("이미지 즐겨찾기 테스트")
     void updateImageFavoriteStatusTest() {
         // given
-        ImageFavoriteReq imageFavoriteReq = new ImageFavoriteReq(placeId, true);
+        FavoriteImageReq favoriteImageReq = new FavoriteImageReq(placeId, true);
 
         // when
-        tripPlaceImageCommandService.updateImageFavoriteStatus(tripDayPlaceId, imageId, imageFavoriteReq);
+        tripPlaceImageCommandService.updateImageFavoriteStatus(tripDayPlaceId, imageId, favoriteImageReq);
 
         // then
         verify(tripDayPlaceService, times(1))

--- a/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageQueryServiceTest.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.application.tripplace.image.service;
 
+import kr.co.yeogiga.application.tripplace.image.dto.FavoriteImageRes;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageRes;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
@@ -21,6 +22,7 @@ import java.util.Optional;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -101,5 +103,19 @@ public class TripPlaceImageQueryServiceTest {
         // then
         assertEquals(image.getUrl(), result.images().get(0).url());
         assertThat(result.images()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("특정 여행에서 즐겨찾기한 이미지 조회 테스트")
+    void getFavoriteImagesTest() {
+        // given
+        given(tripDayPlaceService.readFavoriteImages(tripDayPlaceId))
+                .willReturn(List.of(image));
+
+        // when
+        List<FavoriteImageRes> result = tripPlaceImageQueryService.getFavoriteImages(tripDayPlaceId);
+
+        // then
+        assertEquals(1, result.size());
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
@@ -1,7 +1,7 @@
 package kr.co.yeogiga.presentation.tripplace.image.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.co.yeogiga.application.tripplace.image.dto.ImageFavoriteReq;
+import kr.co.yeogiga.application.tripplace.image.dto.FavoriteImageReq;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDeleteDto;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageReq;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageRes;
@@ -329,7 +329,7 @@ public class TripPlaceImageControllerTest {
     void updateImageFavoriteStatusTest() throws Exception {
         // given
         String placeId = "place-id";
-        ImageFavoriteReq request = new ImageFavoriteReq(placeId, true);
+        FavoriteImageReq request = new FavoriteImageReq(placeId, true);
 
         // when
         ResultActions resultActions = mockMvc.perform(

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
@@ -373,6 +373,7 @@ public class TripPlaceImageControllerTest {
                         .content(objectMapper.writeValueAsString(request))
         );
 
+        // then
         resultActions
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
@@ -2,6 +2,7 @@ package kr.co.yeogiga.presentation.tripplace.image.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.tripplace.image.dto.FavoriteImageReq;
+import kr.co.yeogiga.application.tripplace.image.dto.FavoriteImageRes;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDeleteDto;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageReq;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageRes;
@@ -32,6 +33,8 @@ import org.springframework.web.context.WebApplicationContext;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
@@ -147,6 +150,38 @@ public class TripPlaceImageControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."))
                     .andExpect(jsonPath("$.data.images").isArray());
+        }
+
+        @Test
+        @DisplayName("즐겨찾기한 이미지 조회")
+        void getFavoriteImagesSuccess() throws Exception {
+            // given
+            FavoriteImageRes image1 = new FavoriteImageRes(
+                    "image1-id", "https://image1.com", 0.0, 1.1,
+                    LocalDateTime.now(), true
+            );
+
+            FavoriteImageRes image2 = new FavoriteImageRes(
+                    "image2-id", "https://image2.com", 2.2, 3.3,
+                    LocalDateTime.now(), true
+            );
+
+            given(tripPlaceImageQueryService.getFavoriteImages(tripDayPlaceId))
+                    .willReturn(List.of(image1, image2));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip/{tripId}/day-place/{tripDayPlaceId}/images/favorite", tripId, tripDayPlaceId)
+            );
+
+            // then
+            resultActions
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."))
+                    .andExpect(jsonPath("$.data", hasSize(2)))
+                    .andExpect(jsonPath("$.data[0].id").value("image1-id"))
+                    .andExpect(jsonPath("$.data[1].id").value("image2-id"));
         }
     }
 

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.presentation.tripplace.image.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.application.tripplace.image.dto.ImageFavoriteReq;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDeleteDto;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageReq;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageRes;
@@ -316,6 +317,27 @@ public class TripPlaceImageControllerTest {
         ResultActions resultActions = mockMvc.perform(
                 patch("/api/v1/trip/{tripId}/day-place/{tripDayPlaceId}/images/re-assign", tripId, tripDayPlaceId)
         );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
+    }
+
+    @Test
+    @DisplayName("이미지 즐겨찾기 테스트")
+    void updateImageFavoriteStatusTest() throws Exception {
+        // given
+        String placeId = "place-id";
+        ImageFavoriteReq request = new ImageFavoriteReq(placeId, true);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                patch("/api/v1/trip/{tripId}/day-place/{tripDayPlaceId}/images/{imageId}/favorite", tripId, tripDayPlaceId, imageId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
         resultActions
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageDeleteDto;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageReq;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageRes;
-import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageDeleteService;
+import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageCommandService;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageMovementService;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageQueryService;
 import kr.co.yeogiga.application.tripplace.image.service.TripPlaceImageReassignmentService;
@@ -59,7 +59,7 @@ public class TripPlaceImageControllerTest {
     private TripPlaceImageMovementService tripPlaceImageMovementService;
 
     @MockBean
-    private TripPlaceImageDeleteService tripPlaceImageDeleteService;
+    private TripPlaceImageCommandService tripPlaceImageCommandService;
 
     @MockBean
     private TripPlaceImageQueryService tripPlaceImageQueryService;


### PR DESCRIPTION
## 배경
이미지에 대해 즐겨찾기를 수행하고, 즐겨찾기한 이미지 조회하는 로직이 필요

## 작업 사항
- 이미지 즐겨찾기 필드 추가 (69b34a21f72e0f03042e435aace9084dbc6d9fbd)
- DB내 이미지 즐겨찾기 수정 로직 구현 (2edb91b6c296adaf032ae68136dd4bf96b10fb86)
- 이미지 즐겨찾기 로직 구현 (89db42b445ece1fcf2dc3f388a08941a4866f878)
    - 이미지 조회 시, 즐겨찾기 여부 추가 (442b23a32fbb03e42d52788b6843e9324dfbe7a2)
- 즐겨찾기한 이미지 조회 로직 구현 (83b275c04910cb824c796ef462b3bc18d3042a6c)
    - 목적지에 매핑한 이미지 속 즐겨찾기
    - 기타(ummatched)이미지 속 즐겨찾기
- 즐겨찾기한 이미지 조회 서비스 로직 구현 (177f9a315b099c6b00b3eb8cb744e2b29f582b95)

## 기타
즐겨찾기 이미지 조회 중, 몽고db 쿼리를 한번으로 처리할 수 없을까 찾아보았지만, 복잡하고 사용하기 어려움이 느껴져 각각 조회하여 합치는 형식으로 진행하였습니다.