### PR TITLE
Fix: 트랜잭션 옵션 수정 및 여행 응답 DTO 변경

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripReq.java
@@ -17,11 +17,7 @@ public class TripReq {
             @Schema(description = "여행 제목", example = "여기가 여행")
             @NotBlank(message = "제목은 필수 입력값입니다.")
             @Size(max = 20, message = "제목은 최대 20글자까지 가능합니다.")
-            String title,
-
-            @Schema(description = "목적지 도시", example = "대구광역시")
-            @Size(max = 20, message = "여행 도시는 최대 20글자까지 가능합니다.")
-            String city
+            String title
     ) {
     }
 

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripRes.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripRes.java
@@ -37,6 +37,7 @@ public class TripRes {
             Long tripId,
             String title,
             String city,
+            Long leaderId,
             LocalDateTime startedAt,
             LocalDateTime endedAt,
             TravelStatus status,
@@ -46,6 +47,8 @@ public class TripRes {
             return TripSummary.builder()
                     .tripId(trip.getId())
                     .title(trip.getTitle())
+                    .city(trip.getCity())
+                    .leaderId(trip.getLeaderId())
                     .startedAt(trip.getStartedAt())
                     .endedAt(trip.getEndedAt())
                     .status(trip.getTravelStatus())

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
@@ -34,7 +34,6 @@ public class TripCommandService {
     public Long create(Long leaderId, TripReq.Creation creationRequest) {
         Trip trip = Trip.builder()
                 .title(creationRequest.title())
-                .city(creationRequest.city())
                 .leaderId(leaderId)
                 .travelStatus(TravelStatus.PLANNED)
                 .build();

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
@@ -38,7 +38,7 @@ public class TripQueryService {
      *                      - 여행 중: 진행 중인 여행과 그 일차의 목적지 정보
      *                      - 그 외: null
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public TripRes.TripMainInfo getTripMainInfo(Long userId) {
         List<Trip> tripList = tripMemberService.readAllTripByUserId(userId);
 

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
@@ -111,29 +111,40 @@ public interface TripApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                              {
-                                                    "code": 200,
-                                                    "message": "요청이 성공하였습니다.",
-                                                    "data": {
-                                                        "tripId": 1,
-                                                        "title": "여행2",
-                                                        "city": null,
-                                                        "startedAt": "2025-05-15T12:00:00",
-                                                        "endedAt": "2025-05-21T12:01:00",
-                                                        "status": "COMPLETED",
-                                                        "members": [
-                                                            {
-                                                                "userId": 1,
-                                                                "nickname": "nick",
-                                                                "imageUrl": null
-                                                            },
-                                                            {
-                                                                "userId": 4,
-                                                                "nickname": "nick2",
-                                                                "imageUrl": null
-                                                            }
-                                                        ]
-                                                    }
-                                                }
+                                                     "code": 200,
+                                                     "message": "요청이 성공하였습니다.",
+                                                     "data": {
+                                                         "tripId": 1,
+                                                         "title": "새로운 여행1",
+                                                         "city": "경주시",
+                                                         "leaderId": 2,
+                                                         "startedAt": "2025-05-01T12:00:00",
+                                                         "endedAt": "2025-05-02T12:01:00",
+                                                         "status": "COMPLETED",
+                                                         "members": [
+                                                             {
+                                                                 "userId": 1,
+                                                                 "nickname": "nick3",
+                                                                 "imageUrl": null
+                                                             },
+                                                             {
+                                                                 "userId": 2,
+                                                                 "nickname": "nick",
+                                                                 "imageUrl": null
+                                                             },
+                                                             {
+                                                                 "userId": 3,
+                                                                 "nickname": "nick2",
+                                                                 "imageUrl": null
+                                                             },
+                                                             {
+                                                                 "userId": 4,
+                                                                 "nickname": "testNick",
+                                                                 "imageUrl": null
+                                                             }
+                                                         ]
+                                                     }
+                                                 }
                                     """)
                     })),
             @ApiResponse(responseCode = "404", description = "특정 여행 조회 실패",
@@ -157,46 +168,90 @@ public interface TripApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(name = "조회 성공", value = """
                                              {
-                                                  "code": 200,
-                                                  "message": "요청이 성공하였습니다.",
-                                                  "data": [
-                                                      {
-                                                          "tripId": 1,
-                                                          "title": "여행2",
-                                                          "city": null,
-                                                          "startedAt": null,
-                                                          "endedAt": null,
-                                                          "status": "PLANNED",
-                                                          "members": [
-                                                              {
-                                                                  "userId": 1,
-                                                                  "nickname": "nick",
-                                                                  "imageUrl": "http://image.com"
-                                                              },
-                                                              {
-                                                                  "userId": 4,
-                                                                  "nickname": "nick2",
-                                                                  "imageUrl": null
-                                                              }
-                                                          ]
-                                                      },
-                                                      {
-                                                          "tripId": 2,
-                                                          "title": "여행1",
-                                                          "city": null,
-                                                          "startedAt": null,
-                                                          "endedAt": null,
-                                                          "status": "PLANNED",
-                                                          "members": [
-                                                              {
-                                                                  "userId": 1,
-                                                                  "nickname": "nick",
-                                                                  "imageUrl": "http://image.com"
-                                                              }
-                                                          ]
-                                                      }
-                                                  ]
-                                              }
+                                                   "code": 200,
+                                                   "message": "요청이 성공하였습니다.",
+                                                   "data": [
+                                                       {
+                                                           "tripId": 1,
+                                                           "title": "새로운 여행1",
+                                                           "city": "경주시",
+                                                           "leaderId": 2,
+                                                           "startedAt": "2025-05-01T12:00:00",
+                                                           "endedAt": "2025-05-02T12:01:00",
+                                                           "status": "COMPLETED",
+                                                           "members": [
+                                                               {
+                                                                   "userId": 1,
+                                                                   "nickname": "nick3",
+                                                                   "imageUrl": null
+                                                               },
+                                                               {
+                                                                   "userId": 2,
+                                                                   "nickname": "nick",
+                                                                   "imageUrl": null
+                                                               },
+                                                               {
+                                                                   "userId": 3,
+                                                                   "nickname": "nick2",
+                                                                   "imageUrl": null
+                                                               },
+                                                               {
+                                                                   "userId": 4,
+                                                                   "nickname": "testNick",
+                                                                   "imageUrl": null
+                                                               }
+                                                           ]
+                                                       },
+                                                       {
+                                                           "tripId": 2,
+                                                           "title": "여행2",
+                                                           "city": "대구광역시",
+                                                           "leaderId": 2,
+                                                           "startedAt": "2025-05-01T12:00:00",
+                                                           "endedAt": "2025-05-02T12:01:00",
+                                                           "status": "COMPLETED",
+                                                           "members": [
+                                                               {
+                                                                   "userId": 2,
+                                                                   "nickname": "nick",
+                                                                   "imageUrl": null
+                                                               }
+                                                           ]
+                                                       },
+                                                       {
+                                                           "tripId": 3,
+                                                           "title": "여행3",
+                                                           "city": "부산광역시",
+                                                           "leaderId": 2,
+                                                           "startedAt": "2025-05-01T12:00:00",
+                                                           "endedAt": "2025-05-02T12:01:00",
+                                                           "status": "COMPLETED",
+                                                           "members": [
+                                                               {
+                                                                   "userId": 2,
+                                                                   "nickname": "nick",
+                                                                   "imageUrl": null
+                                                               }
+                                                           ]
+                                                       },
+                                                       {
+                                                           "tripId": 4,
+                                                           "title": "여행4",
+                                                           "city": "가평",
+                                                           "leaderId": 2,
+                                                           "startedAt": "2025-05-17T12:00:00",
+                                                           "endedAt": "2025-05-25T12:01:00",
+                                                           "status": "IN_PROGRESS",
+                                                           "members": [
+                                                               {
+                                                                   "userId": 2,
+                                                                   "nickname": "nick",
+                                                                   "imageUrl": null
+                                                               }
+                                                           ]
+                                                       }
+                                                   ]
+                                               }
                                     """),
                             @ExampleObject(name = "조회 성공 - 속한 여행 없는 경우 빈 배열 반환", value = """
                                              {

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripCommandServiceTest.java
@@ -59,7 +59,6 @@ public class TripCommandServiceTest {
 
         private TripReq.Creation creationRequest = TripReq.Creation.builder()
                 .title("test")
-                .city("대구광역시")
                 .build();
 
         @Captor
@@ -79,7 +78,6 @@ public class TripCommandServiceTest {
 
             Trip trip = Trip.builder()
                     .title(creationRequest.title())
-                    .city(creationRequest.city())
                     .travelStatus(TravelStatus.PLANNED)
                     .leaderId(leaderId)
                     .build();
@@ -99,7 +97,6 @@ public class TripCommandServiceTest {
 
             Trip capturedTrip = tripCaptor.getValue();
             assertEquals(creationRequest.title(), capturedTrip.getTitle());
-            assertEquals(creationRequest.city(), capturedTrip.getCity());
             assertEquals(leaderId, capturedTrip.getLeaderId());
             assertEquals(TravelStatus.PLANNED, capturedTrip.getTravelStatus());
 

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
@@ -105,7 +105,6 @@ public class TripControllerTest {
             // given
             TripReq.Creation creationRequest = TripReq.Creation.builder()
                     .title("test")
-                    .city("대구광역시")
                     .build();
 
             when(tripCommandService.create(any(), any())).thenReturn(1L);
@@ -131,7 +130,6 @@ public class TripControllerTest {
             // given
             TripReq.Creation creationRequest = TripReq.Creation.builder()
 //                    .title("test")
-                    .city("대구광역시")
                     .build();
 
             // when
@@ -153,8 +151,7 @@ public class TripControllerTest {
         void failValidationLength() throws Exception {
             // given
             TripReq.Creation creationRequest = TripReq.Creation.builder()
-                    .title("test")
-                    .city("대구광역시대구광역시대구광역시대구광역시대구광역시대구광역시")
+                    .title("titletitletitletitletitle")
                     .build();
 
             // when
@@ -168,7 +165,7 @@ public class TripControllerTest {
             // then
             resultActions
                     .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.errors.city").value("여행 도시는 최대 20글자까지 가능합니다."));
+                    .andExpect(jsonPath("$.errors.title").exists());
         }
     }
 


### PR DESCRIPTION
## 배경
- 메인 여행 조회 시 트랙잭션 readOnly 설정 필요
- 여행 요약 정보 응답 dto 내 도시, 방장 id 추가 요구

## 작업 사항
- 메인 여행 조회 시 트랙잭션 readOnly 설정 - (3fcff9f8c43f16d205d1f81b7af1dc93239dd38a)
- 여행 요약 정보 응답 dto 내 도시, 방장 id 추가 - (39436dd57db53993040de72d51ffdd4b2ab5418f)