### PR TITLE
Refactor: 목적지 순서 변경 및 삽입 로직 변경

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceReq.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceReq.java
@@ -57,11 +57,7 @@ public class TripPlaceReq {
             @Schema(description = "경도", example = "126.98")
             double longitude,
             @Schema(description = "장소 타입", example = "관광명소")
-            String placeType,
-            @Schema(description = "이전 목적지 ID (nullable)", example = "prevId")
-            String prevPlaceId,
-            @Schema(description = "다음 목적지 ID (nullable)", example = "nextId")
-            String nextPlaceId
+            String placeType
     ) {
         public Place toEntity(Double order) {
             return Place.builder()

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandService.java
@@ -29,7 +29,7 @@ public class TripPlaceCommandService {
      */
     public void addNewPlace(String tripDayPlaceId, TripPlaceReq.InsertRequest insertRequest) {
         Double maxPlaceOrder = tripDayPlaceService.readMaxOrderById(tripDayPlaceId);
-        System.out.println(maxPlaceOrder);
+
         tripDayPlaceService.savePlace(
                 tripDayPlaceId,
                 createPlace(insertRequest, maxPlaceOrder)
@@ -38,7 +38,7 @@ public class TripPlaceCommandService {
 
     /**
      * 목적지 객체를 만드는 메서드
-     * 현재 목적지 order 최대값 기준으로 값을 기반으로 새로운 order를 계산하여 새로운 Place 객체를 생성
+     * 현재 목적지 order 최대값 기반으로 새로운 order를 계산하여 새로운 Place 객체를 생성
      * 1. maxPlaceOrder : 0.0 => 존재하는 목적지가 없는 상황
      * 2. maxPlaceOrder : 0.0 x => 마지막 목적지 뒤에 추가하는 상화
      *

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandService.java
@@ -22,64 +22,32 @@ public class TripPlaceCommandService {
 
     /**
      * 여행 일차에 새로운 목적지를 삽입 메서드
-     * 삽입 위치는 prevPlaceId, nextPlaceId를 기준으로 order를 계산하여 결정
+     * 삽입 위치는 현재 목적지 order 중 최대값을 기준으로 order를 계산하여 결정
      *
-     * @param tripPlaceId   여행 일차(TripDayPlace)의 ID
-     * @param insertRequest 삽입할 장소 정보 및 위치 기준 정보
+     * @param tripDayPlaceId 여행 일차(TripDayPlace)의 ID
+     * @param insertRequest  삽입할 장소 정보 및 위치 기준 정보
      */
-    public void addNewPlace(String tripPlaceId, TripPlaceReq.InsertRequest insertRequest) {
-        Double prevPlaceOrder = getPlaceOrder(tripPlaceId, insertRequest.prevPlaceId());
-        Double nextPlaceOrder = getPlaceOrder(tripPlaceId, insertRequest.nextPlaceId());
-
+    public void addNewPlace(String tripDayPlaceId, TripPlaceReq.InsertRequest insertRequest) {
+        Double maxPlaceOrder = tripDayPlaceService.readMaxOrderById(tripDayPlaceId);
+        System.out.println(maxPlaceOrder);
         tripDayPlaceService.savePlace(
-                tripPlaceId,
-                createPlace(insertRequest, prevPlaceOrder, nextPlaceOrder)
+                tripDayPlaceId,
+                createPlace(insertRequest, maxPlaceOrder)
         );
     }
 
     /**
-     * 목적지의 순서(order)를 반환하는 메서드
-     * - 주어진 placeId가 존재할 경우, 해당 place의 order 값을 반환
-     *
-     * @param tripPlaceId 여행 일차 ID
-     * @param placeId     참조할 목적지 ID (nullable)
-     * @return order 값 또는 null
-     */
-    private Double getPlaceOrder(String tripPlaceId, String placeId) {
-        if (placeId != null) {
-            return tripDayPlaceService.readOrderByIdAndPlaceId(tripPlaceId, placeId);
-        }
-
-        return null;
-    }
-
-    /**
      * 목적지 객체를 만드는 메서드
-     * 삽입 기준이 되는 prev/next order 값을 기반으로 새로운 order를 계산하여 새로운 Place 객체를 생성
-     * 1. prev/next 모두 null => 존재하는 목적지가 없는 상황
-     * 2. prev가 null => 목적지를 가장 앞에 추가하는 상황
-     * 3. next가 null => 목적지를 가장 뒤에 추가하는 상황
-     * 4. prev/next 모두 null x => 목적지 사이에 추가하는 상황
+     * 현재 목적지 order 최대값 기준으로 값을 기반으로 새로운 order를 계산하여 새로운 Place 객체를 생성
+     * 1. maxPlaceOrder : 0.0 => 존재하는 목적지가 없는 상황
+     * 2. maxPlaceOrder : 0.0 x => 마지막 목적지 뒤에 추가하는 상화
      *
-     * @param insertRequest  사용자 요청 정보
-     * @param prevPlaceOrder 이전 목적지의 order 값 (nullable)
-     * @param nextPlaceOrder 다음 목적지의 order 값 (nullable)
+     * @param insertRequest 사용자 요청 정보
+     * @param maxPlaceOrder 현재 목적지 order 중 최대값 (nullable)
      * @return 생성된 Place 객체
      */
-    private Place createPlace(TripPlaceReq.InsertRequest insertRequest, Double prevPlaceOrder, Double nextPlaceOrder) {
-        if (prevPlaceOrder == null && nextPlaceOrder == null) {
-            return insertRequest.toEntity(10.0);
-        }
-
-        if (prevPlaceOrder == null) {
-            return insertRequest.toEntity(nextPlaceOrder / 2);
-        }
-
-        if (nextPlaceOrder == null) {
-            return insertRequest.toEntity(prevPlaceOrder + 10.0);
-        }
-
-        return insertRequest.toEntity((prevPlaceOrder + nextPlaceOrder) / 2);
+    private Place createPlace(TripPlaceReq.InsertRequest insertRequest, Double maxPlaceOrder) {
+        return insertRequest.toEntity(maxPlaceOrder + 10.0);
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingService.java
@@ -8,7 +8,11 @@ import kr.co.yeogiga.infrastructure.redis.constant.PlaceConstant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * 여행 생성 단계에서 사용자들이 선택한 "목적지"들을 임시 저장하고 관리하는 서비스 클래스.
@@ -96,26 +100,61 @@ public class TripPlaceEditingService {
     }
 
     /**
-     * 편집 중인 여행 일정의 목적지를 수정하는 메서드 (목적지의 새로운 순서로 덮어쓰기 등)
+     * 편집 중인 여행 일정의 목적지 순서를 수정하는 메서드
      * - 기존 List & Set 모두 삭제
      * - 새로운 순서대로 List & Set에 저장
      *
-     * @param tripId : 여행 ID
-     * @param day    : 여행 일차
-     * @param places : 새로운 순서의 TripPlaceDto.Request 리스트
+     * @param tripId         여행 ID
+     * @param day            여행 일차
+     * @param reorderRequest 재정렬할 목적지 ID 리스트
      */
-    public void updatePlaces(Long tripId, int day, List<TripPlaceReq.Request> places) {
+    public void reorderPlaces(Long tripId, int day, TripPlaceReq.ReorderRequest reorderRequest) {
         String dayPlacesKey = PlaceConstant.dayPlacesKey(tripId, day);
         String dayPlaceSetKey = PlaceConstant.dayPlaceSetKey(tripId, day);
+
+        List<TripPlaceReq.StoredFormat> storedPlaces =
+                redisRepository.getList(dayPlacesKey, TripPlaceReq.StoredFormat.class);
+
+        if (storedPlaces == null || storedPlaces.isEmpty()) {
+            return;
+        }
+
+        Map<String, TripPlaceReq.StoredFormat> placeMap = storedPlaces.stream()
+                .collect(Collectors.toMap(TripPlaceReq.StoredFormat::id, Function.identity()));
+
+        // 요청한 정렬 순서에 맞게 목적지 재정렬
+        List<TripPlaceReq.StoredFormat> reordered =
+                buildReorderedPlaces(reorderRequest.orderedPlaceIds(), placeMap);
 
         redisRepository.del(dayPlacesKey);
         redisRepository.del(dayPlaceSetKey);
 
-        for (TripPlaceReq.Request place : places) {
-            redisRepository.setList(dayPlacesKey, place.toStoredFormat());
+        for (TripPlaceReq.StoredFormat place : reordered) {
+            redisRepository.setList(dayPlacesKey, place);
             String placeUniqueKey = makeUniqueKey(place.name(), place.latitude(), place.longitude());
             redisRepository.addToSet(dayPlaceSetKey, placeUniqueKey);
         }
+    }
+
+    /**
+     * 목적지를 정렬하여 반환하는 메서드
+     *
+     * @param orderedIds 정렬된 Place ID 목록
+     * @param placeMap   ID 기준 Place 매핑 정보
+     * @return 재정렬된 Place 리스트
+     */
+    private List<TripPlaceReq.StoredFormat> buildReorderedPlaces(
+            List<String> orderedIds,
+            Map<String, TripPlaceReq.StoredFormat> placeMap
+    ) {
+        List<TripPlaceReq.StoredFormat> reordered = new ArrayList<>();
+
+        for (String placeId : orderedIds) {
+            TripPlaceReq.StoredFormat place = placeMap.get(placeId);
+            reordered.add(place);
+        }
+
+        return reordered;
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
@@ -1,6 +1,5 @@
 package kr.co.yeogiga.domain.tripplace.repository;
 
-import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
@@ -12,7 +11,7 @@ public interface CustomTripDayPlaceRepository {
     void savePlace(String id, Place place);
     void saveImage(String id, String placeId, Image image);
     void saveImageToUnmatched(String id, Image image);
-    Double findOrderByIdAndPlaceId(String id, String placeId);
+    Double findMaxOrderById(String id);
     Optional<TripDayPlace> findByIdSorted(String id);
     List<TripDayPlace> findByTripIdSorted(Long tripId);
     Optional<Place> findPlaceByIdAndPlaceId(String id, String placeId);

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
@@ -1,6 +1,5 @@
 package kr.co.yeogiga.domain.tripplace.repository;
 
-import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
@@ -47,20 +46,19 @@ public class CustomTripDayPlaceRepositoryImpl implements CustomTripDayPlaceRepos
     }
 
     @Override
-    public Double findOrderByIdAndPlaceId(String id, String placeId) {
-        Query query = new Query(
-                Criteria.where("_id").is(id)
-                        .and("places.id").is(placeId)
+    public Double findMaxOrderById(String id) {
+        Aggregation aggregation = Aggregation.newAggregation(
+                Aggregation.match(Criteria.where("_id").is(id)),
+                Aggregation.unwind("places"),
+                Aggregation.sort(Sort.by(Sort.Direction.DESC, "places.order")),
+                Aggregation.limit(1),
+                Aggregation.project().and("places.order").as("order")
         );
 
-        query.fields().include("places.$");
-        TripDayPlace result = mongoTemplate.findOne(query, TripDayPlace.class);
+        Document doc = mongoTemplate.aggregate(aggregation, "trip_day_place", Document.class)
+                .getUniqueMappedResult();
 
-        if (result == null || result.getPlaces().isEmpty()) {
-            throw new RuntimeException("Place not found");
-        }
-
-        return result.getPlaces().get(0).getOrder();
+        return doc != null ? doc.getDouble("order") : 0.0;
     }
 
     @Override

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
@@ -47,8 +47,8 @@ public class TripDayPlaceService {
         return tripDayPlaceRepository.findByTripIdSorted(tripId);
     }
 
-    public Double readOrderByIdAndPlaceId(String id, String placeId) {
-        return tripDayPlaceRepository.findOrderByIdAndPlaceId(id, placeId);
+    public Double readMaxOrderById(String id) {
+        return tripDayPlaceRepository.findMaxOrderById(id);
     }
 
     public Optional<Place> readPlaceByIdAndPlaceId(String id, String placeId) {

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/api/TripPlaceEditingApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/api/TripPlaceEditingApi.java
@@ -91,7 +91,7 @@ public interface TripPlaceEditingApi {
 
     @TrackApi(description = "일차별 목적지의 순서를 수정 (이 과정에서 목적지 삭제도 가능)")
     @Operation(summary = "일차별 목적지의 순서를 수정 (이 과정에서 목적지 삭제도 가능)", description = "일차별 목적지의 순서를 수정하는 API입니다." +
-            "<br/> 예를 들어, 기존 순서가 (a, b, c, d, e)이고, 순서를 (b, c, a, d, e)로 바꾼다면 바뀐 순서에 대한 목적지 정보들을 List형식으로 담아 보내면 됩니다." +
+            "<br/> 예를 들어, 기존 순서가 (a, b, c, d, e)이고, 순서를 (b, c, a, d, e)로 바꾼다면 바뀐 순서에 대한 목적지 id를 List형식으로 바꿔 보내면 됩니다." +
             "<br/> 삭제도 가능하다는 말은, (a, b, c, d, e)에서 (b, c, e, d)로 바꿔서 보낸다면 a는 자동으로 삭제됩니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "목적지 수정 성공",
@@ -104,15 +104,15 @@ public interface TripPlaceEditingApi {
                                     """)
                     }))
     })
-    ResponseEntity<?> updatePlaces(
+    ResponseEntity<?> reorderPlaces(
             @Parameter(description = "여행 ID")
             @PathVariable Long tripId,
 
             @Parameter(description = "수정하고자 하는 일차")
             @PathVariable int day,
 
-            @Parameter(description = "변경된 순서로의 목적지 정보 리스트")
-            @RequestBody List<TripPlaceReq.Request> requests
+            @Parameter(description = "변경된 순서로의 목적지 ID 리스트")
+            @RequestBody TripPlaceReq.ReorderRequest request
     );
 
     @TrackApi(description = "일차에 지정된 목적지 삭제")

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingController.java
@@ -16,8 +16,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/v1/trip")
 @RequiredArgsConstructor

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingController.java
@@ -44,11 +44,11 @@ public class TripPlaceEditingController implements TripPlaceEditingApi {
 
     @Override
     @PutMapping("/{tripId}/days/{day}/places")
-    public ResponseEntity<?> updatePlaces(@PathVariable Long tripId,
+    public ResponseEntity<?> reorderPlaces(@PathVariable Long tripId,
                                           @PathVariable int day,
-                                          @RequestBody List<TripPlaceReq.Request> requests) {
+                                          @RequestBody TripPlaceReq.ReorderRequest request) {
 
-        tripPlaceEditingService.updatePlaces(tripId, day, requests);
+        tripPlaceEditingService.reorderPlaces(tripId, day, request);
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandServiceTest.java
@@ -49,34 +49,12 @@ public class TripPlaceCommandServiceTest {
         @DisplayName("가장 처음 추가되는 경우 - 기존에 목적지 없는 상태")
         void addPlaceFirst() {
             // given
+            given(tripDayPlaceService.readMaxOrderById(tripDayPlaceId)).willReturn(0.0);
             TripPlaceReq.InsertRequest insertRequest = TripPlaceReq.InsertRequest.builder()
                     .name("목적지1")
                     .latitude(0.0)
                     .longitude(0.0)
                     .placeType("카페")
-                    .build();
-
-            // when
-            tripPlaceCommandService.addNewPlace(tripDayPlaceId, insertRequest);
-
-            // then
-            verify(tripDayPlaceService).savePlace(eq(tripDayPlaceId), placeCaptor.capture());
-
-            Place captured = placeCaptor.getValue();
-            assertEquals(10.0, captured.getOrder());
-        }
-
-        @Test
-        @DisplayName("가장 앞에 추가되는 경우")
-        void addPlaceFront() {
-            // given
-            given(tripDayPlaceService.readOrderByIdAndPlaceId(tripDayPlaceId, "nextId")).willReturn(20.0);
-            TripPlaceReq.InsertRequest insertRequest = TripPlaceReq.InsertRequest.builder()
-                    .name("목적지1")
-                    .latitude(0.0)
-                    .longitude(0.0)
-                    .placeType("카페")
-                    .nextPlaceId("nextId")
                     .build();
 
             // when
@@ -93,13 +71,12 @@ public class TripPlaceCommandServiceTest {
         @DisplayName("가장 뒤에 추가되는 경우")
         void addPlaceBack() {
             // given
-            given(tripDayPlaceService.readOrderByIdAndPlaceId(tripDayPlaceId, "prevId")).willReturn(20.0);
+            given(tripDayPlaceService.readMaxOrderById(tripDayPlaceId)).willReturn(20.0);
             TripPlaceReq.InsertRequest insertRequest = TripPlaceReq.InsertRequest.builder()
                     .name("목적지1")
                     .latitude(0.0)
                     .longitude(0.0)
                     .placeType("카페")
-                    .prevPlaceId("prevId")
                     .build();
 
             // when
@@ -112,31 +89,6 @@ public class TripPlaceCommandServiceTest {
             assertEquals(30.0, captured.getOrder());
         }
 
-        @Test
-        @DisplayName("중간에 추가되는 경우")
-        void addPlaceBetween() {
-            // given
-            given(tripDayPlaceService.readOrderByIdAndPlaceId(tripDayPlaceId, "prevId")).willReturn(10.0);
-            given(tripDayPlaceService.readOrderByIdAndPlaceId(tripDayPlaceId, "nextId")).willReturn(30.0);
-
-            TripPlaceReq.InsertRequest insertRequest = TripPlaceReq.InsertRequest.builder()
-                    .name("목적지1")
-                    .latitude(0.0)
-                    .longitude(0.0)
-                    .placeType("카페")
-                    .prevPlaceId("prevId")
-                    .nextPlaceId("nextId")
-                    .build();
-
-            // when
-            tripPlaceCommandService.addNewPlace(tripDayPlaceId, insertRequest);
-
-            // then
-            verify(tripDayPlaceService).savePlace(eq(tripDayPlaceId), placeCaptor.capture());
-
-            Place captured = placeCaptor.getValue();
-            assertEquals(20.0, captured.getOrder());
-        }
     }
 
 

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingServiceTest.java
@@ -128,31 +128,28 @@ public class TripPlaceEditingServiceTest {
 
     @Test
     @DisplayName("목적지 순서 수정 성공")
-    void updatePlacesInEditingSuccess() {
+    void reorderPlacesInEditingSuccess() {
         // given
-        TripPlaceReq.Request place1 = TripPlaceReq.Request.builder()
-                .name("목적지1")
-                .latitude(0.0)
-                .longitude(0.0)
-                .placeType("카페")
-                .build();
+        List<TripPlaceReq.StoredFormat> storedPlace = List.of(
+                new TripPlaceReq.StoredFormat("place1-id", "목적지1", 33.1, 126.1, PlaceCategory.CAFE.getGroupName()),
+                new TripPlaceReq.StoredFormat("place2-id", "목적지2", 33.2, 126.2, PlaceCategory.CAFE.getGroupName()),
+                new TripPlaceReq.StoredFormat("place3-id", "목적지3", 33.3, 126.3, PlaceCategory.CAFE.getGroupName())
+        );
 
-        TripPlaceReq.Request place2 = TripPlaceReq.Request.builder()
-                .name("목적지2")
-                .latitude(0.0)
-                .longitude(0.0)
-                .placeType("카페")
-                .build();
+        TripPlaceReq.ReorderRequest request =
+                new TripPlaceReq.ReorderRequest(List.of("place3-id", "place1-id", "place2-id"));
 
-        List<TripPlaceReq.Request> newPlaces = List.of(place2, place1);
+        String listKey = "trip:1:day:1:places";
+
+        given(redisRepository.getList(listKey, TripPlaceReq.StoredFormat.class)).willReturn(storedPlace);
 
         // when
-        tripPlaceEditingService.updatePlaces(tripId, day, newPlaces);
+        tripPlaceEditingService.reorderPlaces(tripId, day, request);
 
         // then
         verify(redisRepository, times(2)).del(anyString());
-        verify(redisRepository, times(2)).setList(anyString(), any(TripPlaceReq.StoredFormat.class));
-        verify(redisRepository, times(2)).addToSet(anyString(), anyString());
+        verify(redisRepository, times(3)).setList(anyString(), any(TripPlaceReq.StoredFormat.class));
+        verify(redisRepository, times(3)).addToSet(anyString(), anyString());
     }
 
     @Test

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceControllerTest.java
@@ -105,8 +105,6 @@ public class TripPlaceControllerTest {
                 .latitude(0.0)
                 .longitude(0.0)
                 .placeType("카페")
-                .prevPlaceId("prevId")
-                .nextPlaceId("nextId")
                 .build();
         doNothing().when(tripPlaceCommandService).addNewPlace(tripDayPlaceId, insertRequest);
 

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingControllerTest.java
@@ -123,20 +123,18 @@ public class TripPlaceEditingControllerTest {
 
     @Test
     @DisplayName("목적지 수정 성공")
-    void updatePlacesSuccess() throws Exception {
+    void reorderPlacesSuccess() throws Exception {
         // given
-        List<TripPlaceReq.Request> requests = List.of(
-                TripPlaceReq.Request.builder().name("목적지1").latitude(0.0).longitude(0.0).placeType("관광명소").build(),
-                TripPlaceReq.Request.builder().name("목적지2").latitude(0.0).longitude(0.0).placeType("카페").build()
-        );
+        TripPlaceReq.ReorderRequest request =
+                new TripPlaceReq.ReorderRequest(List.of("place3-id", "place1-id", "place2-id"));
 
-        doNothing().when(tripPlaceEditingService).updatePlaces(anyLong(), anyInt(), Mockito.anyList());
+        doNothing().when(tripPlaceEditingService).reorderPlaces(anyLong(), anyInt(), any());
 
         // when
         ResultActions resultActions = mockMvc.perform(
                 put("/api/v1/trip/{tripId}/days/{day}/places", tripId, day)
                         .contentType(APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(requests))
+                        .content(objectMapper.writeValueAsString(request))
         );
 
         // then


### PR DESCRIPTION
## 배경
목적지 확정 전, 목적지 순서 변경 로직을 통일성 있게 변경 (목적지 매핑 후의 목적지 변경 로직과 통일성)
목적지 확정 후, 목적지 삽입 로직 단순화 

## 작업 사항
- 목적지 확정 전
    - 목적지 순서 변경 로직 변경 (8bfb89e915f8c5d7bf9ac5832e6b0a75bc6a0a5f)
        - 변경된 목적지 id 전체 리스트를 보내면 그에 맞게 정렬하도록 수정

- 목적지 확정 후
    - 목적지 삽입 로직 단순화 (65483d2384588bb4d14de503f42bc07689d21e21)
        - 기존에는 삽입된 목적지 위치에서 앞, 뒤 목적지의 id를 기반으로 order 삽입
        - => 현재는 목적지들 중 가장 큰 order를 기준으로 order 삽입 (98a5561975f1ff99dafbf8a490fa648a2c572688)

## 추가 논의
x