### PR TITLE
Feature(IL-153): Silent Push 전송 로직 구현

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,14 +44,21 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      # 3. Docker 이미지 build 및 push
+      # 3. Firebase를 위한 JSON 파일 생성
+      - name: Create Json
+        uses: jsdaniell/create-json@v1.2.2
+        with:
+          name: "./src/main/resources/yeogiga-808f2-firebase-adminsdk-fbsvc-b180bb10a5.json"
+          json: ${{ secrets.FIREBASE_PRODUCTION_JSON }}
+
+      # 4. Docker 이미지 build 및 push
       - name: docker build and push
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
           docker build -t ${{ secrets.DOCKER_USERNAME }}/yeogiga:latest .
           docker push ${{ secrets.DOCKER_USERNAME }}/yeogiga:latest
 
-      # 4. ec2 pull
+      # 5. ec2 pull
       - name: Deploy to server
         uses: appleboy/ssh-action@master
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ out/
 .vscode/
 
 **/.DS_Store
+
+### firebase ###
+/src/main/resources/*.json

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,9 @@ dependencies {
     /* JAXB */
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'com.sun.xml.bind:jaxb-impl:2.3.1'
+
+    /* FCM (Firebase Cloud Messaging) */
+    implementation 'com.google.firebase:firebase-admin:9.3.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/co/yeogiga/application/fcm/scheduler/FcmScheduler.java
+++ b/src/main/java/kr/co/yeogiga/application/fcm/scheduler/FcmScheduler.java
@@ -1,0 +1,20 @@
+package kr.co.yeogiga.application.fcm.scheduler;
+
+import kr.co.yeogiga.application.fcm.service.TripTokenPushProcessor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FcmScheduler {
+    private final TripTokenPushProcessor tripTokenPushProcessor;
+
+    /**
+     * Silent Push 전송을 위한 스케쥴러
+     */
+    @Scheduled(cron = "0 */10 * * * *")
+    public void sendSilentPushToActiveTripsJob() {
+        tripTokenPushProcessor.process();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/fcm/service/TripPushSender.java
+++ b/src/main/java/kr/co/yeogiga/application/fcm/service/TripPushSender.java
@@ -1,0 +1,52 @@
+package kr.co.yeogiga.application.fcm.service;
+
+import kr.co.yeogiga.application.user.service.UserFcmTokenService;
+import kr.co.yeogiga.infrastructure.fcm.FcmNotificationSender;
+import kr.co.yeogiga.infrastructure.fcm.response.FcmSendResult;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class TripPushSender {
+    private final FcmNotificationSender fcmNotificationSender;
+    private final UserFcmTokenService userFcmTokenService;
+    private final RedisRepository redisRepository;
+
+    /**
+     * FCM 토큰을 통해 푸시 알림을 비동기로 전송하는 메서드
+     * - 유효하지 않은 토큰은 Redis 및 DB에서 제거
+     *
+     * @param tripId       알림 대상 여행 ID
+     * @param redisListKey FCM 토큰이 저장된 Redis 리스트 키
+     * @param fcmToken     푸시 알림 전송 대상 FCM 토큰
+     */
+    @Async
+    public void sendPush(Long tripId, String redisListKey, String fcmToken) {
+        Map<String, String> notificationData = buildTripPushData(tripId);
+
+        FcmSendResult result = fcmNotificationSender.send(fcmToken, notificationData);
+
+        if (result.shouldRemoveToken()) {
+            redisRepository.removeFromList(redisListKey, fcmToken);
+            userFcmTokenService.deleteFcmTokenByToken(fcmToken);
+        }
+    }
+
+    /**
+     * Silent Push를 위한 data 생성 메서드
+     *
+     * @param tripId 알림 대상 여행 ID
+     * @return data가 저장된 Map 자료구조
+     */
+    private Map<String, String> buildTripPushData(Long tripId) {
+        Map<String, String> data = new HashMap<>();
+        data.put("tripId", tripId.toString());
+        return data;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/fcm/service/TripTokenPushProcessor.java
+++ b/src/main/java/kr/co/yeogiga/application/fcm/service/TripTokenPushProcessor.java
@@ -1,0 +1,68 @@
+package kr.co.yeogiga.application.fcm.service;
+
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import kr.co.yeogiga.infrastructure.redis.constant.TripMemberTokenConstant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 진행 중인 여행 멤버들의 GPS정보를 얻기 위해 Silent Push 호출 클래스
+ */
+@Component
+@RequiredArgsConstructor
+public class TripTokenPushProcessor {
+    private final RedisRepository redisRepository;
+    private final TripPushSender tripPushSender;
+
+    /**
+     * 진행 중인 여행의 멤버들에게 Silent Push 보내는 메서드
+     * - Redis에 저장된 (진행 중인 여행 멤버들) FcmToken을 불러와 전송
+     */
+    public void process() {
+        Set<String> tripTokenKeys = redisRepository.getKeysByPattern(TripMemberTokenConstant.TRIP_MEMBER_TOKEN_KEY_PATTERN);
+
+        if (tripTokenKeys == null || tripTokenKeys.isEmpty()) {
+            return;
+        }
+
+        for (String redisKey : tripTokenKeys) {
+            Long tripId = extractTripIdFromKey(redisKey);
+            if (tripId == null) continue;
+
+            sendPushToTripMembers(tripId);
+        }
+    }
+
+    /**
+     * 여행 멤버들에게 보낼 알림 호출 메서드
+     * - Redis에 저장된 여행 진행 중인 멤버들의 FcmToken 조회 후 전송
+     *
+     * @param tripId FCM 푸시 전송 대상 여행 ID
+     */
+    private void sendPushToTripMembers(Long tripId) {
+        String redisListKey = TripMemberTokenConstant.tripTokenKey(tripId);
+        List<String> fcmTokens = redisRepository.getList(redisListKey, String.class);
+
+        if (fcmTokens == null || fcmTokens.isEmpty()) {
+            return;
+        }
+
+        for (String fcmToken : fcmTokens) {
+            tripPushSender.sendPush(tripId, redisListKey, fcmToken);
+        }
+    }
+
+    /**
+     * Redis 키 문자열에서 여행 ID(tripId) 추출 메서드
+     *
+     * @param key Redis 키 (예: "trip:token:{tripId}")
+     * @return 추출된 tripId
+     */
+    private Long extractTripIdFromKey(String key) {
+        String[] parts = key.split(":");
+        return Long.parseLong(parts[2]);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/user/service/UserFcmTokenService.java
+++ b/src/main/java/kr/co/yeogiga/application/user/service/UserFcmTokenService.java
@@ -31,7 +31,7 @@ public class UserFcmTokenService {
 
     /**
      * 사용자의 FCM 토큰을 제거 메서드
-     * - 로그아웃, 회원 탈퇴 등에 사용
+     * - 로그아웃에 사용
      *
      * @param userId 토큰을 삭제할 사용자 ID
      * @throws CustomException UserErrorType.NOT_FOUND - 사용자가 존재하지 않는 경우
@@ -41,6 +41,19 @@ public class UserFcmTokenService {
         User user = userService.readById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
 
-        user.updateFcmToken(null);
+        user.clearFcmToken();
+    }
+
+    /**
+     * fcmToken을 통해 사용자의 FCM 토큰을 제거 메서드
+     *
+     * @param fcmToken 제거할 FcmToken
+     */
+    @Transactional
+    public void deleteFcmTokenByToken(String fcmToken) {
+        User user = userService.readByFcmToken(fcmToken)
+                .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
+
+        user.clearFcmToken();
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -1,6 +1,12 @@
 package kr.co.yeogiga.domain.user.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import kr.co.yeogiga.domain.common.entity.BaseTimeEntity;
 import kr.co.yeogiga.domain.user.type.Role;
 import lombok.AccessLevel;
@@ -11,6 +17,7 @@ import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
+
 import java.time.LocalDateTime;
 
 @Getter
@@ -80,5 +87,9 @@ public class User extends BaseTimeEntity {
 
     public void updateFcmToken(String fcmToken) {
         this.fcmToken = fcmToken;
+    }
+
+    public void clearFcmToken() {
+        this.fcmToken = null;
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
@@ -54,6 +54,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
             "WHERE email = :email LIMIT 1", nativeQuery = true)
     Optional<Long> findUserIdIncludeDeletedByEmail(@Param(value = "email") String email);
 
+    Optional<User> findByFcmToken(String fcmToken);
+
     @Modifying
     @Query(value = "DELETE " +
             "FROM users " +

--- a/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
@@ -43,6 +43,10 @@ public class UserService {
         return userRepository.findDeletedUserIdBefore(date);
     }
 
+    public Optional<User> readByFcmToken(String fcmToken) {
+        return userRepository.findByFcmToken(fcmToken);
+    }
+
     public boolean existsIncludeDeletedByUsername(String username) {
         return userRepository.findUserIdIncludeDeletedByUsername(username).isPresent();
     }

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/FcmConfig.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/FcmConfig.java
@@ -1,0 +1,30 @@
+package kr.co.yeogiga.infrastructure.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Configuration
+public class FcmConfig {
+
+    @Value("${firebase.key}")
+    private String firebaseKey;
+
+    @Bean
+    public FirebaseApp initializeFirebase() throws IOException {
+        InputStream serviceAccount = new ClassPathResource(firebaseKey).getInputStream();
+
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
+
+        return FirebaseApp.initializeApp(options);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/fcm/FcmNotificationSender.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/fcm/FcmNotificationSender.java
@@ -1,0 +1,70 @@
+package kr.co.yeogiga.infrastructure.fcm;
+
+import com.google.firebase.messaging.AndroidConfig;
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import kr.co.yeogiga.infrastructure.fcm.response.FcmSendResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+public class FcmNotificationSender {
+
+    /**
+     * FCM 푸시 알림을 전송하고 결과를 반환하는 메서드
+     *
+     * @param token 수신자의 FCM 디바이스 토큰
+     * @param data  fcm data 정보
+     * @return FCM 전송 결과 객체
+     */
+    public FcmSendResult send(String token, Map<String, String> data) {
+        Message message = buildSilentMessage(token, data);
+
+        try {
+            String response = FirebaseMessaging.getInstance().send(message);
+            return FcmSendResult.success(response);
+        } catch (FirebaseMessagingException e) {
+            MessagingErrorCode code = e.getMessagingErrorCode();
+
+            if (code == MessagingErrorCode.UNREGISTERED || code == MessagingErrorCode.INVALID_ARGUMENT) {
+                log.info("[FCM] Detected invalid token to be removed: {}", token);
+                return FcmSendResult.invalidToken(e.getMessage());
+            }
+
+            log.error("[FCM] Failed to send push notification: {}", e.getMessage(), e);
+            return FcmSendResult.failure(e.getMessage());
+        }
+    }
+
+    /**
+     * Silent Push를 위한 메시지 생성 메서드
+     *
+     * @param token 수신자의 FCM 디바이스 토큰
+     * @param data  fcm data 정보
+     * @return FCM 전송 메시지
+     */
+    private Message buildSilentMessage(String token, Map<String, String> data) {
+        return Message.builder()
+                .setToken(token)
+                .putAllData(data)
+                .setApnsConfig(ApnsConfig.builder()
+                        .putHeader("apns-priority", "5")
+                        .putHeader("apns-push-type", "background")
+                        .setAps(Aps.builder()
+                                .setContentAvailable(true)
+                                .build())
+                        .build())
+                .setAndroidConfig(AndroidConfig.builder()
+                        .setPriority(AndroidConfig.Priority.HIGH)
+                        .build())
+                .build();
+    }
+}
+

--- a/src/main/java/kr/co/yeogiga/infrastructure/fcm/response/FcmSendResult.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/fcm/response/FcmSendResult.java
@@ -1,0 +1,26 @@
+package kr.co.yeogiga.infrastructure.fcm.response;
+
+/**
+ * FCM 푸시 알림 전송 결과를 나타내는 클래스
+ *
+ * @param success           전송 성공 여부
+ * @param shouldRemoveToken 토큰 삭제 필요 여부 (UNREGISTERED, INVALID_ARGUMENT 등)
+ * @param message           전송 결과에 대한 메시지 (성공/실패 이유 등)
+ */
+public record FcmSendResult(
+        boolean success,
+        boolean shouldRemoveToken,
+        String message
+) {
+    public static FcmSendResult success(String message) {
+        return new FcmSendResult(true, false, message);
+    }
+
+    public static FcmSendResult invalidToken(String message) {
+        return new FcmSendResult(false, true, message);
+    }
+
+    public static FcmSendResult failure(String message) {
+        return new FcmSendResult(false, false, message);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/redis/constant/TripMemberTokenConstant.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/redis/constant/TripMemberTokenConstant.java
@@ -1,0 +1,13 @@
+package kr.co.yeogiga.infrastructure.redis.constant;
+
+public final class TripMemberTokenConstant {
+
+    private TripMemberTokenConstant() { }
+
+    private static final String TRIP_MEMBER_TOKEN_KEY_PREFIX = "trip:token:%d";
+    public static final String TRIP_MEMBER_TOKEN_KEY_PATTERN = "trip:token:*";
+
+    public static String tripTokenKey(Long tripId) {
+        return String.format(TRIP_MEMBER_TOKEN_KEY_PREFIX, tripId);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,3 +50,7 @@ jwt:
   expiration:
     access-token: ${JWT_AT_EXPIRATION:1800000}
     refresh-token: ${JWT_RT_EXPIRATION:86400000}
+
+--- # firebase
+firebase:
+  key: ${FIREBASE_KEY}

--- a/src/test/java/kr/co/yeogiga/application/user/service/UserFcmTokenServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/user/service/UserFcmTokenServiceTest.java
@@ -90,13 +90,27 @@ public class UserFcmTokenServiceTest {
                 .build();
 
         @Test
-        @DisplayName("성공")
-        void success() {
+        @DisplayName("성공 - 사용자 ID를 통한 사용자 토큰 삭제")
+        void deletesUserFcmTokenByUserId() {
             // given
             given(userService.readById(userId)).willReturn(Optional.ofNullable(user));
 
             // when
             userFcmTokenService.deleteFcmToken(userId);
+
+            // then
+            assertNull(user.getFcmToken());
+        }
+
+        @Test
+        @DisplayName("성공 - 토큰을 통한 사용자 토큰 삭제")
+        void deletesUserFcmTokenByFcmToken() {
+            // given
+            String fcmToken = "fcm-token";
+            given(userService.readByFcmToken(fcmToken)).willReturn(Optional.ofNullable(user));
+
+            // when
+            userFcmTokenService.deleteFcmTokenByToken(fcmToken);
 
             // then
             assertNull(user.getFcmToken());


### PR DESCRIPTION
## 배경
앱의 백그라운드에서 동작하여 GPS를 주기적으로 보내기 위해 Silent Push 전송이 필요

## 작업 사항
- FCM 설정 (aa1a2234b902c7f2d9a04da06cf87c2c603fd45b)
- FCM 전송 로직 구현 (f964558b93780e4944353d5b471a794c32a901e8)
    - 전송 결과에 따른 처리를 위해 응답 모델 생성 (aa1a2234b902c7f2d9a04da06cf87c2c603fd45b)
        - 아래에 적겠지만, 추후 확장을 위해 발생하는 경우의 수들에 대해 처리
- 여행 진행 중인 멤버들의 토큰을 통해 Silent Push 전송 로직 구현 (3da116ddf82e9d803e8484fc4a404d2f7309ba7a)
- 주기적 Silent Push 전송을 위한 스케쥴러 등록 (12465701989eb66080cffeb041f362596081d501)

## 추가 논의
- GPS 정보를 얻기 위한 Silent Push 전송 주기를 10분으로 잡았습니다. 10분은 이전에 얘기한 것인데, 만약 조정이 필요하다면 더 얘기해보면 좋을 것 같습니다.
- 이후에 여행이 진행 상태로 변경되면, 여행 멤버들의 토큰을 Redis에 담는 로직을 진행할 예정입니다.
- (f964558b93780e4944353d5b471a794c32a901e8)에 있는 `buildSilentMessage`에서의 APN 설정 내용은 아래 사이트들을 참고하며 Silent Push 메시지를 만들었습니다.
    - [파이어베이스 문서](https://firebase.google.com/docs/cloud-messaging/concept-options?hl=ko), [애플 디벨로퍼 문서](https://developer.apple.com/documentation/usernotifications/sending-notification-requests-to-apns)

## 기타
현재, 비동기 FCM 전송 과정에서 발생할 수 있는 문제는 아래와 같습니다.
1. 전송량이 많아지면 현재의 하나씩 보내는 `FirebaseMessaging.getInstance().send(message);`는 시간이 오래 걸릴 수 있음.
   - `sendEachForMulticast`와 같은 전송 방법 고려
2. 위와 같은 상황에서는 서버에 부하가 발생할 수 있음.
   - 상황에 맞게 스레드풀 조정
   - 메시지 브로커 형식으로 서버에서는 단순히 메시지 큐에 담기만 하고, 컨슈머들이 순차적으로 처리
   - (정말 커진다면) 스케일 아웃하여 여러 개의 서버에 메시지 브로커 사용
3. 전송량이 많아지면, 전송을 실패하는 경우가 발생할 수 있음
   - try-catch를 통해 재시도 로직 구현
   - 메시지 브로커 사용한다면, 재시도 로직 구현