### PR TITLE
Feature(IL-165): 준비 중 여행 조회

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripRes.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripRes.java
@@ -6,6 +6,9 @@ import kr.co.yeogiga.domain.trip.type.TravelStatus;
 
 import kr.co.yeogiga.domain.user.entity.User;
 import lombok.Builder;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.time.LocalDate;
 import java.util.List;
 import java.time.LocalDateTime;
 
@@ -53,6 +56,25 @@ public class TripRes {
                     .endedAt(trip.getEndedAt())
                     .status(trip.getTravelStatus())
                     .members(members.stream().map(TripMemberRes.MemberInfo::fromEntity).toList())
+                    .build();
+        }
+    }
+
+    @Builder
+    public record SettingTripInfo(
+            Long tripId,
+            String title,
+            LocalDate startedAt,
+            LocalDate endedAt,
+            TravelStatus status
+    ) {
+        public static SettingTripInfo from(Trip trip, Pair<LocalDate, LocalDate> time) {
+            return SettingTripInfo.builder()
+                    .tripId(trip.getId())
+                    .title(trip.getTitle())
+                    .startedAt(time.getLeft())
+                    .endedAt(time.getRight())
+                    .status(trip.getTravelStatus())
                     .build();
         }
     }

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripRes.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripRes.java
@@ -3,14 +3,11 @@ package kr.co.yeogiga.application.trip.dto;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
-
 import kr.co.yeogiga.domain.user.entity.User;
 import lombok.Builder;
-import org.apache.commons.lang3.tuple.Pair;
 
