### PR TITLE
Feature(IL-158): 여행 상태 변경 과정 중, FCM Token 저장 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ out/
 
 ### firebase ###
 /src/main/resources/*.json
+
+/src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -72,8 +72,33 @@ dependencies {
 
     /* FCM (Firebase Cloud Messaging) */
     implementation 'com.google.firebase:firebase-admin:9.3.0'
+
+    /* QueryDSL */
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api:2.1.1"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+def querydslDir = 'src/main/generated'
+
+sourceSets {
+    main.java.srcDirs += [querydslDir]
+}
+
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+clean.doLast {
+    file(querydslDir).deleteDir()
+}
+

--- a/src/main/java/kr/co/yeogiga/application/trip/scheduler/TripScheduler.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/scheduler/TripScheduler.java
@@ -12,8 +12,8 @@ import java.time.LocalDateTime;
 public class TripScheduler {
     private final TripCommandService tripCommandService;
 
-    @Scheduled(cron = "0 55 * * * *")
+    @Scheduled(cron = "0 */30 * * * *")
     public void runUpdateTravelStatusJob() {
-        tripCommandService.updateTravelStatus(LocalDateTime.now().plusMinutes(5));
+        tripCommandService.updateTravelStatus(LocalDateTime.now());
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
@@ -2,6 +2,7 @@ package kr.co.yeogiga.application.trip.service;
 
 import kr.co.yeogiga.application.trip.dto.TripReq;
 import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.dto.TripFcmTokenQueryDto;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.entity.TripMember;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
@@ -11,11 +12,18 @@ import kr.co.yeogiga.domain.trip.type.TravelStatus;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.exception.UserErrorType;
 import kr.co.yeogiga.domain.user.service.UserService;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import kr.co.yeogiga.infrastructure.redis.constant.TripMemberTokenConstant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +31,7 @@ public class TripCommandService {
     private final TripService tripService;
     private final TripMemberService tripMemberService;
     private final UserService userService;
+    private final RedisRepository redisRepository;
 
     /**
      * 여행 생성 메서드
@@ -86,13 +95,71 @@ public class TripCommandService {
 
     /**
      * 여행 상태 갱신 메서드
+     * 1. 진행 상태로 변화하는 여행 멤버의 Fcm Token을 Redis에 저장
+     * 2. 조건에 만족하는 여행 상태 데이터 변경
      *
      * @param time      현재 시간
      */
     @Transactional
     public void updateTravelStatus(LocalDateTime time) {
+        List<TripFcmTokenQueryDto> tripFcmTokens = tripService.readTripFcmTokensByTime(time);
+
+        // FCM Token 저장 로직
+        cacheTripFcmTokensToRedis(tripFcmTokens);
+
         tripService.updateAllTravelStatusToInProgress(time);
         tripService.updateAllTravelStatusToCompleted(time);
+    }
+
+    /**
+     * 여행 ID별로 그룹화된 FCM 토큰 목록을 Redis에 저장하는 메서드
+     *
+     * @param tripFcmTokens 시간 조건에 맞는 여행 FCM 토큰 목록
+     */
+    private void cacheTripFcmTokensToRedis(List<TripFcmTokenQueryDto> tripFcmTokens) {
+        Map<Long, List<TripFcmTokenQueryDto>> grouped = tripFcmTokens.stream()
+                .collect(Collectors.groupingBy(TripFcmTokenQueryDto::tripId));
+
+        for (Map.Entry<Long, List<TripFcmTokenQueryDto>> entry : grouped.entrySet()) {
+            Long tripId = entry.getKey();
+            List<TripFcmTokenQueryDto> dtos = entry.getValue();
+
+            if (dtos.isEmpty()) continue;
+
+            saveTripFcmTokensToRedis(tripId, dtos);
+        }
+    }
+
+    /**
+     * 특정 여행 ID에 대한 FCM 토큰 리스트를 Redis에 저장하고 만료 시간 설정 메서드
+     *
+     * @param tripId    여행 ID
+     * @param dtos      해당 여행의 FCM 토큰 및 종료 시간 정보
+     */
+    private void saveTripFcmTokensToRedis(Long tripId, List<TripFcmTokenQueryDto> dtos) {
+        String redisKey = TripMemberTokenConstant.tripTokenKey(tripId);
+
+        // 토큰 리스트 추출
+        List<String> tokens = dtos.stream()
+                .map(TripFcmTokenQueryDto::fcmToken)
+                .filter(Objects::nonNull)
+                .toList();
+
+        // 여행 종료 시간
+        LocalDateTime endedAt = dtos.get(0).endedAt();
+
+        redisRepository.setListAll(redisKey, tokens);
+        redisRepository.expire(redisKey, calculateDuration(endedAt));
+    }
+
+    /**
+     * Redis 만료 기한(TTL)을 계산하는 메서드
+     *
+     * @param time          여행 종료 시간
+     * @return              redis 만료 기한
+     */
+    private Duration calculateDuration(LocalDateTime time) {
+        return Duration.between(LocalDateTime.now(), time);
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingService.java
@@ -129,8 +129,8 @@ public class TripPlaceEditingService {
         redisRepository.del(dayPlacesKey);
         redisRepository.del(dayPlaceSetKey);
 
+        redisRepository.setListAll(dayPlacesKey, reordered);
         for (TripPlaceReq.StoredFormat place : reordered) {
-            redisRepository.setList(dayPlacesKey, place);
             String placeUniqueKey = makeUniqueKey(place.name(), place.latitude(), place.longitude());
             redisRepository.addToSet(dayPlaceSetKey, placeUniqueKey);
         }

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortService.java
@@ -52,9 +52,7 @@ public class TripPlaceSortService {
         sorted.addAll(lodgings);
 
         redisRepository.del(listKey);
-        for (TripPlaceReq.StoredFormat place : sorted) {
-            redisRepository.setList(listKey, place);
-        }
+        redisRepository.setListAll(listKey, sorted);
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/domain/trip/dto/TripFcmTokenQueryDto.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/dto/TripFcmTokenQueryDto.java
@@ -1,0 +1,10 @@
+package kr.co.yeogiga.domain.trip.dto;
+
+import java.time.LocalDateTime;
+
+public record TripFcmTokenQueryDto(
+        Long tripId,
+        String fcmToken,
+        LocalDateTime endedAt
+) {
+}

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripRepository.java
@@ -1,0 +1,10 @@
+package kr.co.yeogiga.domain.trip.repository;
+
+import kr.co.yeogiga.domain.trip.dto.TripFcmTokenQueryDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface CustomTripRepository {
+    List<TripFcmTokenQueryDto> findTripFcmTokensByTime(LocalDateTime time);
+}

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripRepositoryImpl.java
@@ -1,0 +1,43 @@
+package kr.co.yeogiga.domain.trip.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.co.yeogiga.domain.trip.dto.TripFcmTokenQueryDto;
+import kr.co.yeogiga.domain.trip.entity.QTrip;
+import kr.co.yeogiga.domain.trip.entity.QTripMember;
+import kr.co.yeogiga.domain.trip.type.TravelStatus;
+import kr.co.yeogiga.domain.user.entity.QUser;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomTripRepositoryImpl implements CustomTripRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    private final QTrip trip = QTrip.trip;
+    private final QTripMember tripMember = QTripMember.tripMember;
+    private final QUser user = QUser.user;
+
+    @Override
+    public List<TripFcmTokenQueryDto> findTripFcmTokensByTime(LocalDateTime time) {
+        return jpaQueryFactory
+                .select(Projections.constructor(
+                        TripFcmTokenQueryDto.class,
+                        trip.id,
+                        user.fcmToken,
+                        trip.endedAt
+                ))
+                .from(tripMember)
+                .join(tripMember.trip, trip)
+                .join(tripMember.user, user)
+                .where(
+                        trip.travelStatus.ne(TravelStatus.IN_PROGRESS),
+                        trip.travelStatus.ne(TravelStatus.SETTING),
+                        trip.startedAt.loe(time),
+                        trip.endedAt.goe(time)
+                )
+                .fetch();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/TripRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/TripRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-public interface TripRepository extends JpaRepository<Trip, Long> {
+public interface TripRepository extends JpaRepository<Trip, Long>, CustomTripRepository {
 
     @Modifying
     @Query("UPDATE trip " +

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/TripService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/TripService.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.domain.trip.service;
 
+import kr.co.yeogiga.domain.trip.dto.TripFcmTokenQueryDto;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.repository.TripRepository;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,10 @@ public class TripService {
 
     public Optional<Long> readLeaderIdByTripId(Long tripId) {
         return tripRepository.findLeaderIdById(tripId);
+    }
+
+    public List<TripFcmTokenQueryDto> readTripFcmTokensByTime(LocalDateTime time) {
+        return tripRepository.findTripFcmTokensByTime(time);
     }
 
     public boolean existsById(Long tripId) {

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/QueryDslConfig.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/QueryDslConfig.java
@@ -1,0 +1,15 @@
+package kr.co.yeogiga.infrastructure.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/redis/RedisRepository.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/redis/RedisRepository.java
@@ -36,8 +36,16 @@ public class RedisRepository {
         redisTemplate.opsForList().rightPush(key, value);
     }
 
+    public <T> void setListAll(String key, Collection<T> values) {
+        redisTemplate.opsForList().rightPushAll(key, (Collection<Object>) values);
+    }
+
     public void setValueInList(String key, long index, Object value) {
         redisTemplate.opsForList().set(key, index, value);
+    }
+
+    public void expire(String key, Duration duration) {
+        redisTemplate.expire(key, duration);
     }
 
     public <T> List<T> getList(String key, Class<T> clazz) {

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripCommandServiceTest.java
@@ -2,6 +2,7 @@ package kr.co.yeogiga.application.trip.service;
 
 import kr.co.yeogiga.application.trip.dto.TripReq;
 import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.dto.TripFcmTokenQueryDto;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.service.TripMemberService;
@@ -10,6 +11,8 @@ import kr.co.yeogiga.domain.trip.type.TravelStatus;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.service.UserService;
 import kr.co.yeogiga.domain.user.type.Role;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import kr.co.yeogiga.infrastructure.redis.constant.TripMemberTokenConstant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -28,12 +31,17 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -48,6 +56,9 @@ public class TripCommandServiceTest {
 
     @Mock
     private UserService userService;
+
+    @Mock
+    private RedisRepository redisRepository;
 
     @InjectMocks
     private TripCommandService tripCommandService;
@@ -255,6 +266,49 @@ public class TripCommandServiceTest {
                 // then
                 assertEquals(TripErrorType.PERMISSION_DENIED_NOT_LEADER, exception.getErrorType());
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("여행 상태 변경")
+    class UpdateTravelStatus {
+
+        private final Long tripId = 1L;
+
+        @Test
+        @DisplayName("시작되는 여행이 존재하는 경우 - Redis에 멤버들의 Fcm Token을 저장")
+        void shouldStoreFcmTokensToRedisWhenTripStarts() {
+            // given
+            LocalDateTime now = LocalDateTime.of(2025, 5, 29, 12, 0);
+            TripFcmTokenQueryDto dto = new TripFcmTokenQueryDto(1L, "fcm-token", now.plusDays(1));
+            given(tripService.readTripFcmTokensByTime(now)).willReturn(List.of(dto));
+
+            // when
+            tripCommandService.updateTravelStatus(now);
+
+            // then
+            String redisKey = TripMemberTokenConstant.tripTokenKey(tripId);
+            verify(redisRepository, times(1)).setListAll(redisKey, List.of("fcm-token"));
+            verify(redisRepository, times(1)).expire(anyString(), any());
+            verify(tripService, times(1)).updateAllTravelStatusToInProgress(now);
+            verify(tripService, times(1)).updateAllTravelStatusToCompleted(now);
+        }
+
+        @Test
+        @DisplayName("시작되는 여행이 없는 경우 - 아무것도 저장하지 않고 상태만 갱신")
+        void shouldOnlyUpdateStatusWhenNoTripsToStart() {
+            // given
+            LocalDateTime now = LocalDateTime.of(2025, 5, 29, 14, 0);
+            given(tripService.readTripFcmTokensByTime(now)).willReturn(List.of());
+
+            // when
+            tripCommandService.updateTravelStatus(now);
+
+            // then
+            verify(redisRepository, never()).setListAll(any(), any());
+            verify(redisRepository, never()).expire(any(), any());
+            verify(tripService, times(1)).updateAllTravelStatusToInProgress(now);
+            verify(tripService, times(1)).updateAllTravelStatusToCompleted(now);
         }
     }
 

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingServiceTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -148,7 +149,7 @@ public class TripPlaceEditingServiceTest {
 
         // then
         verify(redisRepository, times(2)).del(anyString());
-        verify(redisRepository, times(3)).setList(anyString(), any(TripPlaceReq.StoredFormat.class));
+        verify(redisRepository, times(1)).setListAll(anyString(), anyList());
         verify(redisRepository, times(3)).addToSet(anyString(), anyString());
     }
 

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortServiceTest.java
@@ -11,6 +11,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -70,11 +72,13 @@ class TripPlaceSortServiceTest {
         tripPlaceSortService.sortDayTripPlaces(tripId, day);
 
         // then
-        ArgumentCaptor<TripPlaceReq.StoredFormat> captor = ArgumentCaptor.forClass(TripPlaceReq.StoredFormat.class);
-        verify(redisRepository, times(3)).setList(eq(listKey), captor.capture());
+        ArgumentCaptor<Collection<TripPlaceReq.StoredFormat>> captor =
+                ArgumentCaptor.forClass(Collection.class);
 
-        List<TripPlaceReq.StoredFormat> saved = captor.getAllValues();
-        assertEquals("숙소", saved.get(2).placeCategory(), "마지막 장소는 숙소여야 함");
+        verify(redisRepository, times(1)).setListAll(eq(listKey), captor.capture());
+
+        List<TripPlaceReq.StoredFormat> saved = new ArrayList<>(captor.getValue());
+        assertEquals("숙소", saved.get(2).placeCategory());
     }
 
     @Test
@@ -98,9 +102,10 @@ class TripPlaceSortServiceTest {
         tripPlaceSortService.sortDayTripPlaces(tripId, day);
 
         // then
-        ArgumentCaptor<TripPlaceReq.StoredFormat> captor = ArgumentCaptor.forClass(TripPlaceReq.StoredFormat.class);
-        verify(redisRepository, times(5)).setList(eq(listKey), captor.capture());
-        List<TripPlaceReq.StoredFormat> saved = captor.getAllValues();
+        ArgumentCaptor<Collection<TripPlaceReq.StoredFormat>> captor =
+                ArgumentCaptor.forClass(Collection.class);
+        verify(redisRepository, times(1)).setListAll(eq(listKey), captor.capture());
+        List<TripPlaceReq.StoredFormat> saved = new ArrayList<>(captor.getValue());
 
         // 식당 카테고리가 3번 이상 연속하지 않는지 확인
         int maxConsecutiveRestaurants = 0;

--- a/src/test/java/kr/co/yeogiga/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/kr/co/yeogiga/domain/user/repository/UserRepositoryTest.java
@@ -8,6 +8,7 @@ import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.type.Role;
 import kr.co.yeogiga.infrastructure.TestObjectMapperConfig;
 import kr.co.yeogiga.infrastructure.config.JpaConfig;
+import kr.co.yeogiga.infrastructure.config.QueryDslConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @TestPropertySource(locations = "classpath:application-test.yml")
-@Import({JpaConfig.class, TestObjectMapperConfig.class})
+@Import({JpaConfig.class, TestObjectMapperConfig.class, QueryDslConfig.class})
 public class UserRepositoryTest {
     @Autowired
     private UserRepository userRepository;


### PR DESCRIPTION
## 배경
여행 상태 변경 스케줄링 과정에서 여행이 시작되면, 해당 여행 멤버들의 FCM Token을 Redis에 저장해야함 (주기적으로 Silent Token을 보내기 위해)

## 작업 사항
- 시작한 여행 정보 조회 로직 구현 (2b6403b1557bd278ac53e3c99d2549495fdc14e6)
    - 효율적 조회를 위한 QueryDSL 적용 (788baf530dd04b1d2ebe32b907e90a6e7d240f9c) - 추후에 적용하고자 했지만, 해당 로직에 우선적으로 적용했습니다.
- 시작한 여행의 멤버 Fcm Token을 Redis에 저장 로직 추가 (6202075bfbb9e3fb0e1582f74d0854c954c6122c)

## 테스트
| <img width="353" alt="스크린샷 2025-05-29 오후 7 51 58" src="https://github.com/user-attachments/assets/79019041-4ad9-4657-b49f-745e9f734d8e" /> |
|----|
| 시작된 여행 멤버의 토큰이 redis에 저장 및 TTL 설정 확인 테스트|

## 추가 논의
여행 상태 확인을 위한 주기적 스케줄링 로직을 30분 단위로 적용했습니다. 추후에 다시 팀원들과 얘기할 예정이고 진행할 예정입니다.

## 기타
이전에 `rightPushAll`을 통해서 리스트의 내용을 한번에 저장하고자 했지만, 하나의 인덱스에 모든 값이 들어가는 문제가 있었습니다.
해당 메서드를 들어가보면 아래의 두가지 로직이 있습니다.
``` java
    @Nullable
    Long rightPushAll(K key, V... values);

    @Nullable
    Long rightPushAll(K key, Collection<V> values);
```

정확한 타입을 지정해주지 않으니 varargs 형식인  `Long rightPushAll(K key, V... values);`가 호출되었습니다.
그래서 아래의 로직으로 가기 위해 `redisTemplate.opsForList().rightPushAll(key, (Collection<Object>) values);`으로 강제 타입 변경을 하였고 (Object는 저희가 설정에 value를 Object로 했기 때문), 또 다른 방식으로는 new ArrayList<>(values)으로 진행할 수 있습니다.

위와 같은 방법으로, 현재 하나씩 삽입하는 로직을 `rightPushAll`을 사용하도록 변경하였습니다.