### PR TITLE
Feature(IL-148): 여행 준비 상태 추가

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
@@ -53,6 +53,7 @@ public class TripCommandService {
 
     /**
      * 여행 시간 수정 메서드
+     * - 여행 일정과 목적지까지 확정이 나지 않은 상태(SETTING)일 경우, 여행 상태(TravelStatus)값 미변경
      *
      * @param tripId        여행 ID
      * @param userId        요청자 ID
@@ -75,10 +76,12 @@ public class TripCommandService {
             throw new CustomException(TripErrorType.PERMISSION_DENIED_NOT_LEADER);
         }
 
-        TravelStatus status = TravelStatus.resolveStatus(time.start(), time.end());
+        if (trip.getTravelStatus() != TravelStatus.SETTING) {
+            TravelStatus status = TravelStatus.resolveStatus(time.start(), time.end());
+            trip.updateStatus(status);
+        }
 
         trip.updateTime(time.start(), time.end());
-        trip.updateStatus(status);
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
@@ -35,7 +35,7 @@ public class TripCommandService {
         Trip trip = Trip.builder()
                 .title(creationRequest.title())
                 .leaderId(leaderId)
-                .travelStatus(TravelStatus.PLANNED)
+                .travelStatus(TravelStatus.SETTING)
                 .build();
 
         User leader = userService.readById(leaderId)

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingService.java
@@ -1,6 +1,11 @@
 package kr.co.yeogiga.application.tripplace.service;
 
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.trip.service.TripService;
+import kr.co.yeogiga.domain.trip.type.TravelStatus;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
@@ -8,6 +13,7 @@ import kr.co.yeogiga.infrastructure.redis.RedisRepository;
 import kr.co.yeogiga.infrastructure.redis.constant.PlaceConstant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,17 +22,20 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TripPlaceSavingService {
     private final TripDayPlaceService tripDayPlaceService;
+    private final TripService tripService;
     private final RedisRepository redisRepository;
 
     /**
      * 여행 생성 완료 시, Redis에 임시 저장된 일차별 목적지들을 MongoDB에 저장하는 메서드
      * - 1일차부터 lastDay까지 순회하며 TripDayPlace 생성
      * - Redis에 임시 저장한 데이터 삭제 (list, set)
-     * - 생성된 TripDayPlace 리스트를 MongoDB에 일괄 저장
+     * - 생성된 TripDayPlace 리스트를 MongoDB에 일괄
+     * - 여행 생성 완료 시, 여행 상태 변경
      *
      * @param tripId  : 여행 ID
      * @param lastDay : 여행 마지막 일차
      */
+    @Transactional
     public void completeTrip(Long tripId, int lastDay) {
         List<TripDayPlace> tripDayPlaces = new ArrayList<>();
 
@@ -37,6 +46,11 @@ public class TripPlaceSavingService {
             redisRepository.del(PlaceConstant.dayPlacesKey(tripId, day));
             redisRepository.del(PlaceConstant.dayPlaceSetKey(tripId, day));
         }
+
+        Trip trip = tripService.readById(tripId)
+                .orElseThrow(() -> new CustomException(TripErrorType.TRIP_NOT_FOUND));
+
+        trip.updateStatus(TravelStatus.resolveStatus(trip.getStartedAt(), trip.getEndedAt()));
 
         tripDayPlaceService.saveAll(tripDayPlaces);
     }

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/TripRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/TripRepository.java
@@ -15,13 +15,13 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
     @Modifying
     @Query("UPDATE trip " +
             "SET travelStatus = 'IN_PROGRESS' " +
-            "WHERE travelStatus != 'IN_PROGRESS' AND startedAt <= :time AND :time <= endedAt")
+            "WHERE travelStatus != 'IN_PROGRESS' AND travelStatus != 'SETTING' AND startedAt <= :time AND :time <= endedAt")
     void updateTravelStatusInProgress(@Param(value = "time") LocalDateTime time);
 
     @Modifying
     @Query("UPDATE trip " +
             "SET travelStatus = 'COMPLETED' " +
-            "WHERE travelStatus != 'COMPLETED' AND endedAt <= :time")
+            "WHERE travelStatus != 'COMPLETED' AND travelStatus != 'SETTING' AND endedAt <= :time")
     void updateTravelStatusCompleted(@Param(value = "time") LocalDateTime time);
 
     List<Trip> findAllByIdIn(Set<Long> ids);