-import java.time.LocalDate;
-import java.util.List;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class TripRes {
 
@@ -64,16 +61,12 @@ public class TripRes {
     public record SettingTripInfo(
             Long tripId,
             String title,
-            LocalDate startedAt,
-            LocalDate endedAt,
             TravelStatus status
     ) {
-        public static SettingTripInfo from(Trip trip, Pair<LocalDate, LocalDate> time) {
+        public static SettingTripInfo from(Trip trip) {
             return SettingTripInfo.builder()
                     .tripId(trip.getId())
                     .title(trip.getTitle())
-                    .startedAt(time.getLeft())
-                    .endedAt(time.getRight())
                     .status(trip.getTravelStatus())
                     .build();
         }

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
@@ -3,6 +3,8 @@ package kr.co.yeogiga.application.trip.service;
 import kr.co.yeogiga.application.trip.dto.TripRes;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
 import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.calendar.entity.Calendar;
+import kr.co.yeogiga.domain.calendar.service.CalendarService;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.service.TripMemberService;
@@ -12,15 +14,19 @@ import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import kr.co.yeogiga.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +34,7 @@ public class TripQueryService {
     private final TripService tripService;
     private final TripMemberService tripMemberService;
     private final TripDayPlaceService tripDayPlaceService;
+    private final CalendarService calendarService;
 
     /**
      * 메인 화면 내 여행 정보를 조회하는 메서드
@@ -157,5 +164,36 @@ public class TripQueryService {
         List<User> members = tripMemberService.readAllUserByTripId(tripId);
 
         return TripRes.TripSummary.from(trip, members);
+    }
+
+    /**
+     * 준비 상태의 여행 목록을 조회하는 메서드
+     *
+     * @param userId        사용자 ID
+     * @return              준비 상태 여행 DTO 목록
+     */
+    @Transactional(readOnly = true)
+    public List<TripRes.SettingTripInfo> getSettingTrip(Long userId) {
+        List<Trip> tripList = tripMemberService.readAllTripByUserId(userId);
+
+        return tripList.stream()
+                .filter(trip -> TravelStatus.SETTING.equals(trip.getTravelStatus()))
+                .map(trip -> TripRes.SettingTripInfo.from(trip, getLeaderW2M(trip)))
+                .toList();
+    }
+
+    /**
+     * 여행 방장의 W2M 정보를 반환하는 메서드
+     *
+     * @param trip      여행 객체
+     * @return          여행 방장의 W2M 정보 (가장 빠른 날짜, 가장 늦은 날짜)
+     */
+    private Pair<LocalDate, LocalDate> getLeaderW2M(Trip trip) {
+        Optional<Calendar> calendar = calendarService.readByUserIdAndTripId(trip.getLeaderId(), trip.getId());
+
+        return calendar.isPresent()
+                ? Pair.of(Collections.min(calendar.get().getAvailableDates()), Collections.max(calendar.get().getAvailableDates()))
+                : Pair.of(null, null);
+
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
@@ -3,8 +3,6 @@ package kr.co.yeogiga.application.trip.service;
 import kr.co.yeogiga.application.trip.dto.TripRes;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
 import kr.co.yeogiga.common.exception.CustomException;
-import kr.co.yeogiga.domain.calendar.entity.Calendar;
-import kr.co.yeogiga.domain.calendar.service.CalendarService;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.service.TripMemberService;
@@ -14,19 +12,15 @@ import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import kr.co.yeogiga.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -34,7 +28,6 @@ public class TripQueryService {
     private final TripService tripService;
     private final TripMemberService tripMemberService;
     private final TripDayPlaceService tripDayPlaceService;
-    private final CalendarService calendarService;
 
     /**
      * 메인 화면 내 여행 정보를 조회하는 메서드
@@ -174,26 +167,10 @@ public class TripQueryService {
      */
     @Transactional(readOnly = true)
     public List<TripRes.SettingTripInfo> getSettingTrip(Long userId) {
-        List<Trip> tripList = tripMemberService.readAllTripByUserId(userId);
+        List<Trip> settingTripList = tripMemberService.readAllSettingTripByUserId(userId);
 
-        return tripList.stream()
-                .filter(trip -> TravelStatus.SETTING.equals(trip.getTravelStatus()))
-                .map(trip -> TripRes.SettingTripInfo.from(trip, getLeaderW2M(trip)))
+        return settingTripList.stream()
+                .map(TripRes.SettingTripInfo::from)
                 .toList();
-    }
-
-    /**
-     * 여행 방장의 W2M 정보를 반환하는 메서드
-     *
-     * @param trip      여행 객체
-     * @return          여행 방장의 W2M 정보 (가장 빠른 날짜, 가장 늦은 날짜)
-     */
-    private Pair<LocalDate, LocalDate> getLeaderW2M(Trip trip) {
-        Optional<Calendar> calendar = calendarService.readByUserIdAndTripId(trip.getLeaderId(), trip.getId());
-
-        return calendar.isPresent()
-                ? Pair.of(Collections.min(calendar.get().getAvailableDates()), Collections.max(calendar.get().getAvailableDates()))
-                : Pair.of(null, null);
-
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/TripMemberRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/TripMemberRepository.java
@@ -15,6 +15,9 @@ public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
     @Query("SELECT tm.trip FROM trip_member tm WHERE tm.user.id = :userId ORDER BY tm.trip.startedAt ASC NULLS LAST")
     List<Trip> findAllTripByUserId(@Param(value = "userId") Long userId);
 
+    @Query("SELECT tm.trip FROM trip_member tm WHERE tm.user.id = :userId AND tm.trip.travelStatus = 'SETTING'")
+    List<Trip> findAllSettingTripByUserId(Long userId);
+
     @Query("SELECT tm.user FROM trip_member tm WHERE tm.trip.id = :tripId")
     List<User> findAllUserByTripId(@Param(value = "tripId") Long tripId);
 

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
@@ -22,6 +22,10 @@ public class TripMemberService {
         return tripMemberRepository.findAllTripByUserId(userId);
     }
 
+    public List<Trip> readAllSettingTripByUserId(Long userId) {
+        return tripMemberRepository.findAllSettingTripByUserId(userId);
+    }
+
     public List<User> readAllUserByTripId(Long tripId) {
         return tripMemberRepository.findAllUserByTripId(tripId);
     }

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
@@ -264,6 +264,44 @@ public interface TripApi {
     })
     ResponseEntity<?> getAllTrip(@AuthenticationPrincipal CustomUserDetails userDetails);
 
+    @TrackApi(description = "준비 중 여행 조회")
+    @Operation(summary = "준비 중 여행 조회", description = "준비 중 여행 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "준비 중 여행 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "준비 중 여행 조회 성공", description = "방장 w2m 설정 안 된 경우 null 값 응답", value = """
+                                             {
+                                                      "code": 200,
+                                                      "message": "요청이 성공하였습니다.",
+                                                      "data": [
+                                                          {
+                                                              "tripId": 1,
+                                                              "title": "여행1",
+                                                              "startedAt": null,
+                                                              "endedAt": null,
+                                                              "status": "SETTING"
+                                                          },
+                                                          {
+                                                              "tripId": 2,
+                                                              "title": "여행1",
+                                                              "startedAt": "2025-07-01",
+                                                              "endedAt": "2025-07-10",
+                                                              "status": "SETTING"
+                                                          }
+                                                      ]
+                                                  }
+                                    """),
+                            @ExampleObject(name = "준비 중 여행 조회 성공 - 준비 중 여행이 없는 경우", value = """
+                                             {
+                                                       "code": 200,
+                                                       "message": "요청이 성공하였습니다.",
+                                                       "data": []
+                                                   }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getSettingTrip(@AuthenticationPrincipal CustomUserDetails userDetails);
+
     @TrackApi(description = "여행 생성")
     @Operation(summary = "여행 생성", description = "여행 생성 API")
     @ApiResponses({

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
@@ -269,33 +269,17 @@ public interface TripApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "준비 중 여행 조회 성공",
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name = "준비 중 여행 조회 성공", description = "방장 w2m 설정 안 된 경우 null 값 응답", value = """
-                                             {
-                                                      "code": 200,
-                                                      "message": "요청이 성공하였습니다.",
-                                                      "data": [
-                                                          {
-                                                              "tripId": 1,
-                                                              "title": "여행1",
-                                                              "startedAt": null,
-                                                              "endedAt": null,
-                                                              "status": "SETTING"
-                                                          },
-                                                          {
-                                                              "tripId": 2,
-                                                              "title": "여행1",
-                                                              "startedAt": "2025-07-01",
-                                                              "endedAt": "2025-07-10",
-                                                              "status": "SETTING"
-                                                          }
-                                                      ]
-                                                  }
-                                    """),
-                            @ExampleObject(name = "준비 중 여행 조회 성공 - 준비 중 여행이 없는 경우", value = """
+                            @ExampleObject(name = "준비 중 여행 조회 성공", value = """
                                              {
                                                        "code": 200,
                                                        "message": "요청이 성공하였습니다.",
-                                                       "data": []
+                                                       "data": [
+                                                           {
+                                                               "tripId": 3,
+                                                               "title": "여행3",
+                                                               "status": "SETTING"
+                                                           }
+                                                       ]
                                                    }
                                     """)
                     }))

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
@@ -54,6 +54,7 @@ public class TripController implements TripApi {
         return ResponseEntity.ok().body(SuccessResponse.from(tripList));
     }
 
+    @Override
     @GetMapping("/setting")
     public ResponseEntity<?> getSettingTrip(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity.ok()

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
@@ -54,6 +54,12 @@ public class TripController implements TripApi {
         return ResponseEntity.ok().body(SuccessResponse.from(tripList));
     }
 
+    @GetMapping("/setting")
+    public ResponseEntity<?> getSettingTrip(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok()
+                .body(SuccessResponse.from(tripQueryService.getSettingTrip(userDetails.getUserId())));
+    }
+
     @Override
     @PostMapping
     public ResponseEntity<?> createTrip(

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
@@ -2,6 +2,8 @@ package kr.co.yeogiga.application.trip.service;
 
 import kr.co.yeogiga.application.trip.dto.TripRes;
 import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.calendar.entity.Calendar;
+import kr.co.yeogiga.domain.calendar.service.CalendarService;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.service.TripMemberService;
@@ -26,6 +28,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
@@ -49,6 +52,9 @@ public class TripQueryServiceTest {
 
     @Mock
     private TripDayPlaceService tripDayPlaceService;
+
+    @Mock
+    private CalendarService calendarService;
 
     @InjectMocks
     private TripQueryService tripQueryService;
@@ -307,6 +313,75 @@ public class TripQueryServiceTest {
 
             // then
             assertEquals(TripErrorType.TRIP_NOT_FOUND, exception.getErrorType());
+        }
+    }
+
+    @Nested
+    @DisplayName("준비 중 여행 조회")
+    class GetSettingTrip {
+        private final Long userId = 1L;
+
+        private Trip trip = Trip.builder()
+                .title("title")
+                .leaderId(userId)
+                .travelStatus(TravelStatus.SETTING)
+                .build();
+
+        private Calendar calendar = Calendar.builder()
+                .trip(trip)
+                .userId(userId)
+                .availableDates(List.of(
+                        LocalDate.of(2025, 7, 1),
+                        LocalDate.of(2025, 7, 2),
+                        LocalDate.of(2025, 7, 10)
+                ))
+                .build();
+
+        @BeforeEach
+        void setUp() {
+            ReflectionTestUtils.setField(trip, "id", 1L);
+        }
+
+        @Test
+        @DisplayName("성공 - 여행 시간은 확정된 경우")
+        void successIfTimeIsSet() {
+            // given
+            when(tripMemberService.readAllTripByUserId(userId)).thenReturn(List.of(trip));
+            when(calendarService.readByUserIdAndTripId(userId, trip.getId())).thenReturn(Optional.of(calendar));
+
+            // when
+            List<TripRes.SettingTripInfo> result = tripQueryService.getSettingTrip(userId);
+
+            // then
+            assertThat(result).hasSize(1);
+
+            TripRes.SettingTripInfo settingTripInfo = result.get(0);
+            assertEquals(trip.getId(), settingTripInfo.tripId());
+            assertEquals(trip.getTitle(), settingTripInfo.title());
+            assertEquals(LocalDate.of(2025, 7, 1), settingTripInfo.startedAt());
+            assertEquals(LocalDate.of(2025, 7, 10), settingTripInfo.endedAt());
+            assertEquals(TravelStatus.SETTING, settingTripInfo.status());
+        }
+
+        @Test
+        @DisplayName("성공 - 여행 시간이 확정되지 않은 경우")
+        void successIfTimeIsNotSet() {
+            // given
+            when(tripMemberService.readAllTripByUserId(userId)).thenReturn(List.of(trip));
+            when(calendarService.readByUserIdAndTripId(userId, trip.getId())).thenReturn(Optional.empty());
+
+            // when
+            List<TripRes.SettingTripInfo> result = tripQueryService.getSettingTrip(userId);
+
+            // then
+            assertThat(result).hasSize(1);
+
+            TripRes.SettingTripInfo settingTripInfo = result.get(0);
+            assertEquals(trip.getId(), settingTripInfo.tripId());
+            assertEquals(trip.getTitle(), settingTripInfo.title());
+            assertThat(settingTripInfo.startedAt()).isNull();
+            assertThat(settingTripInfo.endedAt()).isNull();
+            assertEquals(TravelStatus.SETTING, settingTripInfo.status());
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
@@ -2,8 +2,6 @@ package kr.co.yeogiga.application.trip.service;
 
 import kr.co.yeogiga.application.trip.dto.TripRes;
 import kr.co.yeogiga.common.exception.CustomException;
-import kr.co.yeogiga.domain.calendar.entity.Calendar;
-import kr.co.yeogiga.domain.calendar.service.CalendarService;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.service.TripMemberService;
@@ -28,7 +26,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
@@ -52,9 +49,6 @@ public class TripQueryServiceTest {
 
     @Mock
     private TripDayPlaceService tripDayPlaceService;
-
-    @Mock
-    private CalendarService calendarService;
 
     @InjectMocks
     private TripQueryService tripQueryService;
@@ -327,60 +321,27 @@ public class TripQueryServiceTest {
                 .travelStatus(TravelStatus.SETTING)
                 .build();
 
-        private Calendar calendar = Calendar.builder()
-                .trip(trip)
-                .userId(userId)
-                .availableDates(List.of(
-                        LocalDate.of(2025, 7, 1),
-                        LocalDate.of(2025, 7, 2),
-                        LocalDate.of(2025, 7, 10)
-                ))
-                .build();
-
         @BeforeEach
         void setUp() {
             ReflectionTestUtils.setField(trip, "id", 1L);
         }
 
         @Test
-        @DisplayName("성공 - 여행 시간은 확정된 경우")
-        void successIfTimeIsSet() {
+        @DisplayName("성공")
+        void success() {
             // given
-            when(tripMemberService.readAllTripByUserId(userId)).thenReturn(List.of(trip));
-            when(calendarService.readByUserIdAndTripId(userId, trip.getId())).thenReturn(Optional.of(calendar));
+            when(tripMemberService.readAllSettingTripByUserId(userId)).thenReturn(List.of(trip));
 
             // when
             List<TripRes.SettingTripInfo> result = tripQueryService.getSettingTrip(userId);
 
             // then
+            System.out.println(result);
             assertThat(result).hasSize(1);
 
             TripRes.SettingTripInfo settingTripInfo = result.get(0);
             assertEquals(trip.getId(), settingTripInfo.tripId());
             assertEquals(trip.getTitle(), settingTripInfo.title());
-            assertEquals(LocalDate.of(2025, 7, 1), settingTripInfo.startedAt());
-            assertEquals(LocalDate.of(2025, 7, 10), settingTripInfo.endedAt());
-            assertEquals(TravelStatus.SETTING, settingTripInfo.status());
-        }
-
-        @Test
-        @DisplayName("성공 - 여행 시간이 확정되지 않은 경우")
-        void successIfTimeIsNotSet() {
-            // given
-            when(tripMemberService.readAllTripByUserId(userId)).thenReturn(List.of(trip));
-            when(calendarService.readByUserIdAndTripId(userId, trip.getId())).thenReturn(Optional.empty());
-
-            // when
-            List<TripRes.SettingTripInfo> result = tripQueryService.getSettingTrip(userId);
-
-            // then
-            assertThat(result).hasSize(1);
-
-            TripRes.SettingTripInfo settingTripInfo = result.get(0);
-            assertEquals(trip.getId(), settingTripInfo.tripId());
-            assertEquals(trip.getTitle(), settingTripInfo.title());
-            assertThat(settingTripInfo.startedAt()).isNull();
-            assertThat(settingTripInfo.endedAt()).isNull();
             assertEquals(TravelStatus.SETTING, settingTripInfo.status());
         }
     }

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
@@ -556,8 +556,6 @@ public class TripControllerTest {
                 .tripId(1L)
                 .title("title")
                 .status(TravelStatus.SETTING)
-                .startedAt(LocalDate.of(2025, 7, 1))
-                .endedAt(LocalDate.of(2025, 7, 10))
                 .build();
 
         @Test
@@ -577,9 +575,7 @@ public class TripControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data[0].tripId").value(settingTripInfo.tripId()))
                     .andExpect(jsonPath("$.data[0].title").value(settingTripInfo.title()))
-                    .andExpect(jsonPath("$.data[0].status").value(settingTripInfo.status().name()))
-                    .andExpect(jsonPath("$.data[0].startedAt").value(settingTripInfo.startedAt().toString()))
-                    .andExpect(jsonPath("$.data[0].endedAt").value(settingTripInfo.endedAt().toString()));
+                    .andExpect(jsonPath("$.data[0].status").value(settingTripInfo.status().name()));
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
@@ -35,6 +35,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -545,6 +546,40 @@ public class TripControllerTest {
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.code").value(TripErrorType.TRIP_NOT_FOUND.getCode()))
                     .andExpect(jsonPath("$.message").value(TripErrorType.TRIP_NOT_FOUND.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("준비 중 여행 조회")
+    class GetSettingTrip {
+        private TripRes.SettingTripInfo settingTripInfo = TripRes.SettingTripInfo.builder()
+                .tripId(1L)
+                .title("title")
+                .status(TravelStatus.SETTING)
+                .startedAt(LocalDate.of(2025, 7, 1))
+                .endedAt(LocalDate.of(2025, 7, 10))
+                .build();
+
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            when(tripQueryService.getSettingTrip(any())).thenReturn(List.of(settingTripInfo));
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip/setting")
+                            .with(user(userDetails))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data[0].tripId").value(settingTripInfo.tripId()))
+                    .andExpect(jsonPath("$.data[0].title").value(settingTripInfo.title()))
+                    .andExpect(jsonPath("$.data[0].status").value(settingTripInfo.status().name()))
+                    .andExpect(jsonPath("$.data[0].startedAt").value(settingTripInfo.startedAt().toString()))
+                    .andExpect(jsonPath("$.data[0].endedAt").value(settingTripInfo.endedAt().toString()));
         }
     }
 }


### PR DESCRIPTION
## 배경
- 준비(SETTING) 중인 여행 조회 기능 필요

## 작업 사항
- 준비 중인 여행 조회 로직 구현
	- ~여행 시작, 종료 날짜는 방장의 w2m 가능 날짜 목록 중 가장 빠른 날짜, 가장 느린 날짜 응답~
	- ~여행에 w2m이 정해지지 않은 경우 (여행 생성만 하고 w2m 하지 않고 앱을 나간 경우) 방장의 w2m 값이 null 이므로, 시간에 null 값 응답~

## 추가 논의
- 현재 SETTING인 여행 분류를 비지니스 로직 코드 내에서 분류하는데 조인을 진행하여 SETTING인 여행을 조회할 지 고민하였습니다.차후 QueryDsl 도입 시 Setting인 여행만 가지고 오도록 리팩토링할 것 같기는하지만 현재는 어떻게 해야할지 고민이라 일단은 놔두고 진행하였습니다.