### PR TITLE
Feature(IL-161): 여행 멤버 위치 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,9 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
 
     /* Redis */
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'io.lettuce:lettuce-core:6.5.5.RELEASE'
+    implementation 'org.springframework.data:spring-data-redis:3.5.0'
+
 
     /* JAXB */
     implementation 'javax.xml.bind:jaxb-api:2.3.1'

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripMemberLocationDto.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripMemberLocationDto.java
@@ -1,17 +1,21 @@
 package kr.co.yeogiga.application.trip.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public class TripMemberLocationDto {
 
+    @Schema(name = "TripMemberLocationDto.Request", description = "여행 멤버 위치 저장 요청 DTO")
     public record Request(
+            @Schema(description = "위도", example = "33.3")
             @Min(value = -90, message = "위도는 -90도보다 작을 수 없습니다.")
             @Max(value = 90, message = "위도는 90도보다 클 수 없습니다.")
             @NotNull(message = "위도는 필수 입력값입니다.")
             Double latitude,
-
+            
+            @Schema(description = "경도", example = "120.3")
             @Min(value = -180, message = "경도는 -180도보다 작을 수 없습니다.")
             @Max(value = 180, message = "경도는 180도보다 클 수 없습니다.")
             @NotNull(message = "경도는 필수 입력값입니다.")

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripMemberLocationDto.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripMemberLocationDto.java
@@ -1,0 +1,19 @@
+package kr.co.yeogiga.application.trip.dto;
+
+public class TripMemberLocationDto {
+
+    public record Request(
+            Double latitude,
+            Double longitude
+    ) {
+        public StoredFormat toStoredFormat(Long userId) {
+            return new StoredFormat(latitude, longitude, userId);
+        }
+    }
+
+    public record StoredFormat(
+            Double latitude,
+            Double longitude,
+            Long userId
+    ) { }
+}

--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripMemberLocationDto.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripMemberLocationDto.java
@@ -1,9 +1,20 @@
 package kr.co.yeogiga.application.trip.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
 public class TripMemberLocationDto {
 
     public record Request(
+            @Min(value = -90, message = "위도는 -90도보다 작을 수 없습니다.")
+            @Max(value = 90, message = "위도는 90도보다 클 수 없습니다.")
+            @NotNull(message = "위도는 필수 입력값입니다.")
             Double latitude,
+
+            @Min(value = -180, message = "경도는 -180도보다 작을 수 없습니다.")
+            @Max(value = 180, message = "경도는 180도보다 클 수 없습니다.")
+            @NotNull(message = "경도는 필수 입력값입니다.")
             Double longitude
     ) {
         public StoredFormat toStoredFormat(Long userId) {

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripMemberLocationCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripMemberLocationCommandService.java
@@ -8,7 +8,6 @@ import kr.co.yeogiga.infrastructure.redis.RedisRepository;
 import kr.co.yeogiga.infrastructure.redis.constant.TripMemberLocationConstant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 
@@ -27,7 +26,6 @@ public class TripMemberLocationCommandService {
      * @param userId        사용자 ID
      * @param location      사용자 위치 정보 DTO
      */
-    @Transactional(readOnly = true)
     public void saveLocation(Long tripId, Long userId, TripMemberLocationDto.Request location) {
         if (!tripMemberService.existsByTripIdAndUserId(tripId, userId)) {
             throw new CustomException(TripMemberErrorType.IS_NOT_MEMBER);

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripMemberLocationCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripMemberLocationCommandService.java
@@ -1,0 +1,42 @@
+package kr.co.yeogiga.application.trip.service;
+
+import kr.co.yeogiga.application.trip.dto.TripMemberLocationDto;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.exception.TripMemberErrorType;
+import kr.co.yeogiga.domain.trip.service.TripMemberService;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import kr.co.yeogiga.infrastructure.redis.constant.TripMemberLocationConstant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class TripMemberLocationCommandService {
+    private final TripMemberService tripMemberService;
+    private final RedisRepository redisRepository;
+
+    /**
+     * 사용자의 현재 위치를 Redis에 저장하는 메서드
+     * - Redis의 Hash 자료구조를 통한 저장
+     * - 각 필드(사용자 위치 정보)마다 30분의 ttl을 설정
+     *
+     * @param tripId        여행 ID
+     * @param userId        사용자 ID
+     * @param location      사용자 위치 정보 DTO
+     */
+    @Transactional(readOnly = true)
+    public void saveLocation(Long tripId, Long userId, TripMemberLocationDto.Request location) {
+        if (!tripMemberService.existsByTripIdAndUserId(tripId, userId)) {
+            throw new CustomException(TripMemberErrorType.IS_NOT_MEMBER);
+        }
+
+        String key = TripMemberLocationConstant.tripMemberLocationKey(tripId);
+        String subKey = TripMemberLocationConstant.tripMemberLocationSubKey(userId);
+
+        redisRepository.setHash(key, subKey, location.toStoredFormat(userId));
+        redisRepository.setHashExpire(key, subKey, Duration.ofMinutes(30));
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/redis/RedisRepository.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/redis/RedisRepository.java
@@ -96,4 +96,18 @@ public class RedisRepository {
             redisTemplate.delete(keys);
         }
     }
+
+    public void setHash(String key, String subKey, Object value) {
+        redisTemplate.opsForHash().put(key, subKey, value);
+    }
+
+    public void setHashExpire(String key, String subKey, Duration duration) {
+        redisTemplate.opsForHash().expire(key, duration, List.of(subKey));
+    }
+
+    public Set<String> getHashKeys(String key) {
+        return redisTemplate.opsForHash().keys(key).stream()
+                .map(String::valueOf)
+                .collect(Collectors.toSet());
+    }
 }

--- a/src/main/java/kr/co/yeogiga/infrastructure/redis/constant/TripMemberLocationConstant.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/redis/constant/TripMemberLocationConstant.java
@@ -1,0 +1,17 @@
+package kr.co.yeogiga.infrastructure.redis.constant;
+
+public final class TripMemberLocationConstant {
+
+    private TripMemberLocationConstant() { }
+
+    private static final String TRIP_MEMBER_LOCATION_KEY_PREFIX = "trip:%d:location";
+    private static final String TRIP_MEMBER_LOCATION_SUBKEY_PREFIX = "user:%d";
+
+    public static String tripMemberLocationKey(Long tripId) {
+        return String.format(TRIP_MEMBER_LOCATION_KEY_PREFIX, tripId);
+    }
+
+    public static String tripMemberLocationSubKey(Long userId) {
+        return String.format(TRIP_MEMBER_LOCATION_SUBKEY_PREFIX, userId);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripMemberLocationApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripMemberLocationApi.java
@@ -1,0 +1,73 @@
+package kr.co.yeogiga.presentation.trip.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.co.yeogiga.application.trip.dto.TripMemberLocationDto;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@ApiGroup(value = "[여행 멤버 위치 API]")
+@Tag(name = "[여행 멤버 위치 API]", description = "여행 멤버 위치 관련 API")
+public interface TripMemberLocationApi {
+    
+    @TrackApi(description = "여행 멤버 위치 저장")
+    @Operation(summary = "여행 멤버 위치 저장", description = "여행 멤버 위치 저장 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "여행 멤버 위치 저장 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                             {
+                                                 "code": 201,
+                                                 "message": "요청이 성공하였습니다."
+                                             }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "여행 멤버 위치 저장 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "위도, 경도 범위 초과", value = """
+                                             {
+                                                 "code": "G002",
+                                                 "errors": {
+                                                     "latitude": "위도는 90도보다 클 수 없습니다.",
+                                                     "longitude": "경도는 180도보다 클 수 없습니다."
+                                                 }
+                                             }
+                                    """),
+                            @ExampleObject(name = "위도, 경도가 null인 경우", value = """
+                                             {
+                                                  "code": "G002",
+                                                  "errors": {
+                                                      "latitude": "위도는 필수 입력값입니다.",
+                                                      "longitude": "경도는 필수 입력값입니다."
+                                                  }
+                                              }
+                                    """),
+                            @ExampleObject(name = "여행이 존재하지 않거나 멤버가 아닌 경우", value = """
+                                             {
+                                                 "code": "T102",
+                                                 "message": "해당 여행의 멤버가 아닙니다."
+                                             }
+                                    """),
+                            
+                    }))
+    })
+    ResponseEntity<?> saveLocation(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            
+            @Parameter(description = "여행 ID")
+            @PathVariable Long tripId,
+            
+            @Valid @RequestBody TripMemberLocationDto.Request request
+    );
+}

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripMemberLocationController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripMemberLocationController.java
@@ -5,6 +5,7 @@ import kr.co.yeogiga.application.trip.dto.TripMemberLocationDto;
 import kr.co.yeogiga.application.trip.service.TripMemberLocationCommandService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.presentation.trip.api.TripMemberLocationApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,9 +19,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/trip")
 @RequiredArgsConstructor
-public class TripMemberLocationController {
+public class TripMemberLocationController implements TripMemberLocationApi {
     private final TripMemberLocationCommandService tripMemberLocationCommandService;
 
+    @Override
     @PostMapping("/{tripId}/members/location")
     public ResponseEntity<?> saveLocation(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripMemberLocationController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripMemberLocationController.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.presentation.trip.controller;
 
+import jakarta.validation.Valid;
 import kr.co.yeogiga.application.trip.dto.TripMemberLocationDto;
 import kr.co.yeogiga.application.trip.service.TripMemberLocationCommandService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
@@ -24,7 +25,7 @@ public class TripMemberLocationController {
     public ResponseEntity<?> saveLocation(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long tripId,
-            @RequestBody TripMemberLocationDto.Request request
+            @Valid @RequestBody TripMemberLocationDto.Request request
     ) {
         tripMemberLocationCommandService.saveLocation(tripId, userDetails.getUserId(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripMemberLocationController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripMemberLocationController.java
@@ -1,0 +1,32 @@
+package kr.co.yeogiga.presentation.trip.controller;
+
+import kr.co.yeogiga.application.trip.dto.TripMemberLocationDto;
+import kr.co.yeogiga.application.trip.service.TripMemberLocationCommandService;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/trip")
+@RequiredArgsConstructor
+public class TripMemberLocationController {
+    private final TripMemberLocationCommandService tripMemberLocationCommandService;
+
+    @PostMapping("/{tripId}/members/location")
+    public ResponseEntity<?> saveLocation(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long tripId,
+            @RequestBody TripMemberLocationDto.Request request
+    ) {
+        tripMemberLocationCommandService.saveLocation(tripId, userDetails.getUserId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
+    }
+}

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripMemberLocationCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripMemberLocationCommandServiceTest.java
@@ -1,0 +1,83 @@
+package kr.co.yeogiga.application.trip.service;
+
+import kr.co.yeogiga.application.trip.dto.TripMemberLocationDto;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.exception.TripMemberErrorType;
+import kr.co.yeogiga.domain.trip.service.TripMemberService;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TripMemberLocationCommandServiceTest {
+
+    @Mock
+    private TripMemberService tripMemberService;
+
+    @Mock
+    private RedisRepository redisRepository;
+
+    @InjectMocks
+    private TripMemberLocationCommandService tripMemberLocationCommandService;
+
+    @Nested
+    @DisplayName("사용자 위치 저장")
+    class SaveLocation {
+        private final Long tripId = 1L;
+        private final Long userId = 1L;
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            TripMemberLocationDto.Request request
+                    = new TripMemberLocationDto.Request(1.1, 2.2);
+
+            when(tripMemberService.existsByTripIdAndUserId(tripId, userId)).thenReturn(true);
+            doNothing().when(redisRepository).setHash(anyString(), anyString(), any());
+            doNothing().when(redisRepository).setHashExpire(anyString(), anyString(), any());
+
+            // when
+            tripMemberLocationCommandService.saveLocation(tripId, userId, request);
+
+            // then
+            verify(redisRepository, times(1)).setHash(isA(String.class), isA(String.class), isA(TripMemberLocationDto.StoredFormat.class));
+            verify(redisRepository, times(1)).setHashExpire(isA(String.class), isA(String.class), isA(Duration.class));
+        }
+
+        @Test
+        @DisplayName("실패 - 여행 미존재 또는 멤버가 아닌 경우")
+        void failIfTripNotFoundOrIsNotMember() {
+            // given
+            TripMemberLocationDto.Request request
+                    = new TripMemberLocationDto.Request(1.1, 2.2);
+
+            when(tripMemberService.existsByTripIdAndUserId(tripId, userId)).thenReturn(false);
+
+            // when
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> tripMemberLocationCommandService.saveLocation(tripId, userId, request));
+
+            // then
+            assertEquals(TripMemberErrorType.IS_NOT_MEMBER, exception.getErrorType());
+        }
+    }
+}

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripMemberLocationControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripMemberLocationControllerTest.java
@@ -1,0 +1,164 @@
+package kr.co.yeogiga.presentation.trip.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.application.trip.dto.TripMemberLocationDto;
+import kr.co.yeogiga.application.trip.service.TripMemberLocationCommandService;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
+import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.domain.trip.exception.TripMemberErrorType;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.type.Role;
+import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = TripMemberLocationController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthenticationFilter.class})
+        }
+)
+public class TripMemberLocationControllerTest {
+    
+    @Autowired
+    private MockMvc mockMvc;
+    
+    @Autowired
+    private ObjectMapper objectMapper;
+    
+    @MockBean
+    private TripMemberLocationCommandService tripMemberLocationCommandService;
+    
+    private CustomUserDetails userDetails;
+    
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .alwaysDo(print())
+                .build();
+        
+        User user = User.builder()
+                .username("username")
+                .password("password")
+                .nickname("nickname")
+                .email("email")
+                .role(Role.USER)
+                .build();
+        
+        ReflectionTestUtils.setField(user, "id", 1L);
+        
+        userDetails = new CustomUserDetailsImpl(user);
+    }
+    
+    @Nested
+    @DisplayName("멤버 위치 저장")
+    class SaveLocation {
+        private final Long tripId = 1L;
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            TripMemberLocationDto.Request request = new TripMemberLocationDto.Request(
+                    1.1,
+                    2.2
+            );
+            
+            doNothing().when(tripMemberLocationCommandService).saveLocation(any(), any(), any());
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/trip/{tripId}/members/location", tripId)
+                            .with(user(userDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.code").value(SuccessResponse.created().code()))
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.created().message()));
+        }
+        
+        @Test
+        @DisplayName("실패 - 유효성 검증 실패: 위도, 경도 범위 초과")
+        void failValidationLocationRange() throws Exception {
+            // given
+            TripMemberLocationDto.Request request = new TripMemberLocationDto.Request(
+                    300.0,
+                    300.0
+            );
+            
+            doNothing().when(tripMemberLocationCommandService).saveLocation(anyLong(), any(), any());
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/trip/{tripId}/members/location", tripId)
+                            .with(user(userDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors.latitude").exists())
+                    .andExpect(jsonPath("$.errors.longitude").exists());
+        }
+        
+        @Test
+        @DisplayName("실패 - 여행이 존재하지 않거나 멤버가 아닌 경우")
+        void failIfNotMember() throws Exception {
+            // given
+            TripMemberLocationDto.Request request = new TripMemberLocationDto.Request(
+                    30.0,
+                    120.0
+            );
+            
+            doThrow(new CustomException(TripMemberErrorType.IS_NOT_MEMBER))
+                    .when(tripMemberLocationCommandService).saveLocation(anyLong(), any(), any());
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/trip/{tripId}/members/location", tripId)
+                            .with(user(userDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(TripMemberErrorType.IS_NOT_MEMBER.getCode()))
+                    .andExpect(jsonPath("$.message").value(TripMemberErrorType.IS_NOT_MEMBER.getMessage()));
+                    
+        }
+    }
+}


### PR DESCRIPTION
## 배경

- 지도 내 여행 멤버 위치 공유를 위한 멤버 위치 저장

## 작업 사항

- Spring-Data-Redis 디펜던시 버전 변경
	- Redis 7.4.0 버전 이상의 경우 해시의 각 필드에 대한 ttl 설정 가능 - [Redis docs - HEXPIRE](https://redis.io/docs/latest/commands/hexpire/)
	- Spring-Data-Redis 3.5.0 버전 이상 `HashOperation.expire(...)` 메서드로 `HEXPIRE` 사용 가능 - [HashOperation Javadoc](https://docs.spring.io/spring-data/redis/docs/current/api/org/springframework/data/redis/core/HashOperations.html#expire(H,java.time.Duration,java.util.Collection))
	- 기존 서비스에서는 springboot-starter-data-redis 사용으로 인한 spring-data-redis 3.3.2 버전 사용
		> MavenRepository를 참고하면 springboot-starter-data-redis:3.5.0 버전도 spring-data-redis:3.5.0을 사용한다고는하나 실제로 적용해보니 여전히 spring-data-redis:3.3.2 버전이 적용 되었습니다.

	- 버전 변경 및 디펜던시 버전 직접 명시
		- 위 이유로 [springboot-starter-data-redis](https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-redis/3.5.0) 참고하여 Spring-Data-Redis 및 lettuce 디펜던시 직접 버전 명시하여 사용하였습니다. 

<br/>

- Redis 내 해시 자료구조로 사용자 위치 정보 저장
	- 나중에 조회 시 편한 조회를 위해 `longitude`, `latitude`, `userId` 필드로 저장

## 추가 논의
- 차후 PR에서 고려해볼 내용이긴한데 ttl이 30분인데 혹시 멤버 나가기나 추방 시에도 사용자 위치 정보 지우는 로직을 추가할까 고민입니다.
- 현재 trip 패키지 안에 TripMemberLocationXXX 관련 클래스들을 같이 위치시킨 상태입니다. 혹시 따로 패키지를 구성하는 것이 좋을지 고민입니다!