### PR TITLE
Feature(IL-169): 여행 멤버 위치 조회

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripMemberLocationDto.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripMemberLocationDto.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import kr.co.yeogiga.domain.user.entity.User;
+import lombok.Builder;
 
 public class TripMemberLocationDto {
 
@@ -31,4 +33,23 @@ public class TripMemberLocationDto {
             Double longitude,
             Long userId
     ) { }
+    
+    @Builder
+    public record Response (
+            Double latitude,
+            Double longitude,
+            Long userId,
+            String nickname,
+            String imageUrl
+    ) {
+        public static Response from(StoredFormat locationInfo, User user) {
+            return Response.builder()
+                    .latitude(locationInfo.latitude())
+                    .longitude(locationInfo.longitude())
+                    .userId(locationInfo.userId())
+                    .nickname(user.getNickname())
+                    .imageUrl(user.getImageUrl())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripMemberLocationQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripMemberLocationQueryService.java
@@ -1,0 +1,74 @@
+package kr.co.yeogiga.application.trip.service;
+
+import kr.co.yeogiga.application.trip.dto.TripMemberLocationDto;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.exception.TripMemberErrorType;
+import kr.co.yeogiga.domain.trip.service.TripMemberService;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.service.UserService;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import kr.co.yeogiga.infrastructure.redis.constant.TripMemberLocationConstant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TripMemberLocationQueryService {
+    private final RedisRepository redisRepository;
+    private final TripMemberService tripMemberService;
+    private final UserService userService;
+    
+    /**
+     * 특정 여행에 포함된 사용자의 위치를 조회하는 메서드
+     *
+     * @param tripId        여행 ID
+     * @param userId        사용자 ID
+     * @return              여행에 포함된 사용자(멤버)의 위치 정보 DTO
+     */
+    @Transactional(readOnly = true)
+    public List<TripMemberLocationDto.Response> readMemberLocations(Long tripId, Long userId) {
+        if (!tripMemberService.existsByTripIdAndUserId(tripId, userId)) {
+            throw new CustomException(TripMemberErrorType.IS_NOT_MEMBER);
+        }
+        
+        String key = TripMemberLocationConstant.tripMemberLocationKey(tripId);
+        
+        Set<String> subKeys = redisRepository.getHashKeys(key);
+        
+        List<TripMemberLocationDto.StoredFormat> memberLocations
+                = redisRepository.getHashAll(key, subKeys, TripMemberLocationDto.StoredFormat.class);
+        
+        return generateLocationResponse(memberLocations);
+    }
+    
+    /**
+     * 위치 정보 응답 DTO를 생성하는 메서드
+     * - 사용자 위치 저장 정보(StoredFormat)로부터 응답(Response) 정보 DTO를 생성
+     *
+     * @param memberLocations       사용자 위치 저장 정보 목록
+     * @return                      사용자 위치 응답 정보 목록
+     */
+    private List<TripMemberLocationDto.Response> generateLocationResponse(
+            List<TripMemberLocationDto.StoredFormat> memberLocations
+    ) {
+       List<Long> userIds = memberLocations.stream()
+               .map(TripMemberLocationDto.StoredFormat::userId)
+               .toList();
+       
+       Map<Long, User> users = userService.readAllByIds(userIds).stream()
+               .collect(Collectors.toMap(User::getId, user -> user));
+       
+       return memberLocations.stream()
+               .map(locationInfo -> {
+                   User user = users.get(locationInfo.userId());
+                
+                   return TripMemberLocationDto.Response.from(locationInfo, user);
+               }).toList();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripMemberLocationQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripMemberLocationQueryService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -44,7 +45,7 @@ public class TripMemberLocationQueryService {
         List<TripMemberLocationDto.StoredFormat> memberLocations
                 = redisRepository.getHashAll(key, subKeys, TripMemberLocationDto.StoredFormat.class);
         
-        return generateLocationResponse(memberLocations);
+        return memberLocations.isEmpty() ? Collections.emptyList() : generateLocationResponse(memberLocations);
     }
     
     /**

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
@@ -55,6 +55,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<Long> findUserIdIncludeDeletedByEmail(@Param(value = "email") String email);
 
     Optional<User> findByFcmToken(String fcmToken);
+    
+    @Query("SELECT u FROM users u WHERE u.id IN :ids")
+    List<User> findAllByIds(List<Long> ids);
 
     @Modifying
     @Query(value = "DELETE " +

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
@@ -56,8 +56,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByFcmToken(String fcmToken);
     
-    @Query("SELECT u FROM users u WHERE u.id IN :ids")
-    List<User> findAllByIds(List<Long> ids);
+    List<User> findAllByIdIn(List<Long> ids);
 
     @Modifying
     @Query(value = "DELETE " +

--- a/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
@@ -24,7 +24,7 @@ public class UserService {
     }
     
     public List<User> readAllByIds(List<Long> ids) {
-        return userRepository.findAllByIds(ids);
+        return userRepository.findAllByIdIn(ids);
     }
 
     public Optional<User> readIncludeDeletedUserById(Long id) {

--- a/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
@@ -22,6 +22,10 @@ public class UserService {
     public Optional<User> readById(Long id) {
         return userRepository.findById(id);
     }
+    
+    public List<User> readAllByIds(List<Long> ids) {
+        return userRepository.findAllByIds(ids);
+    }
 
     public Optional<User> readIncludeDeletedUserById(Long id) {
         return userRepository.findUserIncludeDeletedById(id);

--- a/src/main/java/kr/co/yeogiga/infrastructure/redis/RedisRepository.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/redis/RedisRepository.java
@@ -110,4 +110,13 @@ public class RedisRepository {
                 .map(String::valueOf)
                 .collect(Collectors.toSet());
     }
+    
+    public <T> List<T> getHashAll(String key, Collection<String> hashKeys, Class<T> clazz) {
+        return redisTemplate.opsForHash().multiGet(
+                key,
+                hashKeys.stream()
+                        .map(Object.class::cast)
+                        .toList()
+        ).stream().map(clazz::cast).toList();
+    }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripMemberLocationApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripMemberLocationApi.java
@@ -58,8 +58,7 @@ public interface TripMemberLocationApi {
                                                  "code": "T102",
                                                  "message": "해당 여행의 멤버가 아닙니다."
                                              }
-                                    """),
-                            
+                                    """)
                     }))
     })
     ResponseEntity<?> saveLocation(
@@ -69,5 +68,57 @@ public interface TripMemberLocationApi {
             @PathVariable Long tripId,
             
             @Valid @RequestBody TripMemberLocationDto.Request request
+    );
+    
+    @TrackApi(description = "여행 멤버 위치 조회")
+    @Operation(summary = "여행 멤버 위치 조회", description = "여행 멤버 위치 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "여행 멤버 위치 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "저장된 위치가 없는 경우", value = """
+                                             {
+                                                 "code": 200,
+                                                 "message": "요청이 성공하였습니다.",
+                                                 "data": []
+                                             }
+                                    """),
+                            @ExampleObject(name = "저장된 위치가 있는 경우", value = """
+                                             {
+                                                 "code": 200,
+                                                 "message": "요청이 성공하였습니다.",
+                                                 "data": [
+                                                     {
+                                                         "latitude": 30.2,
+                                                         "longitude": 120.1,
+                                                         "userId": 2,
+                                                         "nickname": "nick2",
+                                                         "imageUrl": null
+                                                     },
+                                                     {
+                                                         "latitude": 30.2,
+                                                         "longitude": 120.1,
+                                                         "userId": 1,
+                                                         "nickname": "nick",
+                                                         "imageUrl": null
+                                                     }
+                                                 ]
+                                             }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "여행 멤버 위치 조회 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "여행 미존재 또는 여행 멤버가 아닌 경우", value = """
+                                             {
+                                                 "code": "T102",
+                                                 "message": "해당 여행의 멤버가 아닙니다."
+                                             }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getLocations(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            
+            @Parameter(description = "여행 ID")
+            @PathVariable Long tripId
     );
 }

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripMemberLocationController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripMemberLocationController.java
@@ -36,6 +36,7 @@ public class TripMemberLocationController implements TripMemberLocationApi {
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
     }
     
+    @Override
     @GetMapping("/{tripId}/members/location")
     public ResponseEntity<?> getLocations(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripMemberLocationController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripMemberLocationController.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.presentation.trip.controller;
 import jakarta.validation.Valid;
 import kr.co.yeogiga.application.trip.dto.TripMemberLocationDto;
 import kr.co.yeogiga.application.trip.service.TripMemberLocationCommandService;
+import kr.co.yeogiga.application.trip.service.TripMemberLocationQueryService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import kr.co.yeogiga.presentation.trip.api.TripMemberLocationApi;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class TripMemberLocationController implements TripMemberLocationApi {
     private final TripMemberLocationCommandService tripMemberLocationCommandService;
+    private final TripMemberLocationQueryService tripMemberLocationQueryService;
 
     @Override
     @PostMapping("/{tripId}/members/location")
@@ -31,5 +34,14 @@ public class TripMemberLocationController implements TripMemberLocationApi {
     ) {
         tripMemberLocationCommandService.saveLocation(tripId, userDetails.getUserId(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
+    }
+    
+    @GetMapping("/{tripId}/members/location")
+    public ResponseEntity<?> getLocations(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long tripId
+    ) {
+        return ResponseEntity.ok()
+                .body(SuccessResponse.from(tripMemberLocationQueryService.readMemberLocations(tripId, userDetails.getUserId())));
     }
 }

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripMemberLocationQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripMemberLocationQueryServiceTest.java
@@ -1,0 +1,115 @@
+package kr.co.yeogiga.application.trip.service;
+
+import kr.co.yeogiga.application.trip.dto.TripMemberLocationDto;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.exception.TripMemberErrorType;
+import kr.co.yeogiga.domain.trip.service.TripMemberService;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.service.UserService;
+import kr.co.yeogiga.domain.user.type.Role;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TripMemberLocationQueryServiceTest {
+
+    @Mock
+    private RedisRepository redisRepository;
+    
+    @Mock
+    private TripMemberService tripMemberService;
+    
+    @Mock
+    private UserService userService;
+    
+    @InjectMocks
+    private TripMemberLocationQueryService tripMemberLocationQueryService;
+    
+    @Nested
+    @DisplayName("여행 멤버 위치 조회")
+    class GetMemberLocations {
+        private final Long tripId = 1L;
+        private final Long userId = 1L;
+        
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            TripMemberLocationDto.StoredFormat storedInfo
+                    = new TripMemberLocationDto.StoredFormat(1.1, 2.2, 1L);
+            
+            User user = User.builder()
+                    .username("username")
+                    .password("password")
+                    .nickname("nickname")
+                    .role(Role.USER)
+                    .email("test@test.com")
+                    .build();
+            
+            ReflectionTestUtils.setField(user, "id", userId);
+            
+            when(tripMemberService.existsByTripIdAndUserId(tripId, userId)).thenReturn(true);
+            when(redisRepository.getHashAll(anyString(), any(), any())).thenReturn(List.of(storedInfo));
+            when(userService.readAllByIds(any())).thenReturn(List.of(user));
+            
+            // when
+            List<TripMemberLocationDto.Response> result
+                    = tripMemberLocationQueryService.readMemberLocations(tripId, userId);
+            
+            // then
+            assertThat(result).hasSize(1);
+            assertEquals(1.1, result.get(0).latitude());
+            assertEquals(2.2, result.get(0).longitude());
+            assertEquals(userId, result.get(0).userId());
+            assertEquals(user.getNickname(), result.get(0).nickname());
+            assertEquals(user.getImageUrl(), result.get(0).imageUrl());
+        }
+        
+        @Test
+        @DisplayName("성공 - 아직 저장된 위치 정보가 없을 경우")
+        void successIfNoStoredInfo() {
+            // given
+            when(tripMemberService.existsByTripIdAndUserId(tripId, userId)).thenReturn(true);
+            when(redisRepository.getHashAll(anyString(), any(), any())).thenReturn(Collections.emptyList());
+            
+            // when
+            List<TripMemberLocationDto.Response> result
+                    = tripMemberLocationQueryService.readMemberLocations(tripId, userId);
+            
+            // then
+            assertThat(result).hasSize(0);
+        }
+        
+        @Test
+        @DisplayName("실패 - 여행이 존재하기 않거나 멤버가 아닌 경우")
+        void failIfTripNotFoundOrNotMember() {
+            // given
+            when(tripMemberService.existsByTripIdAndUserId(tripId, userId)).thenReturn(false);
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> tripMemberLocationQueryService.readMemberLocations(tripId, userId));
+            
+            // then
+            assertEquals(TripMemberErrorType.IS_NOT_MEMBER, exception.getErrorType());
+        }
+    }
+    
+}

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripMemberLocationControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripMemberLocationControllerTest.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.presentation.trip.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.trip.dto.TripMemberLocationDto;
 import kr.co.yeogiga.application.trip.service.TripMemberLocationCommandService;
+import kr.co.yeogiga.application.trip.service.TripMemberLocationQueryService;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
@@ -28,11 +29,16 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.util.Collections;
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -54,6 +60,9 @@ public class TripMemberLocationControllerTest {
     
     @MockBean
     private TripMemberLocationCommandService tripMemberLocationCommandService;
+    
+    @MockBean
+    private TripMemberLocationQueryService tripMemberLocationQueryService;
     
     private CustomUserDetails userDetails;
     
@@ -159,6 +168,80 @@ public class TripMemberLocationControllerTest {
                     .andExpect(jsonPath("$.code").value(TripMemberErrorType.IS_NOT_MEMBER.getCode()))
                     .andExpect(jsonPath("$.message").value(TripMemberErrorType.IS_NOT_MEMBER.getMessage()));
                     
+        }
+    }
+    
+    @Nested
+    @DisplayName("여행 멤버 위치 조회")
+    class GetMemberLocations {
+        private final Long userId = 1L;
+        private final Long tripId = 1L;
+        
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            TripMemberLocationDto.Response response = TripMemberLocationDto.Response.builder()
+                    .longitude(1.1)
+                    .latitude(2.2)
+                    .userId(userId)
+                    .imageUrl(null)
+                    .nickname("nickname")
+                    .build();
+            
+            when(tripMemberLocationQueryService.readMemberLocations(anyLong(), any())).thenReturn(List.of(response));
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip/{tripId}/members/location", tripId)
+                            .with(user(userDetails))
+            );
+            
+            // when
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data[0].longitude").value(response.longitude()))
+                    .andExpect(jsonPath("$.data[0].latitude").value(response.latitude()))
+                    .andExpect(jsonPath("$.data[0].userId").value(response.userId()))
+                    .andExpect(jsonPath("$.data[0].imageUrl").value(response.imageUrl()))
+                    .andExpect(jsonPath("$.data[0].nickname").value(response.nickname()));
+        }
+
+        @Test
+        @DisplayName("성공 - 저장된 위치 정보가 없는 경우")
+        void successIfLocationNotStored() throws Exception {
+            // given
+            when(tripMemberLocationQueryService.readMemberLocations(anyLong(), any())).thenReturn(Collections.emptyList());
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip/{tripId}/members/location", tripId)
+                            .with(user(userDetails))
+            );
+            
+            // when
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data").isArray());
+        }
+        
+        @Test
+        @DisplayName("실패 - 여행이 존재하지 않거나 여행 멤버가 아닌 경우")
+        void failIfTripNotFoundOrMemberNotStored() throws Exception {
+            // given
+            doThrow(new CustomException(TripMemberErrorType.IS_NOT_MEMBER)).when(tripMemberLocationQueryService).readMemberLocations(anyLong(), any());
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip/{tripId}/members/location", tripId)
+                            .with(user(userDetails))
+            );
+            
+            // when
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(TripMemberErrorType.IS_NOT_MEMBER.getCode()))
+                    .andExpect(jsonPath("$.message").value(TripMemberErrorType.IS_NOT_MEMBER.getMessage()));
         }
     }
 }


### PR DESCRIPTION
## 배경
- 여행 멤버 위치 조회 기능 필요

## 작업 사항
- 여행 멤버 위치 조회 로직 구현 | (5a9b5c8d4ae38d2daf4c771270d68492bdb3ec0d)

## 추가 논의
- 만약 아직 여행 멤버 위치 정보가 아무도 저장되지 않았을 경우 빈 리스트를 응답하도록 해놓았습니다.
```json
{
   "code": 200,
   "message": "요청이 성공하였습니다.",
   "data": []
}
```

## 기타
- Slient Push부터해서 여행 멤버 위치 저장 및 조회 로직 노션에 정리해놓겠습니다.