--- a/src/main/java/kr/co/yeogiga/domain/trip/type/TravelStatus.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/type/TravelStatus.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.domain.trip.type;
 import java.time.LocalDateTime;
 
 public enum TravelStatus {
+    SETTING,
     PLANNED,
     IN_PROGRESS,
     COMPLETED;

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripCommandServiceTest.java
@@ -98,7 +98,7 @@ public class TripCommandServiceTest {
             Trip capturedTrip = tripCaptor.getValue();
             assertEquals(creationRequest.title(), capturedTrip.getTitle());
             assertEquals(leaderId, capturedTrip.getLeaderId());
-            assertEquals(TravelStatus.PLANNED, capturedTrip.getTravelStatus());
+            assertEquals(TravelStatus.SETTING, capturedTrip.getTravelStatus());
 
             assertEquals(1L, newTripId);
         }
@@ -114,6 +114,7 @@ public class TripCommandServiceTest {
                 .title("test")
                 .city("대구광역시")
                 .leaderId(userId)
+                .travelStatus(TravelStatus.PLANNED)
                 .build();
 
         @Test

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingServiceTest.java
@@ -1,6 +1,9 @@
 package kr.co.yeogiga.application.tripplace.service;
 
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.service.TripService;
+import kr.co.yeogiga.domain.trip.type.TravelStatus;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import kr.co.yeogiga.infrastructure.redis.RedisRepository;
 import kr.co.yeogiga.infrastructure.redis.constant.PlaceConstant;
@@ -9,10 +12,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
+import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -29,15 +41,24 @@ public class TripPlaceSavingServiceTest {
     @Mock
     private RedisRepository redisRepository;
 
+    @Mock
+    private TripService tripService;
+
     @InjectMocks
     private TripPlaceSavingService tripPlaceSavingService;
 
     private final Long tripId = 1L;
     private final int lastDay = 2;
 
+    private Trip trip = Trip.builder()
+            .title("title")
+            .travelStatus(TravelStatus.SETTING)
+            .leaderId(1L)
+            .build();
+
     @Test
-    @DisplayName("여행 생성 완료 성공")
-    void completeTripSuccess() {
+    @DisplayName("여행 생성 완료 성공 - 여행 전")
+    void completeTripSuccessPlanned() {
         // given
         TripPlaceReq.StoredFormat place1 = new TripPlaceReq.StoredFormat(
                 "id1", "장소1", 33.123, 126.456, "관광지"
@@ -50,15 +71,114 @@ public class TripPlaceSavingServiceTest {
                 .thenReturn(List.of(place1))
                 .thenReturn(List.of(place2));
 
-        // when
-        tripPlaceSavingService.completeTrip(tripId, lastDay);
 
-        // then
-        verify(redisRepository, times(2)).getList(anyString(), eq(TripPlaceReq.StoredFormat.class));
-        verify(tripDayPlaceService, times(1)).saveAll(any());
-        verify(redisRepository, times(1)).del(PlaceConstant.dayPlacesKey(tripId, 1));
-        verify(redisRepository, times(1)).del(PlaceConstant.dayPlaceSetKey(tripId, 1));
-        verify(redisRepository, times(1)).del(PlaceConstant.dayPlacesKey(tripId, 2));
-        verify(redisRepository, times(1)).del(PlaceConstant.dayPlaceSetKey(tripId, 2));
+        ReflectionTestUtils.setField(trip, "startedAt", LocalDateTime.of(2025, 5, 25, 12, 0));
+        ReflectionTestUtils.setField(trip, "endedAt", LocalDateTime.of(2025, 5, 26, 12, 0));
+
+        when(tripService.readById(tripId)).thenReturn(Optional.of(trip));
+
+        try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+            String date = "2025-05-24T12:00:00Z";
+            Clock clock = Clock.fixed(Instant.parse(date), ZoneId.of("UTC"));
+            LocalDateTime mockNow = LocalDateTime.now(clock);
+            mockedLocalDateTime.when(LocalDateTime::now).thenReturn(mockNow);
+
+            // when
+            tripPlaceSavingService.completeTrip(tripId, lastDay);
+
+            // then
+            verify(redisRepository, times(2)).getList(anyString(), eq(TripPlaceReq.StoredFormat.class));
+            verify(tripDayPlaceService, times(1)).saveAll(any());
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlacesKey(tripId, 1));
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlaceSetKey(tripId, 1));
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlacesKey(tripId, 2));
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlaceSetKey(tripId, 2));
+
+            assertEquals(TravelStatus.PLANNED, trip.getTravelStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("여행 생성 완료 성공 - 여행 중")
+    void completeTripSuccessInProgress() {
+        // given
+        TripPlaceReq.StoredFormat place1 = new TripPlaceReq.StoredFormat(
+                "id1", "장소1", 33.123, 126.456, "관광지"
+        );
+        TripPlaceReq.StoredFormat place2 = new TripPlaceReq.StoredFormat(
+                "id2", "장소2", 33.789, 126.987, "식당"
+        );
+
+        when(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class)))
+                .thenReturn(List.of(place1))
+                .thenReturn(List.of(place2));
+
+
+        ReflectionTestUtils.setField(trip, "startedAt", LocalDateTime.of(2025, 5, 25, 12, 0));
+        ReflectionTestUtils.setField(trip, "endedAt", LocalDateTime.of(2025, 5, 26, 12, 0));
+
+        when(tripService.readById(tripId)).thenReturn(Optional.of(trip));
+
+        try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+            String date = "2025-05-25T18:00:00Z";
+            Clock clock = Clock.fixed(Instant.parse(date), ZoneId.of("Asia/Seoul"));
+            LocalDateTime mockNow = LocalDateTime.now(clock);
+            mockedLocalDateTime.when(LocalDateTime::now).thenReturn(mockNow);
+
+            // when
+            tripPlaceSavingService.completeTrip(tripId, lastDay);
+
+            // then
+            verify(redisRepository, times(2)).getList(anyString(), eq(TripPlaceReq.StoredFormat.class));
+            verify(tripDayPlaceService, times(1)).saveAll(any());
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlacesKey(tripId, 1));
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlaceSetKey(tripId, 1));
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlacesKey(tripId, 2));
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlaceSetKey(tripId, 2));
+
+            assertEquals(TravelStatus.IN_PROGRESS, trip.getTravelStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("여행 생성 완료 성공 - 여행 후")
+    void completeTripSuccessCompleted() {
+        // given
+        TripPlaceReq.StoredFormat place1 = new TripPlaceReq.StoredFormat(
+                "id1", "장소1", 33.123, 126.456, "관광지"
+        );
+        TripPlaceReq.StoredFormat place2 = new TripPlaceReq.StoredFormat(
+                "id2", "장소2", 33.789, 126.987, "식당"
+        );
+
+        when(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class)))
+                .thenReturn(List.of(place1))
+                .thenReturn(List.of(place2));
+
+
+        ReflectionTestUtils.setField(trip, "startedAt", LocalDateTime.of(2025, 5, 20, 12, 0));
+        ReflectionTestUtils.setField(trip, "endedAt", LocalDateTime.of(2025, 5, 21, 12, 0));
+
+        when(tripService.readById(tripId)).thenReturn(Optional.of(trip));
+
+        try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+            String date = "2025-05-24T12:00:00Z";
+            Clock clock = Clock.fixed(Instant.parse(date), ZoneId.of("UTC"));
+            LocalDateTime mockNow = LocalDateTime.now(clock);
+            mockedLocalDateTime.when(LocalDateTime::now).thenReturn(mockNow);
+
+            // when
+            tripPlaceSavingService.completeTrip(tripId, lastDay);
+
+            // then
+            verify(redisRepository, times(2)).getList(anyString(), eq(TripPlaceReq.StoredFormat.class));
+            verify(tripDayPlaceService, times(1)).saveAll(any());
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlacesKey(tripId, 1));
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlaceSetKey(tripId, 1));
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlacesKey(tripId, 2));
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlaceSetKey(tripId, 2));
+
+            assertEquals(TravelStatus.COMPLETED, trip.getTravelStatus());
+        }
     }
 }


