### PR TITLE
Feature(IL-124): 사용자가 속한 여행 조회

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripRes.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripRes.java
@@ -1,0 +1,28 @@
+package kr.co.yeogiga.application.trip.dto;
+
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.type.TravelStatus;
+import lombok.Builder;
+import java.time.LocalDateTime;
+
+public class TripRes {
+
+    @Builder
+    public record TripSummary(
+            Long tripId,
+            String title,
+            LocalDateTime startedAt,
+            LocalDateTime endedAt,
+            TravelStatus status
+    ) {
+        public static TripSummary from(Trip trip) {
+            return TripSummary.builder()
+                    .tripId(trip.getId())
+                    .title(trip.getTitle())
+                    .startedAt(trip.getStartedAt())
+                    .endedAt(trip.getEndedAt())
+                    .status(trip.getTravelStatus())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
@@ -1,0 +1,33 @@
+package kr.co.yeogiga.application.trip.service;
+
+import kr.co.yeogiga.application.trip.dto.TripRes;
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.entity.TripMember;
+import kr.co.yeogiga.domain.trip.service.TripMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TripQueryService {
+    private final TripMemberService tripMemberService;
+
+    /**
+     * 사용자가 속한 여행 목록을 반환하는 메서드
+     * - 여행 시작 시간(staredAt) 기준 정렬, 아직 시간이 정해지지 않은 여행 맨 뒤에 위치
+     *
+     * @param userId        사용자 ID(pk)
+     * @return              사용자가 속한 여행 목록
+     */
+    public List<TripRes.TripSummary> getAllTrip(Long userId) {
+        return tripMemberService.readAllByUserId(userId).stream()
+                .map(TripMember::getTrip)
+                .sorted(Comparator.comparing(Trip::getStartedAt, Comparator.nullsLast(Comparator.naturalOrder())))
+                .map(TripRes.TripSummary::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
@@ -24,9 +24,7 @@ public class TripQueryService {
      * @return              사용자가 속한 여행 목록
      */
     public List<TripRes.TripSummary> getAllTrip(Long userId) {
-        return tripMemberService.readAllByUserId(userId).stream()
-                .map(TripMember::getTrip)
-                .sorted(Comparator.comparing(Trip::getStartedAt, Comparator.nullsLast(Comparator.naturalOrder())))
+        return tripMemberService.readAllTripByUserId(userId).stream()
                 .map(TripRes.TripSummary::from)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/TripMemberRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/TripMemberRepository.java
@@ -3,6 +3,10 @@ package kr.co.yeogiga.domain.trip.repository;
 import kr.co.yeogiga.domain.trip.entity.TripMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
     boolean existsByTripIdAndUserId(Long tripId, Long userId);
+
+    List<TripMember> findTripByUserId(Long userId);
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/TripMemberRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/TripMemberRepository.java
@@ -1,12 +1,15 @@
 package kr.co.yeogiga.domain.trip.repository;
 
+import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.entity.TripMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
     boolean existsByTripIdAndUserId(Long tripId, Long userId);
 
-    List<TripMember> findTripByUserId(Long userId);
+    @Query("SELECT tm.trip FROM trip_member tm WHERE tm.user.id = :userId ORDER BY tm.trip.startedAt ASC NULLS LAST")
+    List<Trip> findAllTripByUserId(Long userId);
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/TripMemberRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/TripMemberRepository.java
@@ -4,6 +4,7 @@ import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.entity.TripMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -11,5 +12,5 @@ public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
     boolean existsByTripIdAndUserId(Long tripId, Long userId);
 
     @Query("SELECT tm.trip FROM trip_member tm WHERE tm.user.id = :userId ORDER BY tm.trip.startedAt ASC NULLS LAST")
-    List<Trip> findAllTripByUserId(Long userId);
+    List<Trip> findAllTripByUserId(@Param(value = "userId") Long userId);
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.domain.trip.service;
 
+import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.entity.TripMember;
 import kr.co.yeogiga.domain.trip.repository.TripMemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +17,8 @@ public class TripMemberService {
         tripMemberRepository.save(tripMember);
     }
 
-    public List<TripMember> readAllByUserId(Long userId) {
-        return tripMemberRepository.findTripByUserId(userId);
+    public List<Trip> readAllTripByUserId(Long userId) {
+        return tripMemberRepository.findAllTripByUserId(userId);
     }
 
     public boolean existsByTripIdAndUserId(Long tripId, Long userId) {

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
@@ -5,6 +5,8 @@ import kr.co.yeogiga.domain.trip.repository.TripMemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class TripMemberService {
@@ -12,6 +14,10 @@ public class TripMemberService {
 
     public void save(TripMember tripMember) {
         tripMemberRepository.save(tripMember);
+    }
+
+    public List<TripMember> readAllByUserId(Long userId) {
+        return tripMemberRepository.findTripByUserId(userId);
     }
 
     public boolean existsByTripIdAndUserId(Long tripId, Long userId) {

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
@@ -21,6 +21,51 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "[여행 API]", description = "여행 관련 API")
 public interface TripApi {
 
+    @TrackApi(description = "사용자가 속한 여행 조회")
+    @Operation(summary = "사용자가 속한 여행 조회", description = "사용자가 속한 여행 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사용자가 속한 여행 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "조회 성공", value = """
+                                             {
+                                                 "code": 200,
+                                                 "message": "요청이 성공하였습니다.",
+                                                 "data": [
+                                                     {
+                                                         "tripId": 2,
+                                                         "title": "여행2",
+                                                         "startedAt": "2025-05-10T12:00:00",
+                                                         "endedAt": "2025-05-20T12:01:00",
+                                                         "status": "IN_PROGRESS"
+                                                     },
+                                                     {
+                                                         "tripId": 1,
+                                                         "title": "여행1",
+                                                         "startedAt": "2025-05-23T12:00:00",
+                                                         "endedAt": "2025-05-26T12:01:00",
+                                                         "status": "PLANNED"
+                                                     },
+                                                     {
+                                                         "tripId": 3,
+                                                         "title": "여행3",
+                                                         "startedAt": null,
+                                                         "endedAt": null,
+                                                         "status": "PLANNED"
+                                                     }
+                                                 ]
+                                             }
+                                    """),
+                            @ExampleObject(name = "조회 성공 - 속한 여행 없는 경우 빈 배열 반환", value = """
+                                             {
+                                                 "code": 200,
+                                                 "message": "요청이 성공하였습니다.",
+                                                 "data": []
+                                             }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getAllTrip(@AuthenticationPrincipal CustomUserDetails userDetails);
+
     @TrackApi(description = "여행 생성")
     @Operation(summary = "여행 생성", description = "여행 생성 API")
     @ApiResponses({

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
@@ -2,7 +2,9 @@ package kr.co.yeogiga.presentation.trip.controller;
 
 import jakarta.validation.Valid;
 import kr.co.yeogiga.application.trip.dto.TripReq;
+import kr.co.yeogiga.application.trip.dto.TripRes;
 import kr.co.yeogiga.application.trip.service.TripCommandService;
+import kr.co.yeogiga.application.trip.service.TripQueryService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import kr.co.yeogiga.presentation.trip.api.TripApi;
@@ -10,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -17,11 +20,20 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/trip")
 @RequiredArgsConstructor
 public class TripController implements TripApi {
+    private final TripQueryService tripQueryService;
     private final TripCommandService tripCommandService;
+
+    @GetMapping
+    public ResponseEntity<?> getAllTrip(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<TripRes.TripSummary> tripList = tripQueryService.getAllTrip(userDetails.getUserId());
+        return ResponseEntity.ok().body(SuccessResponse.from(tripList));
+    }
 
     @Override
     @PostMapping

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
@@ -29,6 +29,7 @@ public class TripController implements TripApi {
     private final TripQueryService tripQueryService;
     private final TripCommandService tripCommandService;
 
+    @Override
     @GetMapping
     public ResponseEntity<?> getAllTrip(@AuthenticationPrincipal CustomUserDetails userDetails) {
         List<TripRes.TripSummary> tripList = tripQueryService.getAllTrip(userDetails.getUserId());

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
@@ -50,16 +50,12 @@ public class TripQueryServiceTest {
                 .role(Role.USER)
                 .build();
 
-        private TripMember tripMember = TripMember.builder()
-                .trip(trip)
-                .user(user)
-                .build();
 
         @Test
         @DisplayName("성공")
         void success() {
             // given
-            when(tripMemberService.readAllByUserId(userId)).thenReturn(List.of(tripMember));
+            when(tripMemberService.readAllTripByUserId(userId)).thenReturn(List.of(trip));
 
             // when
             List<TripRes.TripSummary> result = tripQueryService.getAllTrip(userId);
@@ -72,7 +68,7 @@ public class TripQueryServiceTest {
         @DisplayName("성공 - 빈 배열 반환")
         void successEmptyList() {
             // given
-            when(tripMemberService.readAllByUserId(userId)).thenReturn(List.of());
+            when(tripMemberService.readAllTripByUserId(userId)).thenReturn(List.of());
 
             // when
             List<TripRes.TripSummary> result = tripQueryService.getAllTrip(userId);

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
@@ -1,0 +1,86 @@
+package kr.co.yeogiga.application.trip.service;
+
+import kr.co.yeogiga.application.trip.dto.TripRes;
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.entity.TripMember;
+import kr.co.yeogiga.domain.trip.service.TripMemberService;
+import kr.co.yeogiga.domain.trip.type.TravelStatus;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.type.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+public class TripQueryServiceTest {
+
+    @Mock
+    private TripMemberService tripMemberService;
+
+    @InjectMocks
+    private TripQueryService tripQueryService;
+
+    @Nested
+    @DisplayName("전체 여행 목록 조회")
+    class GetAllTrip {
+        private final Long userId = 1L;
+
+        private Trip trip = Trip.builder()
+                .title("title")
+                .city("대구광역시")
+                .leaderId(userId)
+                .travelStatus(TravelStatus.PLANNED)
+                .build();
+
+        private User user = User.builder()
+                .username("username")
+                .password("password")
+                .nickname("nickname")
+                .email("test@test.com")
+                .role(Role.USER)
+                .build();
+
+        private TripMember tripMember = TripMember.builder()
+                .trip(trip)
+                .user(user)
+                .build();
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            when(tripMemberService.readAllByUserId(userId)).thenReturn(List.of(tripMember));
+
+            // when
+            List<TripRes.TripSummary> result = tripQueryService.getAllTrip(userId);
+
+            // then
+            assertThat(result).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("성공 - 빈 배열 반환")
+        void successEmptyList() {
+            // given
+            when(tripMemberService.readAllByUserId(userId)).thenReturn(List.of());
+
+            // when
+            List<TripRes.TripSummary> result = tripQueryService.getAllTrip(userId);
+
+            // then
+            assertThat(result).hasSize(0);
+        }
+    }
+
+
+}

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
@@ -2,11 +2,14 @@ package kr.co.yeogiga.presentation.trip.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.trip.dto.TripReq;
+import kr.co.yeogiga.application.trip.dto.TripRes;
 import kr.co.yeogiga.application.trip.service.TripCommandService;
+import kr.co.yeogiga.application.trip.service.TripQueryService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.domain.trip.type.TravelStatus;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.type.Role;
 import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
@@ -27,10 +30,14 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -53,6 +60,9 @@ public class TripControllerTest {
 
     @MockBean
     private TripCommandService tripCommandService;
+
+    @MockBean
+    private TripQueryService tripQueryService;
 
     private CustomUserDetails userDetails;
 
@@ -208,6 +218,38 @@ public class TripControllerTest {
             resultActions
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.errors.end").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자가 속한 여행 조회")
+    class GetAllTrip {
+
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            TripRes.TripSummary tripSummary = TripRes.TripSummary.builder()
+                    .tripId(1L)
+                    .title("title")
+                    .startedAt(LocalDateTime.of(2025, 5, 19, 12, 0))
+                    .endedAt(LocalDateTime.of(2025, 5, 20, 12, 0))
+                    .status(TravelStatus.IN_PROGRESS)
+                    .build();
+
+            when(tripQueryService.getAllTrip(any())).thenReturn(List.of(tripSummary));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip")
+                    .with(user(userDetails))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()))
+                    .andExpect(jsonPath("$.data").isArray());
         }
     }
 }


### PR DESCRIPTION
## 배경
- 사용자가 속한 여행 조회 api 필요

## 작업 사항
- 사용자가 속한 여행 조회 로직 구현
    - 속한 여행이 없을 경우 빈 배열 `[]` 응답
    - 여행의 시작 날짜 `statred_at` 기준 정렬
        - 시간이 정해지지 않은 여행의 경우 배열의 맨 마지막으로 정렬

## 추가 논의
- 메인화면의 여행 목록이 전체 여행 목록인 줄 알았으나, 진행 중인 여행/진행 예정 여행/예정 없는 경우 등의 상황이 나뉘어 우선 전체 여행 조회 작업을 먼저 진행하는게 맞는 것 같아 사용자가 속한 모든 여행 조회 작업부터 진행하였습니다. 