### PR TITLE
Feature(IL-152): FCM 토큰 저장 및 삭제 로직 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/user/dto/FcmTokenReq.java
+++ b/src/main/java/kr/co/yeogiga/application/user/dto/FcmTokenReq.java
@@ -1,0 +1,6 @@
+package kr.co.yeogiga.application.user.dto;
+
+public record FcmTokenReq(
+        String fckToken
+) {
+}

--- a/src/main/java/kr/co/yeogiga/application/user/dto/FcmTokenReq.java
+++ b/src/main/java/kr/co/yeogiga/application/user/dto/FcmTokenReq.java
@@ -1,6 +1,10 @@
 package kr.co.yeogiga.application.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "FcmTokenReq", description = "FcmToken 갱신 요청 dto")
 public record FcmTokenReq(
+        @Schema(description = "FcmToken 값", example = "fcm-token")
         String fckToken
 ) {
 }

--- a/src/main/java/kr/co/yeogiga/application/user/service/UserFcmTokenService.java
+++ b/src/main/java/kr/co/yeogiga/application/user/service/UserFcmTokenService.java
@@ -1,0 +1,46 @@
+package kr.co.yeogiga.application.user.service;
+
+import kr.co.yeogiga.application.user.dto.FcmTokenReq;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.exception.UserErrorType;
+import kr.co.yeogiga.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserFcmTokenService {
+    private final UserService userService;
+
+    /**
+     * 사용자의 FCM 토큰을 등록하거나 갱신하는 메서드
+     *
+     * @param userId      토큰을 등록할 사용자 ID
+     * @param fcmTokenReq 클라이언트에서 전달한 FCM 토큰 요청 객체
+     * @throws CustomException UserErrorType.NOT_FOUND - 사용자가 존재하지 않는 경우
+     */
+    @Transactional
+    public void registerFcmToken(Long userId, FcmTokenReq fcmTokenReq) {
+        User user = userService.readById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
+
+        user.updateFcmToken(fcmTokenReq.fckToken());
+    }
+
+    /**
+     * 사용자의 FCM 토큰을 제거 메서드
+     * - 로그아웃, 회원 탈퇴 등에 사용
+     *
+     * @param userId 토큰을 삭제할 사용자 ID
+     * @throws CustomException UserErrorType.NOT_FOUND - 사용자가 존재하지 않는 경우
+     */
+    @Transactional
+    public void deleteFcmToken(Long userId) {
+        User user = userService.readById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
+
+        user.updateFcmToken(null);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -38,6 +38,9 @@ public class User extends BaseTimeEntity {
     @Column(name = "image_url")
     private String imageUrl;
 
+    @Column(name = "fcm_token")
+    private String fcmToken;
+
     @ColumnDefault("false")
     @Column(name = "signed_up", nullable = false)
     private boolean signedUp;
@@ -73,5 +76,9 @@ public class User extends BaseTimeEntity {
 
     public void revertWithdrawal() {
         this.deletedAt = null;
+    }
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    @Query(value = "SELECT u.id, u.username, u.password, u.email, u.nickname,  u.image_url, u.signed_up, u.role, u.deleted_at, u.created_at, u.modified_at " +
+    @Query(value = "SELECT u.id, u.username, u.password, u.email, u.nickname,  u.image_url, u.fcm_token, u.signed_up, u.role, u.deleted_at, u.created_at, u.modified_at " +
                    "FROM users u " +
                    "INNER JOIN oauth o ON u.id = o.user_id " +
                    "WHERE o.platform = :platform AND o.platform_id = :platformId", nativeQuery = true)

--- a/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import kr.co.yeogiga.application.user.dto.FcmTokenReq;
 import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
 import kr.co.yeogiga.application.user.dto.UserInfoUpdateReq;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
@@ -181,5 +182,58 @@ public interface UserApi {
     ResponseEntity<?> update(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody UserInfoUpdateReq userInfoUpdateReq
+    );
+
+    @TrackApi(description = "Fcm Token 저장")
+    @Operation(summary = "Fcm Token 저장", description = "Fcm Token 저장 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Fcm Token 저장 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "Fcm Token 저장 성공", value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "Fcm Token 저장 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "존재하지 않는 사용자", value = """
+                                        {
+                                            "code": "U000",
+                                            "message": "존재하지 않는 사용자입니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> registerFcmToken(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody FcmTokenReq fcmTokenReq
+    );
+
+    @TrackApi(description = "Fcm Token 삭제")
+    @Operation(summary = "Fcm Token 삭제", description = "Fcm Token 삭제 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Fcm Token 삭제 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "Fcm Token 삭제 성공", value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "Fcm Token 삭제 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "존재하지 않는 사용자", value = """
+                                        {
+                                            "code": "U000",
+                                            "message": "존재하지 않는 사용자입니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> deleteFcmToken(
+            @AuthenticationPrincipal CustomUserDetails userDetails
     );
 }

--- a/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
@@ -1,8 +1,10 @@
 package kr.co.yeogiga.presentation.user.controller;
 
 import jakarta.validation.Valid;
+import kr.co.yeogiga.application.user.dto.FcmTokenReq;
 import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
 import kr.co.yeogiga.application.user.dto.UserInfoUpdateReq;
+import kr.co.yeogiga.application.user.service.UserFcmTokenService;
 import kr.co.yeogiga.application.user.service.UserManagementService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
@@ -15,6 +17,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,6 +30,7 @@ import static kr.co.yeogiga.application.auth.constant.AuthConstants.REFRESH_TOKE
 @RequiredArgsConstructor
 public class UserController implements UserApi {
     private final UserManagementService userManagementService;
+    private final UserFcmTokenService userFcmTokenService;
 
     @Override
     @PatchMapping("/password")
@@ -66,5 +70,22 @@ public class UserController implements UserApi {
     ) {
         userManagementService.updateUserInfo(userDetails.getUserId(), userInfoUpdateReq);
         return ResponseEntity.ok().body(SuccessResponse.ok());
+    }
+
+    @PostMapping("/fcm-token")
+    public ResponseEntity<?> registerFcmToken(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody FcmTokenReq fcmTokenReq
+    ) {
+        userFcmTokenService.registerFcmToken(userDetails.getUserId(), fcmTokenReq);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+
+    @DeleteMapping("/fcm-token")
+    public ResponseEntity<?> deleteFcmToken(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        userFcmTokenService.deleteFcmToken(userDetails.getUserId());
+        return ResponseEntity.ok(SuccessResponse.ok());
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
@@ -72,6 +72,7 @@ public class UserController implements UserApi {
         return ResponseEntity.ok().body(SuccessResponse.ok());
     }
 
+    @Override
     @PostMapping("/fcm-token")
     public ResponseEntity<?> registerFcmToken(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -81,6 +82,7 @@ public class UserController implements UserApi {
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 
+    @Override
     @DeleteMapping("/fcm-token")
     public ResponseEntity<?> deleteFcmToken(
             @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/test/java/kr/co/yeogiga/application/user/service/UserFcmTokenServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/user/service/UserFcmTokenServiceTest.java
@@ -1,0 +1,120 @@
+package kr.co.yeogiga.application.user.service;
+
+import kr.co.yeogiga.application.user.dto.FcmTokenReq;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.exception.UserErrorType;
+import kr.co.yeogiga.domain.user.service.UserService;
+import kr.co.yeogiga.domain.user.type.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UserFcmTokenServiceTest {
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private UserFcmTokenService userFcmTokenService;
+
+    @Nested
+    @DisplayName("토큰 등록 테스트")
+    class RegisterFcmToken {
+
+        private final Long userId = 1L;
+        private final String fcmToken = "fcm-token";
+        private final User user = User.builder()
+                .username("test")
+                .password("bcryptPassword")
+                .email("test@test.com")
+                .role(Role.USER)
+                .nickname("test")
+                .build();
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            FcmTokenReq request = new FcmTokenReq(fcmToken);
+            given(userService.readById(userId)).willReturn(Optional.ofNullable(user));
+
+            // when
+            userFcmTokenService.registerFcmToken(userId, request);
+
+            // then
+            assertEquals(fcmToken, user.getFcmToken());
+        }
+
+        @Test
+        @DisplayName("실패 - 사용자 존재하지 않음")
+        void failUserNotFound() {
+            // given
+            FcmTokenReq request = new FcmTokenReq(fcmToken);
+            when(userService.readById(userId)).thenReturn(Optional.empty());
+
+            // when
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    userFcmTokenService.registerFcmToken(userId, request)
+            );
+
+            // then
+            assertEquals(exception.getErrorType(), UserErrorType.NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 삭제 테스트")
+    class DeleteFcmToken {
+
+        private final Long userId = 1L;
+        private final User user = User.builder()
+                .username("test")
+                .password("bcryptPassword")
+                .email("test@test.com")
+                .role(Role.USER)
+                .nickname("test")
+                .build();
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            given(userService.readById(userId)).willReturn(Optional.ofNullable(user));
+
+            // when
+            userFcmTokenService.deleteFcmToken(userId);
+
+            // then
+            assertNull(user.getFcmToken());
+        }
+
+        @Test
+        @DisplayName("실패 - 사용자 존재하지 않음")
+        void failUserNotFound() {
+            // given
+            when(userService.readById(userId)).thenReturn(Optional.empty());
+
+            // when
+            CustomException exception = assertThrows(CustomException.class, () ->
+                    userFcmTokenService.deleteFcmToken(userId)
+            );
+
+            // then
+            assertEquals(exception.getErrorType(), UserErrorType.NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/kr/co/yeogiga/presentation/user/controller/UserControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/user/controller/UserControllerTest.java
@@ -2,9 +2,11 @@ package kr.co.yeogiga.presentation.user.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.auth.constant.AuthConstants;
+import kr.co.yeogiga.application.user.dto.FcmTokenReq;
 import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
 import kr.co.yeogiga.application.user.dto.UserInfoRes;
 import kr.co.yeogiga.application.user.dto.UserInfoUpdateReq;
+import kr.co.yeogiga.application.user.service.UserFcmTokenService;
 import kr.co.yeogiga.application.user.service.UserManagementService;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.response.error.type.CommonErrorType;
@@ -45,6 +47,7 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
@@ -68,6 +71,9 @@ public class UserControllerTest {
 
     @MockBean
     private UserManagementService userManagementService;
+
+    @MockBean
+    private UserFcmTokenService userFcmTokenService;
 
     private CustomUserDetails userDetails;
 
@@ -409,6 +415,52 @@ public class UserControllerTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value(CommonErrorType.VALIDATION_ERROR.getCode()))
                     .andExpect(jsonPath("$.errors.nickname").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("FcmToken 테스트")
+    class FcmToken {
+
+        @Test
+        @DisplayName("FcmToken 등록 테스트")
+        void registerFcmTokenSuccess() throws Exception {
+            // given
+            setUpUserDetails(Role.USER);
+            FcmTokenReq request = new FcmTokenReq("fcm-token");
+            doNothing().when(userFcmTokenService).registerFcmToken(userDetails.getUserId(), request);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/users/fcm-token")
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsBytes(request))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
+
+        @Test
+        @DisplayName("FcmToken 삭제 테스트")
+        void deleteFcmTokenSuccess() throws Exception {
+            // given
+            setUpUserDetails(Role.USER);
+            doNothing().when(userFcmTokenService).deleteFcmToken(userDetails.getUserId());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    delete("/api/v1/users/fcm-token")
+                            .with(user(userDetails))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
         }
     }
 }


### PR DESCRIPTION
## 배경
알림 전송을 위해 FCM 토큰 관리가 필요

## 작업 사항
- FcmToken 토큰 저장을 위한 필드 추가 (cd8c558dbc57d188df27b6c5a7340c5693815502)
   - 필드 추가로 인한 soft delete native쿼리에서 필드 추가 (5d9af9f91e220fd3f2055c71f04bb10b676fd297)
- FcmToken 저장 및 삭제 로직 구현 (0cbf69a4218787ecf6ccf636ad4d0d293ded8831)

## 추가 논의
fcmtoken 삭제의 경우, 로그아웃 과정에서 진행될 것 같습니다. 지금은 단순히 rest api 호출 형식으로 했는데, 추후에 제대로 반영하겠습니다.
또한, FCM 추가 설정의 경우 다음 PR에서 Silent Push와 함께 진행하겠습니다.