### PR TITLE
Feature(IL-155): 사용자 프로필 업로드

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/image/dto/ImageUploadRequest.java
+++ b/src/main/java/kr/co/yeogiga/application/image/dto/ImageUploadRequest.java
@@ -23,6 +23,14 @@ public class ImageUploadRequest {
             long size,
             Long userId
     ) {
+        public static ProfileImage from(MultipartFile file, Long userId) throws IOException {
+            return new ProfileImage(
+                    file.getBytes(), file.getOriginalFilename(),
+                    file.getContentType(), file.getSize(),
+                    userId
+            );
+        }
+
         public AwsUploadInfo toAwsUploadInfo() {
             return AwsUploadInfo.builder()
                     .bytes(bytes)

--- a/src/main/java/kr/co/yeogiga/application/image/dto/ImageUploadRequest.java
+++ b/src/main/java/kr/co/yeogiga/application/image/dto/ImageUploadRequest.java
@@ -1,22 +1,67 @@
 package kr.co.yeogiga.application.image.dto;
 
+import lombok.Builder;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 
-public record ImageUploadRequest(
-        byte[] bytes,
-        String originalFilename,
-        String contentType,
-        long size,
-        Long tripId,
-        String tripDayPlaceId
-) {
-    public static ImageUploadRequest from(MultipartFile file, Long tripId, String tripDayPlaceId) throws IOException {
-        return new ImageUploadRequest(
-                file.getBytes(), file.getOriginalFilename(),
-                file.getContentType(), file.getSize(),
-                tripId, tripDayPlaceId
-        );
+public class ImageUploadRequest {
+
+    @Builder
+    public record AwsUploadInfo(
+            byte[] bytes,
+            String originalFilename,
+            String contentType,
+            long size,
+            Long id
+    ) { }
+
+    public record ProfileImage(
+            byte[] bytes,
+            String originalFilename,
+            String contentType,
+            long size,
+            Long userId
+    ) {
+        public AwsUploadInfo toAwsUploadInfo() {
+            return AwsUploadInfo.builder()
+                    .bytes(bytes)
+                    .originalFilename(originalFilename)
+                    .contentType(contentType)
+                    .size(size)
+                    .id(userId)
+                    .build();
+        }
+    }
+
+    public record TripImage(
+            byte[] bytes,
+            String originalFilename,
+            String contentType,
+            long size,
+            Long tripId,
+            String tripDayPlaceId
+    ) {
+        public static TripImage from(MultipartFile file, Long tripId, String tripDayPlaceId) throws IOException {
+            return new TripImage(
+                    file.getBytes(), file.getOriginalFilename(),
+                    file.getContentType(), file.getSize(),
+                    tripId, tripDayPlaceId
+            );
+        }
+
+        public AwsUploadInfo toAwsUploadInfo() {
+            return AwsUploadInfo.builder()
+                    .bytes(bytes)
+                    .originalFilename(originalFilename)
+                    .contentType(contentType)
+                    .size(size)
+                    .id(tripId)
+                    .build();
+        }
+    }
+
+    public enum ImageType {
+        TRIP, PROFILE
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/image/service/ImageProcessingService.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/ImageProcessingService.java
@@ -26,13 +26,13 @@ public class ImageProcessingService {
      * @param imageUploadRequest 업로드할 이미지 및 관련 정보가 담긴 DTO
      */
     @Async
-    public void processImageUpload(ImageUploadRequest imageUploadRequest) {
+    public void processImageUpload(ImageUploadRequest.TripImage imageUploadRequest) {
         try {
             ImageMetadataDto metadata = imageMetadataService.extractMetadata(
                     imageUploadRequest.bytes(), imageUploadRequest.originalFilename()
             );
 
-            String url = awsS3Storage.upload(imageUploadRequest);
+            String url = awsS3Storage.upload(imageUploadRequest.toAwsUploadInfo(), ImageUploadRequest.ImageType.TRIP);
 
             Image image = Image.builder()
                     .url(url)

--- a/src/main/java/kr/co/yeogiga/application/image/service/ImageProcessingService.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/ImageProcessingService.java
@@ -3,11 +3,16 @@ package kr.co.yeogiga.application.image.service;
 import kr.co.yeogiga.application.image.dto.ImageMetadataDto;
 import kr.co.yeogiga.application.image.dto.ImageUploadRequest;
 import kr.co.yeogiga.domain.tripplace.entity.Image;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.service.UserService;
 import kr.co.yeogiga.infrastructure.s3.AwsS3Storage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -16,6 +21,7 @@ public class ImageProcessingService {
     private final ImageMetadataService imageMetadataService;
     private final AwsS3Storage awsS3Storage;
     private final TempPlaceImagesCommandService tempPlaceImagesCommandService;
+    private final UserService userService;
 
     /**
      * 이미지 업로드 및 메타데이터 추출을 비동기로 처리하는 메서드.
@@ -46,5 +52,24 @@ public class ImageProcessingService {
         } catch (Exception e) {
             log.error("Error processing image - filename: {}", imageUploadRequest.originalFilename(), e);
         }
+    }
+
+    /**
+     * 사용자 프로필 이미지 업로드 및 사용자 프로필 정보 갱신을 비동기로 처리하는 메서드
+     *
+     * @param imageUploadRequest 업로드할 사용자 프로필 이미지 및 관련 정보가 담긴 DTO
+     */
+    @Async
+    @Transactional
+    public void processProfileImageUpload(ImageUploadRequest.ProfileImage imageUploadRequest) {
+        Optional<User> user = userService.readById(imageUploadRequest.userId());
+
+        if (user.isEmpty()) return;
+
+        awsS3Storage.deleteImage(user.get().getImageUrl());
+
+        String url = awsS3Storage.upload(imageUploadRequest.toAwsUploadInfo(), ImageUploadRequest.ImageType.PROFILE);
+
+        user.get().updateProfileImageUrl(url);
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/image/service/ImageUploadProcessor.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/ImageUploadProcessor.java
@@ -1,6 +1,8 @@
 package kr.co.yeogiga.application.image.service;
 
 import kr.co.yeogiga.application.image.dto.ImageUploadRequest;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.tripplace.exception.ImageErrorType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -8,6 +10,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -32,5 +35,34 @@ public class ImageUploadProcessor {
                 log.error("Failed to process image - filename: {}", image.getOriginalFilename(), e);
             }
         }
+    }
+
+    /**
+     * 사용자 프로필 MultiPartFile 이미지를 받아 비동기 업로드 처리 메서드
+     *
+     * @param image         : 업로드 대상 이미지
+     * @param userId        : 사용자 ID
+     */
+    public void uploadProfileImage(MultipartFile image, Long userId) {
+        try {
+            if (!isValidImage(image)) {
+                throw new CustomException(ImageErrorType.IMAGE_REQUIRED);
+            }
+
+            ImageUploadRequest.ProfileImage imageUploadRequest = ImageUploadRequest.ProfileImage.from(image, userId);
+            imageProcessingService.processProfileImageUpload(imageUploadRequest);
+        } catch (IOException e) {
+            log.error("Failed to process profile image - filename: {}", image.getOriginalFilename(), e);
+        }
+    }
+
+    /**
+     * 이미지 유효성 검사 메서드
+     *
+     * @param image         : 이미지 파일
+     * @return              : 이미지 유효성 여부
+     */
+    private boolean isValidImage(MultipartFile image) {
+        return Objects.nonNull(image) && !image.getOriginalFilename().isEmpty();
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/image/service/ImageUploadProcessor.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/ImageUploadProcessor.java
@@ -26,7 +26,7 @@ public class ImageUploadProcessor {
     public void process(List<MultipartFile> images, Long tripId, String tripDayPlaceId) {
         for (MultipartFile image : images) {
             try {
-                ImageUploadRequest imageUploadRequest = ImageUploadRequest.from(image, tripId, tripDayPlaceId);
+                ImageUploadRequest.TripImage imageUploadRequest = ImageUploadRequest.TripImage.from(image, tripId, tripDayPlaceId);
                 imageProcessingService.processImageUpload(imageUploadRequest);
             } catch (IOException e) {
                 log.error("Failed to process image - filename: {}", image.getOriginalFilename(), e);

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/exception/ImageErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/exception/ImageErrorType.java
@@ -11,7 +11,9 @@ import org.springframework.http.HttpStatus;
 public enum ImageErrorType implements BaseErrorType {
 
     TEMP_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "I000", "임시 저장된 이미지가 존재하지 않습니다."),
-    NOT_FOUND(HttpStatus.NOT_FOUND, "I001", "해당 이미지가 존재하지 않습니다.")
+    NOT_FOUND(HttpStatus.NOT_FOUND, "I001", "해당 이미지가 존재하지 않습니다."),
+
+    IMAGE_REQUIRED(HttpStatus.BAD_REQUEST, "I002", "이미지는 필수 입력값입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -92,4 +92,8 @@ public class User extends BaseTimeEntity {
     public void clearFcmToken() {
         this.fcmToken = null;
     }
+
+    public void updateProfileImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/kr/co/yeogiga/infrastructure/s3/AwsS3Storage.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/s3/AwsS3Storage.java
@@ -26,10 +26,14 @@ public class AwsS3Storage {
      * @param imageUploadRequest : 업로드할 이미지 정보가 담긴 DTO
      * @return 업로드된 이미지의 S3 URL
      */
-    public String upload(ImageUploadRequest imageUploadRequest) {
+    public String upload(
+            ImageUploadRequest.AwsUploadInfo imageUploadRequest,
+            ImageUploadRequest.ImageType imageType
+    ) {
         String fileName = generateFileName(
+                imageType,
                 imageUploadRequest.originalFilename(),
-                imageUploadRequest.tripId()
+                imageUploadRequest.id()
         );
         ObjectMetadata metadata = createObjectMetadata(
                 imageUploadRequest.contentType(),
@@ -62,8 +66,13 @@ public class AwsS3Storage {
      * @param id               : 이미지가 속한 DB PK값
      * @return S3에 저장할 파일 경로
      */
-    private String generateFileName(String originalFileName, Long id) {
-        return "image/" + id + "/" + UUID.randomUUID() + "-" + originalFileName;
+    private String generateFileName(ImageUploadRequest.ImageType imageType, String originalFileName, Long id) {
+        String rootDir = switch (imageType) {
+            case TRIP -> "image/";
+            case PROFILE -> "profile/";
+        };
+
+        return rootDir +  id + "/" + UUID.randomUUID() + "-" + originalFileName;
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/infrastructure/s3/AwsS3Storage.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/s3/AwsS3Storage.java
@@ -68,7 +68,7 @@ public class AwsS3Storage {
      */
     private String generateFileName(ImageUploadRequest.ImageType imageType, String originalFileName, Long id) {
         String rootDir = switch (imageType) {
-            case TRIP -> "image/";
+            case TRIP -> "trip/";
             case PROFILE -> "profile/";
         };
 

--- a/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.presentation.user.api;
 import api.link.checker.annotation.ApiGroup;
 import api.link.checker.annotation.TrackApi;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -17,6 +18,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 
 @ApiGroup(value = "[사용자 관련 API]")
 @Tag(name = "[사용자 관련 API]", description = "사용지 관련 API")
@@ -182,6 +185,35 @@ public interface UserApi {
     ResponseEntity<?> update(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody UserInfoUpdateReq userInfoUpdateReq
+    );
+
+    @TrackApi(description = "사용자 프로필 등록 및 수정")
+    @Operation(summary = "사용자 프로필 등록 및 수정", description = "사용자 프로필 등록 및 수정 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사용자 프로필 등록 및 수정 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "성공", value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "회원 정보 수정 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "이미지를 첨부하지 않은 경우", value = """
+                                        {
+                                             "code": "I002",
+                                             "message": "이미지는 필수 입력값입니다."
+                                         }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> updateProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+
+            @Parameter(description = "업로드할 이미지")
+            @RequestPart(name = "image") MultipartFile image
     );
 
     @TrackApi(description = "Fcm Token 저장")

--- a/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
@@ -76,6 +76,7 @@ public class UserController implements UserApi {
         return ResponseEntity.ok().body(SuccessResponse.ok());
     }
 
+    @Override
     @PutMapping("/profile")
     public ResponseEntity<?> updateProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.presentation.user.controller;
 
 import jakarta.validation.Valid;
+import kr.co.yeogiga.application.image.service.ImageUploadProcessor;
 import kr.co.yeogiga.application.user.dto.FcmTokenReq;
 import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
 import kr.co.yeogiga.application.user.dto.UserInfoUpdateReq;
@@ -21,7 +22,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import static kr.co.yeogiga.application.auth.constant.AuthConstants.REFRESH_TOKEN_PREFIX;
 
@@ -31,6 +34,7 @@ import static kr.co.yeogiga.application.auth.constant.AuthConstants.REFRESH_TOKE
 public class UserController implements UserApi {
     private final UserManagementService userManagementService;
     private final UserFcmTokenService userFcmTokenService;
+    private final ImageUploadProcessor imageUploadProcessor;
 
     @Override
     @PatchMapping("/password")
@@ -69,6 +73,15 @@ public class UserController implements UserApi {
             @Valid @RequestBody UserInfoUpdateReq userInfoUpdateReq
     ) {
         userManagementService.updateUserInfo(userDetails.getUserId(), userInfoUpdateReq);
+        return ResponseEntity.ok().body(SuccessResponse.ok());
+    }
+
+    @PutMapping("/profile")
+    public ResponseEntity<?> updateProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestPart(name = "image") MultipartFile image
+    ) {
+        imageUploadProcessor.uploadProfileImage(image, userDetails.getUserId());
         return ResponseEntity.ok().body(SuccessResponse.ok());
     }
 

--- a/src/test/java/kr/co/yeogiga/presentation/user/controller/UserControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/user/controller/UserControllerTest.java
@@ -2,6 +2,7 @@ package kr.co.yeogiga.presentation.user.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.auth.constant.AuthConstants;
+import kr.co.yeogiga.application.image.service.ImageUploadProcessor;
 import kr.co.yeogiga.application.user.dto.FcmTokenReq;
 import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
 import kr.co.yeogiga.application.user.dto.UserInfoRes;
@@ -15,6 +16,7 @@ import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
 import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
+import kr.co.yeogiga.domain.tripplace.exception.ImageErrorType;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.exception.UserErrorType;
 import kr.co.yeogiga.domain.user.type.Role;
@@ -31,6 +33,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -46,6 +49,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -74,6 +78,9 @@ public class UserControllerTest {
 
     @MockBean
     private UserFcmTokenService userFcmTokenService;
+
+    @MockBean
+    private ImageUploadProcessor imageUploadProcessor;
 
     private CustomUserDetails userDetails;
 
@@ -461,6 +468,80 @@ public class UserControllerTest {
             resultActions
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자 프로필 갱신")
+    class UpdateUserProfile {
+
+        @BeforeEach
+        void setUp() {
+            setUpUserDetails(Role.USER);
+        }
+
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            MockMultipartFile mockImage = new MockMultipartFile(
+                    "image",
+                    "test.jpg",
+                    "image/jpeg",
+                    "test image content".getBytes()
+            );
+
+            doNothing().when(imageUploadProcessor).uploadProfileImage(any(), any());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    multipart("/api/v1/users/profile")
+                            .file(mockImage)
+                            .contentType(MediaType.MULTIPART_FORM_DATA)
+                            .with(request -> {
+                                request.setMethod("PUT");
+                                return request;
+                            })
+                            .with(user(userDetails))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(SuccessResponse.ok().code()))
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
+
+        @Test
+        @DisplayName("실패 - 이미지 미업로드")
+        void failIfImageNotUploaded() throws Exception {
+            // given
+            MockMultipartFile mockImage = new MockMultipartFile(
+                    "image",
+                    "",
+                    "image/jpeg",
+                    new byte[]{}
+            );
+
+            doThrow(new CustomException(ImageErrorType.IMAGE_REQUIRED)).when(imageUploadProcessor).uploadProfileImage(any(), any());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    multipart("/api/v1/users/profile")
+                            .file(mockImage)
+                            .contentType(MediaType.MULTIPART_FORM_DATA)
+                            .with(request -> {
+                                request.setMethod("PUT");
+                                return request;
+                            })
+                            .with(user(userDetails))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(ImageErrorType.IMAGE_REQUIRED.getCode()))
+                    .andExpect(jsonPath("$.message").value(ImageErrorType.IMAGE_REQUIRED.getMessage()));
         }
     }
 }


### PR DESCRIPTION
## 배경
- AWS 이미지 업로드용 공통 DTO 사용으로 인한 코드 리팩토링
- 사용자 프로필 업로드 기능 필요

## 작업 사항
- AWS 이미지 업로드용 공통 DTO 사용으로 인한 코드 리팩토링 | (1b49deaafc04b47d7ceb41b2534fcc18fd86e96d), (aa96b2046dc09662f44338d98edf0ba73ae4a4c5)

<br/>

- 사용자 프로필 업로드 로직 구현 | (476a3e3f699d434d6a04fda6144df7c2b047bb79)
	- 사용자는 프로필 업로드 시, AWS 내 기존 프로필 삭제 후 새로운 프로필 이미지 업로드
	- 기존 '사용자 정보 수정' 로직과 예외 처리 등의 불편함이 있어 api 분리

## 추가 논의
### 1. 비동기 처리 로직 + `@Transactional` 메서드 관련
`@Async`를 사용하여 비동기 처리 시 별도의 쓰레드에서 동작하게 되어, 상위 메서드에 정의되어 있는 `@Transactional`이 유효하지 않는다고 하여 `@Async`와 `@Transactional`을 같이 사용하였습니다. (물론, 현재 상위 메서드에 `@Transactional`이 없기는 합니다)

 `userService.save(user)`로 갱신할지 고민하였지만,`User`에 DynamicUpdate 설정 및 유저 프로필 업데이트 로직은 하나뿐이어서 `@Transactional`을 사용하였습니다.

### 2. 메서드명
현재 기존에 있던 `ImageUploadProcessor`와 `ImageProcessingService` 등 여행 이미지 관련 메서드명은 바꾸지 않았습니다.
따라서 아래와 같이 메서드명이 불확실한 부분이 있습니다. 
```java
public class ImageUploadProcessor {
    private final ImageProcessingService imageProcessingService;

	// 기존에 있던 여행 이미지 업로드 메서드
    public void process(List<MultipartFile> images, Long tripId, String tripDayPlaceId) {
		// ...
    }
	// 새로 추가된 사용자 프로필 업로드 메서드
    public void uploadProfileImage(MultipartFile image, Long userId) {
		// ...
    }
}
```

변경이 필요할 것 같기는하나, 초기 PR에서 메서드명을 바꾸면 테스트 코드 등의 변경으로 크기가 너무 커질 것 같아 코드 리뷰 후 의견 여쭤보고 바꿀 계획입니다!

