### PR TITLE
Feature(IL-160): 시작된 여행의 멤버에게 Notification Push 전송 로직 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/fcm/constant/FcmConstant.java
+++ b/src/main/java/kr/co/yeogiga/application/fcm/constant/FcmConstant.java
@@ -1,0 +1,13 @@
+package kr.co.yeogiga.application.fcm.constant;
+
+public final class FcmConstant {
+
+    private FcmConstant() { }
+
+    private static final String FCM_TITLE = "%s 여행이 시작되었습니다!";
+    public static final String FCM_BODY = "앱을 열어 여행 일정을 확인해보세요.";
+
+    public static String formatTitle(String title) {
+        return String.format(FCM_TITLE, title);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/fcm/service/TripPushSender.java
+++ b/src/main/java/kr/co/yeogiga/application/fcm/service/TripPushSender.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.application.fcm.service;
 
+import kr.co.yeogiga.application.fcm.constant.FcmConstant;
 import kr.co.yeogiga.application.user.service.UserFcmTokenService;
 import kr.co.yeogiga.infrastructure.fcm.FcmNotificationSender;
 import kr.co.yeogiga.infrastructure.fcm.response.FcmSendResult;
@@ -9,6 +10,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Component
@@ -19,27 +21,64 @@ public class TripPushSender {
     private final RedisRepository redisRepository;
 
     /**
-     * FCM 토큰을 통해 푸시 알림을 비동기로 전송하는 메서드
-     * - 유효하지 않은 토큰은 Redis 및 DB에서 제거
+     * FCM 토큰을 통해 Silent Push를 비동기로 전송하는 메서드
+     * - 유효하지 않은 토큰은 Redis 및 RDB에서 제거
      *
      * @param tripId       알림 대상 여행 ID
      * @param redisListKey FCM 토큰이 저장된 Redis 리스트 키
-     * @param fcmToken     푸시 알림 전송 대상 FCM 토큰
+     * @param fcmTokens    푸시 알림 전송 대상 FCM 토큰 List
      */
     @Async
-    public void sendPush(Long tripId, String redisListKey, String fcmToken) {
+    public void sendPush(Long tripId, String redisListKey, List<String> fcmTokens) {
         Map<String, String> notificationData = buildTripPushData(tripId);
 
-        FcmSendResult result = fcmNotificationSender.send(fcmToken, notificationData);
+        for (String fcmToken : fcmTokens) {
+            FcmSendResult result = fcmNotificationSender.sendSilent(fcmToken, notificationData);
 
-        if (result.shouldRemoveToken()) {
-            redisRepository.removeFromList(redisListKey, fcmToken);
-            userFcmTokenService.deleteFcmTokenByToken(fcmToken);
+            if (result.shouldRemoveToken()) {
+                deleteFcmToken(redisListKey, fcmToken);
+            }
         }
     }
 
     /**
-     * Silent Push를 위한 data 생성 메서드
+     * FCM 토큰을 통해 Notification Push를 비동기로 전송하는 메서드
+     * - 유효하지 않은 토큰은 Redis 및 RDB에서 제거
+     *
+     * @param tripId       알림 대상 여행 ID
+     * @param title        알림 대상 여행 제목
+     * @param redisListKey FCM 토큰이 저장된 Redis 리스트 키
+     * @param fcmTokens    푸시 알림 전송 대상 FCM 토큰 List
+     */
+    @Async
+    public void sendPush(Long tripId, String title, String redisListKey, List<String> fcmTokens) {
+        Map<String, String> notificationData = buildTripPushData(tripId);
+        String pushTitle = FcmConstant.formatTitle(title);
+        String body = FcmConstant.FCM_BODY;
+
+        for (String fcmToken : fcmTokens) {
+            FcmSendResult result = fcmNotificationSender.sendNotification(fcmToken, pushTitle, body, notificationData);
+
+            if (result.shouldRemoveToken()) {
+                deleteFcmToken(redisListKey, fcmToken);
+            }
+        }
+    }
+
+    /**
+     * 유효하지 않은 FCM Token을 삭제하는 메서드
+     * - Redis 및 RDB에 저장된 FCM Token 정보를 삭제
+     *
+     * @param redisListKey FCM 토큰이 저장된 Redis 리스트 키
+     * @param fcmToken     삭제할 FCM 토큰
+     */
+    private void deleteFcmToken(String redisListKey, String fcmToken) {
+        redisRepository.removeFromList(redisListKey, fcmToken);
+        userFcmTokenService.deleteFcmTokenByToken(fcmToken);
+    }
+
+    /**
+     * Push data 생성 메서드
      *
      * @param tripId 알림 대상 여행 ID
      * @return data가 저장된 Map 자료구조

--- a/src/main/java/kr/co/yeogiga/application/fcm/service/TripTokenPushProcessor.java
+++ b/src/main/java/kr/co/yeogiga/application/fcm/service/TripTokenPushProcessor.java
@@ -50,9 +50,7 @@ public class TripTokenPushProcessor {
             return;
         }
 
-        for (String fcmToken : fcmTokens) {
-            tripPushSender.sendPush(tripId, redisListKey, fcmToken);
-        }
+        tripPushSender.sendPush(tripId, redisListKey, fcmTokens);
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.application.trip.service;
 
+import kr.co.yeogiga.application.fcm.service.TripPushSender;
 import kr.co.yeogiga.application.trip.dto.TripReq;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.dto.TripFcmTokenQueryDto;
@@ -32,6 +33,7 @@ public class TripCommandService {
     private final TripMemberService tripMemberService;
     private final UserService userService;
     private final RedisRepository redisRepository;
+    private final TripPushSender tripPushSender;
 
     /**
      * 여행 생성 메서드
@@ -105,9 +107,11 @@ public class TripCommandService {
         List<TripFcmTokenQueryDto> tripFcmTokens = tripService.readTripFcmTokensByTime(time);
 
         // FCM Token 저장 로직
-        cacheTripFcmTokensToRedis(tripFcmTokens);
+        if (!tripFcmTokens.isEmpty()) {
+            cacheTripFcmTokensToRedis(tripFcmTokens);
+            tripService.updateAllTravelStatusToInProgress(time);
+        }
 
-        tripService.updateAllTravelStatusToInProgress(time);
         tripService.updateAllTravelStatusToCompleted(time);
     }
 
@@ -148,8 +152,14 @@ public class TripCommandService {
         // 여행 종료 시간
         LocalDateTime endedAt = dtos.get(0).endedAt();
 
+        String title = dtos.get(0).title();
+
+        // FCM Token Redis Im-Memory 저장 및 TTL 설정
         redisRepository.setListAll(redisKey, tokens);
         redisRepository.expire(redisKey, calculateDuration(endedAt));
+
+        // Push 알림 전송
+        tripPushSender.sendPush(tripId, title, redisKey, tokens);
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/domain/trip/dto/TripFcmTokenQueryDto.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/dto/TripFcmTokenQueryDto.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 public record TripFcmTokenQueryDto(
         Long tripId,
+        String title,
         String fcmToken,
         LocalDateTime endedAt
 ) {

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripRepositoryImpl.java
@@ -26,6 +26,7 @@ public class CustomTripRepositoryImpl implements CustomTripRepository {
                 .select(Projections.constructor(
                         TripFcmTokenQueryDto.class,
                         trip.id,
+                        trip.title,
                         user.fcmToken,
                         trip.endedAt
                 ))
@@ -33,8 +34,7 @@ public class CustomTripRepositoryImpl implements CustomTripRepository {
                 .join(tripMember.trip, trip)
                 .join(tripMember.user, user)
                 .where(
-                        trip.travelStatus.ne(TravelStatus.IN_PROGRESS),
-                        trip.travelStatus.ne(TravelStatus.SETTING),
+                        trip.travelStatus.notIn(TravelStatus.IN_PROGRESS, TravelStatus.SETTING),
                         trip.startedAt.loe(time),
                         trip.endedAt.goe(time)
                 )

--- a/src/main/java/kr/co/yeogiga/infrastructure/fcm/FcmNotificationSender.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/fcm/FcmNotificationSender.java
@@ -7,6 +7,7 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.Notification;
 import kr.co.yeogiga.infrastructure.fcm.response.FcmSendResult;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -18,15 +19,29 @@ import java.util.Map;
 public class FcmNotificationSender {
 
     /**
+     * Silent Push 메서드
+     */
+    public FcmSendResult sendSilent(String token, Map<String, String> data) {
+        Message message = buildSilentMessage(token, data);
+        return send(token, message);
+    }
+
+    /**
+     * 일반 Notification Push 메서드
+     */
+    public FcmSendResult sendNotification(String token, String title, String body, Map<String, String> data) {
+        Message message = buildNotificationMessage(token, title, body, data);
+        return send(token, message);
+    }
+
+    /**
      * FCM 푸시 알림을 전송하고 결과를 반환하는 메서드
      *
-     * @param token 수신자의 FCM 디바이스 토큰
-     * @param data  fcm data 정보
+     * @param token   수신자의 FCM 디바이스 토큰
+     * @param message fcm message 객체
      * @return FCM 전송 결과 객체
      */
-    public FcmSendResult send(String token, Map<String, String> data) {
-        Message message = buildSilentMessage(token, data);
-
+    private FcmSendResult send(String token, Message message) {
         try {
             String response = FirebaseMessaging.getInstance().send(message);
             return FcmSendResult.success(response);
@@ -63,6 +78,29 @@ public class FcmNotificationSender {
                         .build())
                 .setAndroidConfig(AndroidConfig.builder()
                         .setPriority(AndroidConfig.Priority.HIGH)
+                        .build())
+                .build();
+    }
+
+    /**
+     * 일반 Push를 위한 메시지 생성 메서드
+     *
+     * @param token 수신자의 FCM 디바이스 토큰
+     * @param title 메시지 제목
+     * @param body  메시지 내용
+     * @param data  fcm data 정보
+     * @return FCM 전송 메시지
+     */
+    private Message buildNotificationMessage(String token, String title, String body, Map<String, String> data) {
+        return Message.builder()
+                .setToken(token)
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .putAllData(data)
+                .setApnsConfig(ApnsConfig.builder()
+                        .setAps(Aps.builder().setSound("default").build())
                         .build())
                 .build();
     }

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripCommandServiceTest.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.application.trip.service;
 
+import kr.co.yeogiga.application.fcm.service.TripPushSender;
 import kr.co.yeogiga.application.trip.dto.TripReq;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.dto.TripFcmTokenQueryDto;
@@ -31,13 +32,14 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -59,6 +61,9 @@ public class TripCommandServiceTest {
 
     @Mock
     private RedisRepository redisRepository;
+
+    @Mock
+    private TripPushSender tripPushSender;
 
     @InjectMocks
     private TripCommandService tripCommandService;
@@ -280,7 +285,7 @@ public class TripCommandServiceTest {
         void shouldStoreFcmTokensToRedisWhenTripStarts() {
             // given
             LocalDateTime now = LocalDateTime.of(2025, 5, 29, 12, 0);
-            TripFcmTokenQueryDto dto = new TripFcmTokenQueryDto(1L, "fcm-token", now.plusDays(1));
+            TripFcmTokenQueryDto dto = new TripFcmTokenQueryDto(1L, "여행 제목", "fcm-token", now.plusDays(1));
             given(tripService.readTripFcmTokensByTime(now)).willReturn(List.of(dto));
 
             // when
@@ -292,6 +297,7 @@ public class TripCommandServiceTest {
             verify(redisRepository, times(1)).expire(anyString(), any());
             verify(tripService, times(1)).updateAllTravelStatusToInProgress(now);
             verify(tripService, times(1)).updateAllTravelStatusToCompleted(now);
+            verify(tripPushSender, times(1)).sendPush(anyLong(), anyString(), anyString(), anyList());
         }
 
         @Test
@@ -307,7 +313,6 @@ public class TripCommandServiceTest {
             // then
             verify(redisRepository, never()).setListAll(any(), any());
             verify(redisRepository, never()).expire(any(), any());
-            verify(tripService, times(1)).updateAllTravelStatusToInProgress(now);
             verify(tripService, times(1)).updateAllTravelStatusToCompleted(now);
         }
     }


### PR DESCRIPTION
## 배경
여행이 시작되면 사용자들에게 알리기 위한 Push 알림 전송이 필요

## 작업 사항
- Silent Pust, 일반 Notification Push별 전송 메서드 분리 (83a1fcd6ea181b38f271ae622a00c2f4468e3cd8)
    - Silent Push 호출 과정 중, Token을 하나씩 전송했지만, List형식으로 전송 변경 (a8eb5e387e1cdbdfce55b029468afc5f2ef1012e)
- 시작된 여행에 대해 Push 알림 전송 로직 구현 (b7364953ff50b3cbce1fab9a2d983079c8ef0760)
    - Notification Push의 Title에 여행 제목을 포함시키기 위해 QueryDSL 조회 로직 필드 추가 (e495e11976298b5b51e0082284c9920a3e7d828d)

## 추가 논의
- `FcmConstant`에서 여행 시작 때, 보낼 문구를 임의로 넣었습니다. 추후에 얘기해보고 변경하도록 하겠습니다.
- 현재 여행 상태 변경 메서드인 `TripCommandService.updateTravelStatus`에서 너무 많은 작업으로 인해 (시작된 여행 멤버들의 Token 조회, Redis 저장, 알림 전송 등) 단일 책임 원칙에서 벗어나는 것 같습니다. 스프링의 이벤트를 활용해 이벤트 리스너로 처리를 진행할까 고민을 했지만, 현재 로직에서 적용하기엔 테스트 코드의 변화 및 동일한 상황을 가진 메서드 전체 변화 등의 복잡도가 올라가 추후 리팩토링 사항으로 넣어놓아도 괜찮을 것 같습니다. 이 부분에 대해서는 추후에 얘기해보면 좋을 것 같아요!