### PR TITLE
Refact: 여행 관련 이미지 처리 메서드명 및 주석 변경

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/image/service/ImageProcessingService.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/ImageProcessingService.java
@@ -33,25 +33,20 @@ public class ImageProcessingService {
      */
     @Async
     public void processTripImageUpload(ImageUploadRequest.TripImage imageUploadRequest) {
-        try {
-            ImageMetadataDto metadata = imageMetadataService.extractMetadata(
-                    imageUploadRequest.bytes(), imageUploadRequest.originalFilename()
-            );
+        ImageMetadataDto metadata = imageMetadataService.extractMetadata(
+                imageUploadRequest.bytes(), imageUploadRequest.originalFilename()
+        );
 
-            String url = awsS3Storage.upload(imageUploadRequest.toAwsUploadInfo(), ImageUploadRequest.ImageType.TRIP);
+        String url = awsS3Storage.upload(imageUploadRequest.toAwsUploadInfo(), ImageUploadRequest.ImageType.TRIP);
 
-            Image image = Image.builder()
-                    .url(url)
-                    .latitude(metadata.latitude())
-                    .longitude(metadata.longitude())
-                    .date(metadata.date())
-                    .build();
+        Image image = Image.builder()
+                .url(url)
+                .latitude(metadata.latitude())
+                .longitude(metadata.longitude())
+                .date(metadata.date())
+                .build();
 
-            tempPlaceImagesCommandService.addImageToTripDayPlace(imageUploadRequest.tripDayPlaceId(), image);
-
-        } catch (Exception e) {
-            log.error("Error processing image - filename: {}", imageUploadRequest.originalFilename(), e);
-        }
+        tempPlaceImagesCommandService.addImageToTripDayPlace(imageUploadRequest.tripDayPlaceId(), image);
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/image/service/ImageProcessingService.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/ImageProcessingService.java
@@ -32,7 +32,7 @@ public class ImageProcessingService {
      * @param imageUploadRequest 업로드할 이미지 및 관련 정보가 담긴 DTO
      */
     @Async
-    public void processImageUpload(ImageUploadRequest.TripImage imageUploadRequest) {
+    public void processTripImageUpload(ImageUploadRequest.TripImage imageUploadRequest) {
         try {
             ImageMetadataDto metadata = imageMetadataService.extractMetadata(
                     imageUploadRequest.bytes(), imageUploadRequest.originalFilename()

--- a/src/main/java/kr/co/yeogiga/application/image/service/ImageProcessingService.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/ImageProcessingService.java
@@ -24,7 +24,7 @@ public class ImageProcessingService {
     private final UserService userService;
 
     /**
-     * 이미지 업로드 및 메타데이터 추출을 비동기로 처리하는 메서드.
+     * 여행 이미지 업로드 및 메타데이터 추출을 비동기로 처리하는 메서드.
      * - 입력 받은 이미지 정보를 기반으로 메타데이터를 추출
      * - 이미지를 S3에 업로드
      * - 업로드된 이미지 이미지 임시 저장소에 저장

--- a/src/main/java/kr/co/yeogiga/application/image/service/ImageUploadProcessor.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/ImageUploadProcessor.java
@@ -19,7 +19,7 @@ public class ImageUploadProcessor {
     private final ImageProcessingService imageProcessingService;
 
     /**
-     * MultipartFile 이미지 리스트를 받아 각각 비동기 업로드 및 메타데이터 추출을 요청메서드
+     * 여행 MultipartFile 이미지 리스트를 받아 각각 비동기 업로드 및 메타데이터 추출을 요청메서드
      * 스프링에서 MultipartFile의 경우 요청 범위 내에서만 유효하기 비동기 처리를 위해서 데이터 추출
      *
      * @param images         : 업로드 대상 이미지 리스트

--- a/src/main/java/kr/co/yeogiga/application/image/service/ImageUploadProcessor.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/ImageUploadProcessor.java
@@ -26,11 +26,11 @@ public class ImageUploadProcessor {
      * @param tripId         : 이미지가 속한 여행 ID
      * @param tripDayPlaceId : 이미지가 속할 여행 일차 ID
      */
-    public void process(List<MultipartFile> images, Long tripId, String tripDayPlaceId) {
+    public void uploadTripImage(List<MultipartFile> images, Long tripId, String tripDayPlaceId) {
         for (MultipartFile image : images) {
             try {
                 ImageUploadRequest.TripImage imageUploadRequest = ImageUploadRequest.TripImage.from(image, tripId, tripDayPlaceId);
-                imageProcessingService.processImageUpload(imageUploadRequest);
+                imageProcessingService.processTripImageUpload(imageUploadRequest);
             } catch (IOException e) {
                 log.error("Failed to process image - filename: {}", image.getOriginalFilename(), e);
             }

--- a/src/main/java/kr/co/yeogiga/infrastructure/s3/AwsS3Storage.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/s3/AwsS3Storage.java
@@ -5,13 +5,14 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import kr.co.yeogiga.application.image.dto.ImageUploadRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.util.UUID;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AwsS3Storage {
@@ -42,8 +43,8 @@ public class AwsS3Storage {
 
         try (ByteArrayInputStream inputStream = new ByteArrayInputStream(imageUploadRequest.bytes())) {
             amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, metadata));
-        } catch (IOException e) {
-            throw new IllegalArgumentException("이미지 업로드 중 오류 발생", e);
+        } catch (Exception e) {
+            log.error("Error while uploading image to AWS S3 - filename : {}", imageUploadRequest.originalFilename(), e);
         }
 
         return getFileUrl(fileName);

--- a/src/main/java/kr/co/yeogiga/presentation/image/controller/ImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/image/controller/ImageController.java
@@ -36,7 +36,7 @@ public class ImageController implements ImageApi {
     public ResponseEntity<?> uploadImages(@RequestPart(value = "images", required = false) List<MultipartFile> images,
                                           @PathVariable Long tripId,
                                           @PathVariable String tripDayPlaceId) {
-        imageUploadProcessor.process(images, tripId, tripDayPlaceId);
+        imageUploadProcessor.uploadTripImage(images, tripId, tripDayPlaceId);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
     }
 


### PR DESCRIPTION
## 배경
- 사용자 프로필 이미지 업로드 기능 추가에 따른 기존 여행 이미지 업로드 관련 메서드명 변경 필요

## 작업 사항
- 여행 이미지 업로드 관련 메서드명 변경 | (b486c95ee15b0025c159cf7271a144eb84b21f3b)
- 여행 이미지 업로드 관련 주석 변경 | (fbd01a936f97ed7fb14e3407e3da763f12143c0d)
- AWS S3 이미지 업로드 중 발생 예외 처리 위치 변경 | (b3d9dc6397b914c1316879dc8421c5fca969976e)