### PR TITLE
Feature(IL-139): 특정 여행 조회

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripRes.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripRes.java
@@ -36,6 +36,7 @@ public class TripRes {
     public record TripSummary(
             Long tripId,
             String title,
+            String city,
             LocalDateTime startedAt,
             LocalDateTime endedAt,
             TravelStatus status,

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
@@ -130,7 +130,7 @@ public class TripQueryService {
      * 사용자가 속한 여행 목록을 반환하는 메서드
      * - 여행 시작 시간(staredAt) 기준 정렬, 아직 시간이 정해지지 않은 여행 맨 뒤에 위치
      *
-     * @param userId        사용자 ID(pk)
+     * @param userId        사용자 ID
      * @return              사용자가 속한 여행 목록
      */
     @Transactional(readOnly = true)

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
@@ -2,8 +2,11 @@ package kr.co.yeogiga.application.trip.service;
 
 import kr.co.yeogiga.application.trip.dto.TripRes;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
+import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.service.TripMemberService;
+import kr.co.yeogiga.domain.trip.service.TripService;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
@@ -18,11 +21,11 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class TripQueryService {
+    private final TripService tripService;
     private final TripMemberService tripMemberService;
     private final TripDayPlaceService tripDayPlaceService;
 
@@ -138,5 +141,21 @@ public class TripQueryService {
                     return TripRes.TripSummary.from(trip, members);
                 })
                 .toList();
+    }
+
+    /**
+     * 특정 여행 정보를 조회하는 메서드
+     *
+     * @param tripId        여행 ID
+     * @return              여행 정보
+     */
+    @Transactional(readOnly = true)
+    public TripRes.TripSummary getTrip(Long tripId) {
+        Trip trip = tripService.readById(tripId)
+                .orElseThrow(() -> new CustomException(TripErrorType.TRIP_NOT_FOUND));
+
+        List<User> members = tripMemberService.readAllUserByTripId(tripId);
+
+        return TripRes.TripSummary.from(trip, members);
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
@@ -163,6 +163,7 @@ public interface TripApi {
                                                       {
                                                           "tripId": 1,
                                                           "title": "여행2",
+                                                          "city": null,
                                                           "startedAt": null,
                                                           "endedAt": null,
                                                           "status": "PLANNED",
@@ -182,6 +183,7 @@ public interface TripApi {
                                                       {
                                                           "tripId": 2,
                                                           "title": "여행1",
+                                                          "city": null,
                                                           "startedAt": null,
                                                           "endedAt": null,
                                                           "status": "PLANNED",

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
@@ -103,6 +103,53 @@ public interface TripApi {
     ResponseEntity<?> getMainTrip(
             @AuthenticationPrincipal CustomUserDetails userDetails
     );
+
+    @TrackApi(description = "특정 여행 조회")
+    @Operation(summary = "특정 여행 조회", description = "특정 여행 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "특정 여행 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                             {
+                                                    "code": 200,
+                                                    "message": "요청이 성공하였습니다.",
+                                                    "data": {
+                                                        "tripId": 1,
+                                                        "title": "여행2",
+                                                        "city": null,
+                                                        "startedAt": "2025-05-15T12:00:00",
+                                                        "endedAt": "2025-05-21T12:01:00",
+                                                        "status": "COMPLETED",
+                                                        "members": [
+                                                            {
+                                                                "userId": 1,
+                                                                "nickname": "nick",
+                                                                "imageUrl": null
+                                                            },
+                                                            {
+                                                                "userId": 4,
+                                                                "nickname": "nick2",
+                                                                "imageUrl": null
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "특정 여행 조회 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "여행 미존재",value = """
+                                             {
+                                                     "code": "T006",
+                                                     "message": "해당 여행이 존재하지 않습니다."
+                                                 }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getTrip(
+            @Parameter(description = "여행 ID")
+            @PathVariable Long tripId);
+
     @TrackApi(description = "사용자가 속한 여행 조회")
     @Operation(summary = "사용자가 속한 여행 조회", description = "사용자가 속한 여행 조회 API")
     @ApiResponses({

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
@@ -40,6 +40,7 @@ public class TripController implements TripApi {
         return ResponseEntity.ok().body(SuccessResponse.from(tripMainInfo));
     }
 
+    @Override
     @GetMapping("/{tripId}")
     public ResponseEntity<?> getTrip(@PathVariable Long tripId) {
         return ResponseEntity.ok()

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
@@ -40,6 +40,12 @@ public class TripController implements TripApi {
         return ResponseEntity.ok().body(SuccessResponse.from(tripMainInfo));
     }
 
+    @GetMapping("/{tripId}")
+    public ResponseEntity<?> getTrip(@PathVariable Long tripId) {
+        return ResponseEntity.ok()
+                .body(SuccessResponse.from(tripQueryService.getTrip(tripId)));
+    }
+
     @Override
     @GetMapping
     public ResponseEntity<?> getAllTrip(@AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
@@ -1,16 +1,18 @@
 package kr.co.yeogiga.application.trip.service;
 
 import kr.co.yeogiga.application.trip.dto.TripRes;
+import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.service.TripMemberService;
+import kr.co.yeogiga.domain.trip.service.TripService;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
-import kr.co.yeogiga.domain.trip.entity.TripMember;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.type.Role;
-
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -31,12 +33,16 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class TripQueryServiceTest {
+
+    @Mock
+    private TripService tripService;
 
     @Mock
     private TripMemberService tripMemberService;
@@ -246,6 +252,61 @@ public class TripQueryServiceTest {
 
             // then
             assertThat(result).hasSize(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("특정 여행 조회")
+    class GetTrip {
+
+        private User user = User.builder()
+                .username("username")
+                .password("password")
+                .nickname("nickname")
+                .email("test@test.com")
+                .role(Role.USER)
+                .build();
+
+        private Trip trip = Trip.builder()
+                .title("title")
+                .city("대구광역시")
+                .leaderId(1L)
+                .travelStatus(TravelStatus.IN_PROGRESS)
+                .build();
+
+        @BeforeEach
+        void setUp() {
+            ReflectionTestUtils.setField(trip, "id", 1L);
+        }
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            when(tripService.readById(trip.getId())).thenReturn(Optional.of(trip));
+            when(tripMemberService.readAllUserByTripId(trip.getId())).thenReturn((List.of(user)));
+
+            // when
+            TripRes.TripSummary result = tripQueryService.getTrip(1L);
+
+            // then
+            assertEquals(trip.getId(), result.tripId());
+            assertEquals(trip.getTitle(), result.title());
+            assertThat(result.members()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 여행")
+        void failIfTripNotFound() {
+            // given
+            when(tripService.readById(trip.getId())).thenReturn(Optional.empty());
+
+            // when
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> tripQueryService.getTrip(1L));
+
+            // then
+            assertEquals(TripErrorType.TRIP_NOT_FOUND, exception.getErrorType());
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
@@ -12,6 +12,7 @@ import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
@@ -480,6 +481,66 @@ public class TripControllerTest {
                             .with(user(userDetails))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsBytes(updateRequest))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(TripErrorType.TRIP_NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.message").value(TripErrorType.TRIP_NOT_FOUND.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("특정 여행 조회")
+    class GetTrip {
+        private final Long tripId = 1L;
+
+        private Trip trip = Trip.builder()
+                .title("title")
+                .city("city")
+                .leaderId(1L)
+                .travelStatus(TravelStatus.IN_PROGRESS)
+                .build();
+
+        private User user = User.builder()
+                .username("username")
+                .password("password")
+                .nickname("nickname")
+                .email("test@test.com")
+                .role(Role.USER)
+                .build();
+
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            TripRes.TripSummary tripSummary = TripRes.TripSummary.from(trip, List.of(user));
+            when(tripQueryService.getTrip(tripId)).thenReturn(tripSummary);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip/{tripId}", tripId)
+                            .with(user(userDetails))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.title").value(trip.getTitle()))
+                    .andExpect(jsonPath("$.data.members[0].nickname").value(user.getNickname()));
+        }
+
+        @Test
+        @DisplayName("실패 - 여행 미존재")
+        void failIfTripNotFound() throws Exception {
+            // given
+            doThrow(new CustomException(TripErrorType.TRIP_NOT_FOUND)).when(tripQueryService).getTrip(tripId);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip/{tripId}", tripId)
+                            .with(user(userDetails))
             );
 
             // then


### PR DESCRIPTION
## 배경
- 특정 여행 조회 기능 필요

## 작업 사항
- 특정 여행 조회 로직 구현
- 전체 여행 조회 & 특정 여행 조회 dto 통합 → `TripRes.TripSummary`
    - 전체 여행 조회에도 `city` 값이 필요하다고 생각하여 두 dto 통합시켜 동일한 dto 사용하기로 하였습니다.
    - 이에 따른, 여행 전체 조회 rest api 스웨거 문서 변경 커밋도 포함되어 있습니다.