### PR TITLE
Feature(IL-157): 집결지 핀 조회

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/pin/service/PinQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/pin/service/PinQueryService.java
@@ -1,0 +1,23 @@
+package kr.co.yeogiga.application.pin.service;
+
+import kr.co.yeogiga.domain.pin.entity.Pin;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import kr.co.yeogiga.infrastructure.redis.constant.PinConstant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PinQueryService {
+    private final RedisRepository redisRepository;
+
+    /**
+     * 집결지 핀 조회 메서드
+     *
+     * @param tripId    여행 ID
+     * @return          집결지 핀
+     */
+    public Pin getPin(Long tripId) {
+        return (Pin) redisRepository.get(PinConstant.pinKey(tripId));
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/pin/entity/Pin.java
+++ b/src/main/java/kr/co/yeogiga/domain/pin/entity/Pin.java
@@ -7,10 +7,12 @@ import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
+@NoArgsConstructor
 public class Pin {
     private String place;
 

--- a/src/main/java/kr/co/yeogiga/presentation/pin/controller/PinController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/pin/controller/PinController.java
@@ -3,11 +3,13 @@ package kr.co.yeogiga.presentation.pin.controller;
 import jakarta.validation.Valid;
 import kr.co.yeogiga.application.pin.dto.PinReq;
 import kr.co.yeogiga.application.pin.service.PinCommandService;
+import kr.co.yeogiga.application.pin.service.PinQueryService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.presentation.pin.controller.api.PinApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,6 +21,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PinController implements PinApi {
     private final PinCommandService pinCommandService;
+    private final PinQueryService pinQueryService;
+
+    @GetMapping("/{tripId}/pin")
+    public ResponseEntity<?> getPin(@PathVariable Long tripId) {
+        return ResponseEntity.ok()
+                .body(SuccessResponse.from(pinQueryService.getPin(tripId)));
+    }
 
     @Override
     @PostMapping("/{tripId}/pin")

--- a/src/main/java/kr/co/yeogiga/presentation/pin/controller/PinController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/pin/controller/PinController.java
@@ -23,6 +23,7 @@ public class PinController implements PinApi {
     private final PinCommandService pinCommandService;
     private final PinQueryService pinQueryService;
 
+    @Override
     @GetMapping("/{tripId}/pin")
     public ResponseEntity<?> getPin(@PathVariable Long tripId) {
         return ResponseEntity.ok()

--- a/src/main/java/kr/co/yeogiga/presentation/pin/controller/api/PinApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/pin/controller/api/PinApi.java
@@ -19,6 +19,30 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "[집결지 핀(PIN) API]", description = "집결지 핀(PIN) API")
 public interface PinApi {
 
+    @TrackApi(description = "집결지 핀 조회")
+    @Operation(summary = "집결지 핀 조회", description = "집결지 핀 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "집결지 핀 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                             "code": 200,
+                                             "message": "요청이 성공하였습니다.",
+                                             "data": {
+                                                 "place": "대구광역시 달서구 공원순환로 36",
+                                                 "latitude": 30.857555601596,
+                                                 "longitude": 120.56408081052,
+                                                 "time": "2025-05-26T12:30:00"
+                                             }
+                                         }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getPin(
+            @Parameter(description = "여행 ID")
+            @PathVariable Long tripId)
+   ;
+
     @TrackApi(description = "집결지 핀 생성")
     @Operation(summary = "집결지 핀 생성", description = "집결지 핀 생성 API")
     @ApiResponses({

--- a/src/test/java/kr/co/yeogiga/application/pin/service/PinQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/pin/service/PinQueryServiceTest.java
@@ -1,0 +1,56 @@
+package kr.co.yeogiga.application.pin.service;
+
+import kr.co.yeogiga.domain.pin.entity.Pin;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import kr.co.yeogiga.infrastructure.redis.constant.PinConstant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class PinQueryServiceTest {
+
+    @Mock
+    private RedisRepository redisRepository;
+
+    @InjectMocks
+    private PinQueryService pinQueryService;
+
+    @Nested
+    @DisplayName("핀 조회")
+    class GetPin {
+        private final Long tripId = 1L;
+
+        private Pin pin = Pin.builder()
+                .place("경상북도 경산시 대학로 280")
+                .latitude(1.1)
+                .longitude(2.2)
+                .time(LocalDateTime.of(2025, 5, 26, 13, 0))
+                .build();
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            when(redisRepository.get(PinConstant.pinKey(tripId))).thenReturn(pin);
+
+            // when
+            Pin result = pinQueryService.getPin(tripId);
+
+            // then
+            assertEquals(pin.getPlace(), result.getPlace());
+            assertEquals(pin.getLatitude(), result.getLatitude());
+            assertEquals(pin.getLongitude(), result.getLongitude());
+            assertEquals(pin.getTime(), result.getTime());
+        }
+    }
+}

--- a/src/test/java/kr/co/yeogiga/presentation/pin/controller/PinControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/pin/controller/PinControllerTest.java
@@ -3,10 +3,12 @@ package kr.co.yeogiga.presentation.pin.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.pin.dto.PinReq;
 import kr.co.yeogiga.application.pin.service.PinCommandService;
+import kr.co.yeogiga.application.pin.service.PinQueryService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.domain.pin.entity.Pin;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.type.Role;
 import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
@@ -29,7 +31,9 @@ import org.springframework.web.context.WebApplicationContext;
 import java.time.LocalDateTime;
 
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -51,6 +55,9 @@ public class PinControllerTest {
 
     @MockBean
     private PinCommandService pinCommandService;
+
+    @MockBean
+    private PinQueryService pinQueryService;
 
     private CustomUserDetails userDetails;
 
@@ -156,6 +163,40 @@ public class PinControllerTest {
             resultActions
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.errors").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("핀 조회")
+    class GetPin {
+        private final Long tripId = 1L;
+
+        private Pin pin = Pin.builder()
+                .place("경상북도 경산시 대학로 280")
+                .latitude(1.1)
+                .longitude(2.2)
+                .time(LocalDateTime.of(2025, 5, 26, 13, 0))
+                .build();
+
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            when(pinQueryService.getPin(tripId)).thenReturn(pin);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip/{tripId}/pin", tripId)
+                            .with(user(userDetails))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.place").value(pin.getPlace()))
+                    .andExpect(jsonPath("$.data.latitude").value(pin.getLatitude()))
+                    .andExpect(jsonPath("$.data.longitude").value(pin.getLongitude()))
+                    .andExpect(jsonPath("$.data.time").value("2025-05-26T13:00:00"));
         }
     }
 }


### PR DESCRIPTION
## 배경
- 지도 화면에서 집결지에 대한 핀 조회를 위한 집결지 핀 조회 기능 필요

## 작업 사항
- 집결지 핀 조회 로직 구현

## 추가 논의
- 집결지 핀이 없을 경우 에러를 응답해주기보다는 null 값을 주어, 응답은 성공이지만 body에서 `data` 부분이 제외되도록 하는 것이 낫다고 생각하여 기타 예외처리 없이 단순 핀 조회 로직만 존재합니다.