### PR DESCRIPTION
## 배경
- 여행 일정 & 목적지 확정 전 상태 세분화 요구

## 작업 사항
- 여행 일정 & 목적지 확정 전 상태 추가 - `SETTING` | (1c2b1881be28c539671326b628bfced446b3b731)
- 여행 최초 생성 시, 상태는 `SETTING`으로 변경 | (11291521a1441de694578110f4742a9f968f1327)
- 여행 시간 수정 시, `SETTING`인 상태(목적지까지 확정 안 된 상태)일 경우 여행 상태 업데이트 X | (8df3a7dbebcd9a31d507b326b97ce534d79545f8)
- 여행 상태 업데이트 스케줄링 시, `SETTING`인 여행은 제외를 위한 JPQL 쿼리 변경 | (39cd4630aa2e833e94728e7ffab6c98efba214f6)
- 여행 목적지 확정 (`POST/api/v1/trip/{tripId}/complete`)시, 해당 여행 시작, 종료 시각을 기준으로하여 상태 업데이트 | (85265f7c42cc32be1c5ddcf39b2980f90fa269d1)

## 추가 논의
- 여행 목적지 확정 로직 내 방장만 해당 기능 사용하도록 확인하는 로직이 없는 것 같습니다. 해당 부분 추가해야 된다면 추가하겠습니다.
- 해당 작업 내용 + 피그마 내 여행 생성 flow에서 방장이 선택하는 초기 일자는 방장의 w2m 내용으로 여행 자체의 시간과는 무관하다는 것 프론트 파트 분들에게 따로 전달드렸고 노션에 기록 후 다시 공지하겠습니다.
- 혹시라도 로직에서 변경 놓친 부분이 있다면 말씀해주시면 감사하겠습니다.