### PR TITLE
Fix: OAuth 로그인 시 사용자 엔티티 조회 에러 수정

### DIFF
--- a/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    @Query(value = "SELECT u.id, u.username, u.password, u.email, u.nickname, u.signed_up, u.role, u.deleted_at, u.created_at, u.modified_at " +
+    @Query(value = "SELECT u.id, u.username, u.password, u.email, u.nickname,  u.image_url, u.signed_up, u.role, u.deleted_at, u.created_at, u.modified_at " +
                    "FROM users u " +
                    "INNER JOIN oauth o ON u.id = o.user_id " +
                    "WHERE o.platform = :platform AND o.platform_id = :platformId", nativeQuery = true)


### PR DESCRIPTION
## 배경
- OAuth 로그인 시 사용자 엔티티 조회 시 SQL 에러 발생
    - `User` 엔티티 내 `imageUrl` 필드 추가 후, 사용자 조회 네이티브 쿼리 내 `image_url` 컬럼 미추가로 인한 에러

## 작업 사항
- 사용자 조회 쿼리 내 `image_url` 컬럼 추가