### PR TITLE
Feature(IL-167): 목적지 순서 추천 알고리즘 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageAssignmentService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageAssignmentService.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.application.tripplace.image.service;
 
+import kr.co.yeogiga.common.util.DistanceUtils;
 import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
@@ -168,28 +169,8 @@ public class TripPlaceImageAssignmentService {
     private Place findNearestPlace(List<Place> places, Image image) {
         return places.stream()
                 .min(Comparator.comparingDouble(place ->
-                        calculateDistance(image.getLatitude(), image.getLongitude(),
+                        DistanceUtils.calculateDistance(image.getLatitude(), image.getLongitude(),
                                 place.getLatitude(), place.getLongitude())))
                 .orElse(null);
-    }
-
-    /**
-     * 두 GPS 좌표 간의 지구 표면 거리(km)를 Haversine 공식으로 계산하는 메서드
-     *
-     * @param lat1 첫 번째 위도
-     * @param lon1 첫 번째 경도
-     * @param lat2 두 번째 위도
-     * @param lon2 두 번째 경도
-     * @return 두 지점 간 거리 (단위: km)
-     */
-    private double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
-        final int R = 6371;
-        double dLat = Math.toRadians(lat2 - lat1);
-        double dLon = Math.toRadians(lon2 - lon1);
-        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
-                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
-                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
-        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-        return R * c;
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortService.java
@@ -32,7 +32,9 @@ public class TripPlaceSortService {
         List<TripPlaceReq.StoredFormat> places =
                 redisRepository.getList(listKey, TripPlaceReq.StoredFormat.class);
 
-        if (places.isEmpty()) return;
+        if (places == null || places.isEmpty()) {
+            return;
+        }
 
         // 숙소 카테고리 & 나머지 카테고리 분리
         List<TripPlaceReq.StoredFormat> lodgings = new ArrayList<>();

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortService.java
@@ -1,0 +1,192 @@
+package kr.co.yeogiga.application.tripplace.service;
+
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import kr.co.yeogiga.infrastructure.redis.constant.PlaceConstant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+@Service
+@RequiredArgsConstructor
+public class TripPlaceSortService {
+    private final RedisRepository redisRepository;
+
+    /**
+     * 여행 ID와 날짜를 기반으로 해당 일자의 장소들을 정렬하는 메서드
+     * 정렬 기준 :
+     * 1. 숙소는 항상 마지막에 배치
+     * 2. 나머지 장소는 위도/경도 기준으로 가까운 거리 순으로 정렬
+     * 3. 식당이 3개 이상 연속되지 않도록 배치
+     *
+     * @param tripId 여행 ID
+     * @param day    일차 (1일차, 2일차 등)
+     */
+    public void sortDayTripPlaces(Long tripId, int day) {
+        String listKey = PlaceConstant.dayPlacesKey(tripId, day);
+        List<TripPlaceReq.StoredFormat> places =
+                redisRepository.getList(listKey, TripPlaceReq.StoredFormat.class);
+
+        if (places.isEmpty()) return;
+
+        // 숙소 카테고리 & 나머지 카테고리 분리
+        List<TripPlaceReq.StoredFormat> lodgings = new ArrayList<>();
+        List<TripPlaceReq.StoredFormat> otherPlaces = new ArrayList<>();
+        partitionPlaces(places, otherPlaces, lodgings);
+
+        // 위도/경도 기준 목적지 정렬
+        sortByDistance(otherPlaces);
+
+        // 연속된 식당 카테고리 방지 (3번 이상 방지)
+        List<TripPlaceReq.StoredFormat> sorted = preventConsecutiveRestaurants(otherPlaces);
+
+        // 마지막에 숙소 삽입
+        sorted.addAll(lodgings);
+
+        redisRepository.del(listKey);
+        for (TripPlaceReq.StoredFormat place : sorted) {
+            redisRepository.setList(listKey, place);
+        }
+    }
+
+    /**
+     * 숙소와 그 외 카테고리를 분리하여 각각의 리스트에 저장하는 메서드
+     *
+     * @param places      전체 장소 목록
+     * @param otherPlaces 숙소 외의 장소를 저장할 리스트
+     * @param lodgings    숙소만 저장할 리스트
+     */
+    private void partitionPlaces(
+            List<TripPlaceReq.StoredFormat> places,
+            List<TripPlaceReq.StoredFormat> otherPlaces,
+            List<TripPlaceReq.StoredFormat> lodgings
+    ) {
+        for (TripPlaceReq.StoredFormat place : places) {
+            if ("숙소".equals(place.placeCategory())) {
+                lodgings.add(place);
+            } else {
+                otherPlaces.add(place);
+            }
+        }
+    }
+
+    /**
+     * 위도/경도를 통해 목적지를 정렬하는 메서드
+     * - 첫번째 목적지를 기준으로 목적지를 정렬
+     *
+     * @param places 정렬할 장소 목록
+     */
+    private void sortByDistance(List<TripPlaceReq.StoredFormat> places) {
+        if (places.isEmpty()) return;
+
+        TripPlaceReq.StoredFormat basePlace = places.get(0);
+        places.sort(Comparator.comparingDouble(p ->
+                        calculateDistance(
+                                basePlace.latitude(), basePlace.longitude(), p.latitude(), p.longitude()
+                        )
+                )
+        );
+    }
+
+    /**
+     * 두 GPS 좌표 간의 지구 표면 거리(km)를 Haversine 공식으로 계산하는 메서드
+     *
+     * @param lat1 첫 번째 위도
+     * @param lon1 첫 번째 경도
+     * @param lat2 두 번째 위도
+     * @param lon2 두 번째 경도
+     * @return 두 지점 간 거리 (단위: km)
+     */
+    private double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        final int R = 6371;
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+        double a =
+                Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+                        Math.cos(Math.toRadians(lat1)) *
+                                Math.cos(Math.toRadians(lat2)) *
+                                Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return R * c;
+    }
+
+    /**
+     * 식당이 3개 이상 연속되지 않도록 장소들을 재배치하는 메서드
+     *
+     * @param input 정렬된 장소 목록
+     * @return 재배치된 장소 목록
+     */
+    private List<TripPlaceReq.StoredFormat> preventConsecutiveRestaurants(List<TripPlaceReq.StoredFormat> input) {
+        List<TripPlaceReq.StoredFormat> result = new ArrayList<>();
+        Queue<TripPlaceReq.StoredFormat> restaurants = new LinkedList<>();
+
+        for (TripPlaceReq.StoredFormat place : input) {
+            if (result.contains(place)) continue;
+
+            if (isRestaurant(place)) {  // 식당 카테고리인 경우
+                restaurants.add(place);
+
+                if (restaurants.size() < 3) {
+                    continue;
+                }
+
+                // 식당 3개 연속 방지 로직
+                TripPlaceReq.StoredFormat nonRestaurant = findNextNonRestaurant(input, result, restaurants);
+                if (nonRestaurant != null) {
+                    result.add(restaurants.poll());    // 식당 1
+                    result.add(nonRestaurant);         // 식당 이외의 카테고리
+                    result.addAll(restaurants);        // 식당 2, 3
+                } else {
+                    result.addAll(restaurants);        // 식당 이외의 카테고리가 더 이상 없을 경우
+                }
+
+                restaurants.clear();
+            } else {    // 식당 카테고리가 아닌 경우
+                result.addAll(restaurants);
+                restaurants.clear();
+                result.add(place);
+            }
+        }
+
+        // 삽입되지 않은 식당 카테고리 목적지
+        result.addAll(restaurants);
+        restaurants.clear();
+
+        return result;
+    }
+
+    /**
+     * 아직 결과에 포함되지 않았고 식당이 아닌 장소를 찾는 메서드
+     * - 중복을 피하기 위해 담긴 목적지 및 restaurants에 포함되지 않은 항목만 반환
+     *
+     * @param input       전체 입력 리스트
+     * @param result      현재까지 결과에 추가된 장소들
+     * @param restaurants 현재 연속된 식당 리스트
+     * @return 조건에 맞는 식당 이외 장소, 없으면 null
+     */
+    private TripPlaceReq.StoredFormat findNextNonRestaurant(
+            List<TripPlaceReq.StoredFormat> input,
+            List<TripPlaceReq.StoredFormat> result,
+            Queue<TripPlaceReq.StoredFormat> restaurants
+    ) {
+        return input.stream()
+                .filter(p -> !isRestaurant(p) && !result.contains(p) && !restaurants.contains(p))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * 해당 장소가 식당인지 여부를 판단 메서드
+     *
+     * @param place 장소 객체
+     * @return true = 식당, false = 식당 아님
+     */
+    private boolean isRestaurant(TripPlaceReq.StoredFormat place) {
+        return "식당".equals(place.placeCategory());
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortService.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.application.tripplace.service;
 
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.common.util.DistanceUtils;
 import kr.co.yeogiga.infrastructure.redis.RedisRepository;
 import kr.co.yeogiga.infrastructure.redis.constant.PlaceConstant;
 import lombok.RequiredArgsConstructor;
@@ -88,33 +89,11 @@ public class TripPlaceSortService {
 
         TripPlaceReq.StoredFormat basePlace = places.get(0);
         places.sort(Comparator.comparingDouble(p ->
-                        calculateDistance(
+                        DistanceUtils.calculateDistance(
                                 basePlace.latitude(), basePlace.longitude(), p.latitude(), p.longitude()
                         )
                 )
         );
-    }
-
-    /**
-     * 두 GPS 좌표 간의 지구 표면 거리(km)를 Haversine 공식으로 계산하는 메서드
-     *
-     * @param lat1 첫 번째 위도
-     * @param lon1 첫 번째 경도
-     * @param lat2 두 번째 위도
-     * @param lon2 두 번째 경도
-     * @return 두 지점 간 거리 (단위: km)
-     */
-    private double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
-        final int R = 6371;
-        double dLat = Math.toRadians(lat2 - lat1);
-        double dLon = Math.toRadians(lon2 - lon1);
-        double a =
-                Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-                        Math.cos(Math.toRadians(lat1)) *
-                                Math.cos(Math.toRadians(lat2)) *
-                                Math.sin(dLon / 2) * Math.sin(dLon / 2);
-        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-        return R * c;
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/common/util/DistanceUtils.java
+++ b/src/main/java/kr/co/yeogiga/common/util/DistanceUtils.java
@@ -1,0 +1,27 @@
+package kr.co.yeogiga.common.util;
+
+public class DistanceUtils {
+
+    private static final int EARTH_RADIUS_KM = 6371;
+
+    /**
+     * 두 GPS 좌표 간의 지구 표면 거리(km)를 Haversine 공식으로 계산하는 메서드
+     *
+     * @param lat1 첫 번째 위도
+     * @param lon1 첫 번째 경도
+     * @param lat2 두 번째 위도
+     * @param lon2 두 번째 경도
+     * @return 두 지점 간 거리 (단위: km)
+     */
+    public static double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+        double a =
+                Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+                        Math.cos(Math.toRadians(lat1)) *
+                                Math.cos(Math.toRadians(lat2)) *
+                                Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return EARTH_RADIUS_KM * c;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/api/TripPlaceEditingApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/api/TripPlaceEditingApi.java
@@ -115,6 +115,27 @@ public interface TripPlaceEditingApi {
             @RequestBody List<TripPlaceReq.Request> requests
     );
 
+    @TrackApi(description = "일차별 목적지의 순서 추천 알고리즘")
+    @Operation(summary = "일차별 목적지의 순서 추천 알고리즘", description = "일차별 목적지의 순서 추천 알고리즘 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "목적지 순서 추천 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> sortDayTripPlaces(
+            @Parameter(description = "여행 ID")
+            @PathVariable Long tripId,
+
+            @Parameter(description = "추천받고자 하는 일차")
+            @PathVariable int day
+    );
+
     @TrackApi(description = "일차에 지정된 목적지 삭제")
     @Operation(summary = "일차에 지정된 목적지 삭제", description = "일차에 지정된 목적지 삭제하는 API입니다.")
     @ApiResponses({

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingController.java
@@ -2,6 +2,7 @@ package kr.co.yeogiga.presentation.tripplace.controller;
 
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
 import kr.co.yeogiga.application.tripplace.service.TripPlaceEditingService;
+import kr.co.yeogiga.application.tripplace.service.TripPlaceSortService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.presentation.tripplace.api.TripPlaceEditingApi;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TripPlaceEditingController implements TripPlaceEditingApi {
     private final TripPlaceEditingService tripPlaceEditingService;
+    private final TripPlaceSortService tripPlaceSortService;
 
     @Override
     @PostMapping("/{tripId}/days/{day}/places")
@@ -49,6 +51,13 @@ public class TripPlaceEditingController implements TripPlaceEditingApi {
                                           @RequestBody List<TripPlaceReq.Request> requests) {
 
         tripPlaceEditingService.updatePlaces(tripId, day, requests);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+
+    @PutMapping("/{tripId}/days/{day}/places/sort")
+    public ResponseEntity<?> sortDayTripPlaces(@PathVariable Long tripId,
+                                               @PathVariable int day) {
+        tripPlaceSortService.sortDayTripPlaces(tripId, day);
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingController.java
@@ -54,6 +54,7 @@ public class TripPlaceEditingController implements TripPlaceEditingApi {
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 
+    @Override
     @PutMapping("/{tripId}/days/{day}/places/sort")
     public ResponseEntity<?> sortDayTripPlaces(@PathVariable Long tripId,
                                                @PathVariable int day) {

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortServiceTest.java
@@ -1,0 +1,119 @@
+package kr.co.yeogiga.application.tripplace.service;
+
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import kr.co.yeogiga.infrastructure.redis.constant.PlaceConstant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TripPlaceSortServiceTest {
+
+    @Mock
+    private RedisRepository redisRepository;
+
+    @InjectMocks
+    private TripPlaceSortService tripPlaceSortService;
+
+    private final Long tripId = 1L;
+    private final int day = 1;
+
+    @Test
+    @DisplayName("장소가 비어있으면 정렬을 수행하지 않는다")
+    void emptyPlacesTest() {
+        // given
+        String listKey = PlaceConstant.dayPlacesKey(tripId, day);
+
+        given(redisRepository.getList(eq(listKey), eq(TripPlaceReq.StoredFormat.class)))
+                .willReturn(Collections.emptyList());
+
+        // when
+        tripPlaceSortService.sortDayTripPlaces(tripId, day);
+
+        // then
+        verify(redisRepository, never()).setList(eq(listKey), any());
+    }
+
+    @Test
+    @DisplayName("숙소는 항상 마지막에 배치된다")
+    void lodgingAtLastTest() {
+        // given
+        String listKey = PlaceConstant.dayPlacesKey(tripId, day);
+
+        List<TripPlaceReq.StoredFormat> input = List.of(
+                new TripPlaceReq.StoredFormat("1", "PlaceA", 35.1, 128.1, "식당"),
+                new TripPlaceReq.StoredFormat("2", "PlaceB", 35.2, 128.2, "관광지"),
+                new TripPlaceReq.StoredFormat("3", "PlaceC", 35.3, 128.3, "숙소")
+        );
+
+        given(redisRepository.getList(eq(listKey), eq(TripPlaceReq.StoredFormat.class)))
+                .willReturn(input);
+
+        // when
+        tripPlaceSortService.sortDayTripPlaces(tripId, day);
+
+        // then
+        ArgumentCaptor<TripPlaceReq.StoredFormat> captor = ArgumentCaptor.forClass(TripPlaceReq.StoredFormat.class);
+        verify(redisRepository, times(3)).setList(eq(listKey), captor.capture());
+
+        List<TripPlaceReq.StoredFormat> saved = captor.getAllValues();
+        assertEquals("숙소", saved.get(2).placeCategory(), "마지막 장소는 숙소여야 함");
+    }
+
+    @Test
+    @DisplayName("식당이 3개 이상 연속되지 않도록 배치된다")
+    void preventConsecutiveRestaurantsTest() {
+        // given
+        String listKey = PlaceConstant.dayPlacesKey(tripId, day);
+
+        List<TripPlaceReq.StoredFormat> input = List.of(
+                new TripPlaceReq.StoredFormat("1", "A", 35.0, 128.0, "식당"),
+                new TripPlaceReq.StoredFormat("2", "B", 35.1, 128.1, "식당"),
+                new TripPlaceReq.StoredFormat("3", "C", 35.2, 128.2, "식당"),
+                new TripPlaceReq.StoredFormat("4", "D", 35.3, 128.3, "숙소"),
+                new TripPlaceReq.StoredFormat("5", "E", 35.4, 128.4, "관광지")
+        );
+
+        given(redisRepository.getList(eq(listKey), eq(TripPlaceReq.StoredFormat.class)))
+                .willReturn(input);
+
+        // when
+        tripPlaceSortService.sortDayTripPlaces(tripId, day);
+
+        // then
+        ArgumentCaptor<TripPlaceReq.StoredFormat> captor = ArgumentCaptor.forClass(TripPlaceReq.StoredFormat.class);
+        verify(redisRepository, times(5)).setList(eq(listKey), captor.capture());
+        List<TripPlaceReq.StoredFormat> saved = captor.getAllValues();
+
+        // 식당 카테고리가 3번 이상 연속하지 않는지 확인
+        int maxConsecutiveRestaurants = 0;
+        int currentCount = 0;
+        for (TripPlaceReq.StoredFormat place : saved) {
+            if ("식당".equals(place.placeCategory())) {
+                currentCount++;
+                maxConsecutiveRestaurants = Math.max(maxConsecutiveRestaurants, currentCount);
+            } else {
+                currentCount = 0;
+            }
+        }
+
+        assertTrue(maxConsecutiveRestaurants <= 2);
+    }
+}

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingControllerTest.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.presentation.tripplace.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
 import kr.co.yeogiga.application.tripplace.service.TripPlaceEditingService;
+import kr.co.yeogiga.application.tripplace.service.TripPlaceSortService;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
@@ -56,6 +57,9 @@ public class TripPlaceEditingControllerTest {
 
     @MockBean
     private TripPlaceEditingService tripPlaceEditingService;
+
+    @MockBean
+    private TripPlaceSortService tripPlaceSortService;
 
     private final Long tripId = 1L;
     private final int day = 1;
@@ -184,5 +188,23 @@ public class TripPlaceEditingControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data[0].name").value("목적지1"))
                 .andExpect(jsonPath("$.data[0].placeCategory").value("식당"));
+    }
+
+    @Test
+    @DisplayName("목적지 순서 추천 정렬 알고리즘 성공")
+    void sortDayTripPlacesSuccess() throws Exception {
+        // given
+        doNothing().when(tripPlaceSortService).sortDayTripPlaces(tripId, day);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                put("/api/v1/trip/{tripId}/days/{day}/places/sort", tripId, day)
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
     }
 }


### PR DESCRIPTION
## 배경
사용자가 담은 목적지를 일차별로 순서를 추천해주는 기능이 필요

## 작업 사항
- 여행 목적지 순서 추천 정렬 알고리즘 구현 (513f403305d55fc013830e9df32dc071f77a1e7a)
    - 이전 이미지를 목적지에 매핑하는 알고리즘에서 사용한 `Haversine 공식` 사용
    - 숙소는 맨 마지막 삽입
    - 식당은 최대 2번이 연속되게 구현
    - 문제점은 아래 `추가 논의`에 작성

## 추가 논의
목적지 순서 추천을 할 때, 거리를 기준으로 먼저 정렬을 한 후, 정렬된 순서에서 `식당`카테고리의 연속됨을 찾아 분배하고 있습니다.
하지만, 정렬된 순서가 `관광지-관광지-관광지-식당-식당-식당-식당` 이라면, 현재 알고리즘에서는 식당 뒤에 다른 카테고리가 없기 때문에 식당이 분배되지 않고 앞의 순서를 그대로 반환하게 됩니다.
이것에 대해서는 식당과 나머지 카테고리에 대해서 따로 분류하여 거리를 기반으로 정렬을 한 후, 라운드 로빈 형식으로 차례차례 삽입을 할까 고민했지만, 의도적으로 한쪽에는 식당, 한쪽에는 다른 카테고리를 모아둔다면 거리 순서가 크게 어긋나고사용자가 보기에도 경로가 비효율적으로 왔다 갔다 하는 결과가 발생할 수 있어 현재의 알고리즘으로 짜보았습니다.