### PR TITLE
Feature(IL-170): 집결지 요청 후 푸시 알림 적용

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/fcm/constant/FcmConstant.java
+++ b/src/main/java/kr/co/yeogiga/application/fcm/constant/FcmConstant.java
@@ -7,7 +7,14 @@ public final class FcmConstant {
     private static final String FCM_TITLE = "%s 여행이 시작되었습니다!";
     public static final String FCM_BODY = "앱을 열어 여행 일정을 확인해보세요.";
 
+    private static final String PIN_FCM_TITLE = "%s - 집결지 요청";
+    public static final String PIN_FCM_BODY = "앱을 열어 집결지 요청을 확인해보세요.";
+
     public static String formatTitle(String title) {
         return String.format(FCM_TITLE, title);
+    }
+
+    public static String formatPinTitle(String title) {
+        return String.format(PIN_FCM_TITLE, title);
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/fcm/constant/FcmConstant.java
+++ b/src/main/java/kr/co/yeogiga/application/fcm/constant/FcmConstant.java
@@ -5,10 +5,9 @@ public final class FcmConstant {
     private FcmConstant() { }
 
     private static final String FCM_TITLE = "%s 여행이 시작되었습니다!";
-    public static final String FCM_BODY = "앱을 열어 여행 일정을 확인해보세요.";
+    public static final String FCM_BODY = "앱을 열어 여행 확인해보세요.";
 
     private static final String PIN_FCM_TITLE = "%s - 집결지 요청";
-    public static final String PIN_FCM_BODY = "앱을 열어 집결지 요청을 확인해보세요.";
 
     public static String formatTitle(String title) {
         return String.format(FCM_TITLE, title);

--- a/src/main/java/kr/co/yeogiga/application/fcm/service/TripPushSender.java
+++ b/src/main/java/kr/co/yeogiga/application/fcm/service/TripPushSender.java
@@ -2,6 +2,7 @@ package kr.co.yeogiga.application.fcm.service;
 
 import kr.co.yeogiga.application.fcm.constant.FcmConstant;
 import kr.co.yeogiga.application.user.service.UserFcmTokenService;
+import kr.co.yeogiga.domain.pin.entity.Pin;
 import kr.co.yeogiga.infrastructure.fcm.FcmNotificationSender;
 import kr.co.yeogiga.infrastructure.fcm.response.FcmSendResult;
 import kr.co.yeogiga.infrastructure.redis.RedisRepository;
@@ -66,6 +67,31 @@ public class TripPushSender {
     }
 
     /**
+     * FCM 토큰을 통해 집결지(Pin) Notification Push를 비동기로 전송하는 메서드
+     * - 유효하지 않은 토큰은 Redis 및 RDB에서 제거
+     *
+     * @param tripId        알림 대상 여행 ID
+     * @param title         알림 대상 여행 제목
+     * @param pin           Pin 정보
+     * @param redisListKey  FCM 토큰이 저장된 Redis 리스트 키
+     * @param fcmTokens     푸시 알림 전송 대상 FCM 토큰 List
+     */
+    @Async
+    public void sendPinPush(Long tripId, String title, Pin pin, String redisListKey, List<String> fcmTokens) {
+        Map<String, String> notificationData = buildPinPushData(tripId, pin);
+        String pushTitle = FcmConstant.formatPinTitle(title);
+        String body = FcmConstant.PIN_FCM_BODY;
+
+        for (String fcmToken : fcmTokens) {
+            FcmSendResult result = fcmNotificationSender.sendNotification(fcmToken, pushTitle, body, notificationData);
+
+            if (result.shouldRemoveToken()) {
+                deleteFcmToken(redisListKey, fcmToken);
+            }
+        }
+    }
+
+    /**
      * 유효하지 않은 FCM Token을 삭제하는 메서드
      * - Redis 및 RDB에 저장된 FCM Token 정보를 삭제
      *
@@ -87,5 +113,22 @@ public class TripPushSender {
         Map<String, String> data = new HashMap<>();
         data.put("tripId", tripId.toString());
         return data;
+    }
+
+    /**
+     * 집결지(Pin) Push data 생성 메서드
+     *
+     * @param tripId    알림 대상 여행 ID
+     * @param pin       집결지 정보
+     * @return          집결지 정보가 저장된 Map 자료구조
+     */
+    private Map<String, String> buildPinPushData(Long tripId, Pin pin) {
+        return Map.of(
+                "tripId", tripId.toString(),
+                "place", pin.getPlace(),
+                "latitude", pin.getLatitude().toString(),
+                "longitude", pin.getLongitude().toString(),
+                "time", pin.getTime().toString()
+        );
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/fcm/service/TripPushSender.java
+++ b/src/main/java/kr/co/yeogiga/application/fcm/service/TripPushSender.java
@@ -67,31 +67,6 @@ public class TripPushSender {
     }
 
     /**
-     * FCM 토큰을 통해 집결지(Pin) Notification Push를 비동기로 전송하는 메서드
-     * - 유효하지 않은 토큰은 Redis 및 RDB에서 제거
-     *
-     * @param tripId        알림 대상 여행 ID
-     * @param title         알림 대상 여행 제목
-     * @param pin           Pin 정보
-     * @param redisListKey  FCM 토큰이 저장된 Redis 리스트 키
-     * @param fcmTokens     푸시 알림 전송 대상 FCM 토큰 List
-     */
-    @Async
-    public void sendPinPush(Long tripId, String title, Pin pin, String redisListKey, List<String> fcmTokens) {
-        Map<String, String> notificationData = buildPinPushData(tripId, pin);
-        String pushTitle = FcmConstant.formatPinTitle(title);
-        String body = FcmConstant.PIN_FCM_BODY;
-
-        for (String fcmToken : fcmTokens) {
-            FcmSendResult result = fcmNotificationSender.sendNotification(fcmToken, pushTitle, body, notificationData);
-
-            if (result.shouldRemoveToken()) {
-                deleteFcmToken(redisListKey, fcmToken);
-            }
-        }
-    }
-
-    /**
      * 유효하지 않은 FCM Token을 삭제하는 메서드
      * - Redis 및 RDB에 저장된 FCM Token 정보를 삭제
      *
@@ -113,22 +88,5 @@ public class TripPushSender {
         Map<String, String> data = new HashMap<>();
         data.put("tripId", tripId.toString());
         return data;
-    }
-
-    /**
-     * 집결지(Pin) Push data 생성 메서드
-     *
-     * @param tripId    알림 대상 여행 ID
-     * @param pin       집결지 정보
-     * @return          집결지 정보가 저장된 Map 자료구조
-     */
-    private Map<String, String> buildPinPushData(Long tripId, Pin pin) {
-        return Map.of(
-                "tripId", tripId.toString(),
-                "place", pin.getPlace(),
-                "latitude", pin.getLatitude().toString(),
-                "longitude", pin.getLongitude().toString(),
-                "time", pin.getTime().toString()
-        );
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/pin/service/PinCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/pin/service/PinCommandService.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.application.pin.service;
 
+import kr.co.yeogiga.application.fcm.constant.FcmConstant;
 import kr.co.yeogiga.application.fcm.service.TripPushSender;
 import kr.co.yeogiga.application.pin.dto.PinReq;
 import kr.co.yeogiga.common.exception.CustomException;
@@ -41,7 +42,7 @@ public class PinCommandService {
         redisRepository.set(pinKey, pin.toEntity(), calculatePinDuration(pin.time()));
 
         // Push 알림 전송
-        sendPinPush(tripId, pin);
+        sendPinPush(tripId);
     }
 
     /**
@@ -64,9 +65,8 @@ public class PinCommandService {
      * 집결지(Pin) 생성 후 Push 알림을 보내는 메서드
      *
      * @param tripId    알림 대상 여행 ID
-     * @param pin       집결지 정보
      */
-    private void sendPinPush(Long tripId, PinReq.Creation pin) {
+    private void sendPinPush(Long tripId) {
         List<TripFcmTokenInfoDto> fcmTokenInfos = tripService.readTripFcmTokenInfosById(tripId);
 
         if (fcmTokenInfos.isEmpty()) return;
@@ -79,6 +79,6 @@ public class PinCommandService {
 
         String redisKey = TripMemberTokenConstant.tripTokenKey(tripId);
 
-        tripPushSender.sendPinPush(tripId, title, pin.toEntity(), redisKey, fcmTokens);
+        tripPushSender.sendPush(tripId, FcmConstant.formatPinTitle(title), redisKey, fcmTokens);
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/pin/service/PinCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/pin/service/PinCommandService.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.application.pin.service;
 import kr.co.yeogiga.application.fcm.service.TripPushSender;
 import kr.co.yeogiga.application.pin.dto.PinReq;
 import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.common.response.error.type.CommonErrorType;
 import kr.co.yeogiga.domain.trip.dto.TripFcmTokenInfoDto;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.service.TripService;
@@ -50,6 +51,12 @@ public class PinCommandService {
      * @return              집결지 핀 만료 기한
      */
     private Duration calculatePinDuration(LocalDateTime time) {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (time.isBefore(now)) {
+            throw new CustomException(CommonErrorType.TIME_SHOULD_NOT_BEFORE_NOW);
+        }
+
         return Duration.between(LocalDateTime.now(), time);
     }
 

--- a/src/main/java/kr/co/yeogiga/application/pin/service/PinCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/pin/service/PinCommandService.java
@@ -1,22 +1,28 @@
 package kr.co.yeogiga.application.pin.service;
 
+import kr.co.yeogiga.application.fcm.service.TripPushSender;
 import kr.co.yeogiga.application.pin.dto.PinReq;
 import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.dto.TripFcmTokenInfoDto;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.service.TripService;
 import kr.co.yeogiga.infrastructure.redis.RedisRepository;
 import kr.co.yeogiga.infrastructure.redis.constant.PinConstant;
+import kr.co.yeogiga.infrastructure.redis.constant.TripMemberTokenConstant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class PinCommandService {
     private final TripService tripService;
     private final RedisRepository redisRepository;
+    private final TripPushSender tripPushSender;
 
     /**
      * 집결지 핀 생성 요청 메서드
@@ -24,6 +30,7 @@ public class PinCommandService {
      * @param tripId    여행 ID
      * @param pin       핀 생성 요청 DTO
      */
+    @Transactional(readOnly = true)
     public void createPin(Long tripId, PinReq.Creation pin) {
         if (!tripService.existsById(tripId)) {
             throw new CustomException(TripErrorType.TRIP_NOT_FOUND);
@@ -31,6 +38,9 @@ public class PinCommandService {
 
         String pinKey = PinConstant.pinKey(tripId);
         redisRepository.set(pinKey, pin.toEntity(), calculatePinDuration(pin.time()));
+
+        // Push 알림 전송
+        sendPinPush(tripId, pin);
     }
 
     /**
@@ -41,5 +51,27 @@ public class PinCommandService {
      */
     private Duration calculatePinDuration(LocalDateTime time) {
         return Duration.between(LocalDateTime.now(), time);
+    }
+
+    /**
+     * 집결지(Pin) 생성 후 Push 알림을 보내는 메서드
+     *
+     * @param tripId    알림 대상 여행 ID
+     * @param pin       집결지 정보
+     */
+    private void sendPinPush(Long tripId, PinReq.Creation pin) {
+        List<TripFcmTokenInfoDto> fcmTokenInfos = tripService.readTripFcmTokenInfosById(tripId);
+
+        if (fcmTokenInfos.isEmpty()) return;
+
+        List<String> fcmTokens = fcmTokenInfos.stream()
+                .map(TripFcmTokenInfoDto::fcmToken)
+                .toList();
+
+        String title = fcmTokenInfos.get(0).title();
+
+        String redisKey = TripMemberTokenConstant.tripTokenKey(tripId);
+
+        tripPushSender.sendPinPush(tripId, title, pin.toEntity(), redisKey, fcmTokens);
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.application.trip.service;
 
+import kr.co.yeogiga.application.fcm.constant.FcmConstant;
 import kr.co.yeogiga.application.fcm.service.TripPushSender;
 import kr.co.yeogiga.application.trip.dto.TripReq;
 import kr.co.yeogiga.common.exception.CustomException;
@@ -159,7 +160,7 @@ public class TripCommandService {
         redisRepository.expire(redisKey, calculateDuration(endedAt));
 
         // Push 알림 전송
-        tripPushSender.sendPush(tripId, title, redisKey, tokens);
+        tripPushSender.sendPush(tripId, FcmConstant.formatTitle(title), redisKey, tokens);
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/common/response/error/type/CommonErrorType.java
+++ b/src/main/java/kr/co/yeogiga/common/response/error/type/CommonErrorType.java
@@ -11,7 +11,7 @@ public enum CommonErrorType implements BaseErrorType {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G001", "서버 내부 에러입니다."),
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "G002", "유효성 검증에 실패하였습니다."),
     PATH_VARIABLE_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "G003", "지원하지 않는 Path Variable 값입니다."),
-    ;
+    TIME_SHOULD_NOT_BEFORE_NOW(HttpStatus.BAD_REQUEST, "G004", "요청 시각은 현재 시각 이전이 될 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/kr/co/yeogiga/domain/trip/dto/TripFcmTokenInfoDto.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/dto/TripFcmTokenInfoDto.java
@@ -1,0 +1,8 @@
+package kr.co.yeogiga.domain.trip.dto;
+
+public record TripFcmTokenInfoDto (
+        Long tripId,
+        String title,
+        String fcmToken
+) {
+}

--- a/src/main/java/kr/co/yeogiga/domain/trip/entity/Trip.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/entity/Trip.java
@@ -42,7 +42,7 @@ public class Trip {
     @Column(name = "ended_at")
     private LocalDateTime endedAt;
 
-    @Column(name = "deleted_At")
+    @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
     @Column(name = "travel_status", nullable = false)

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripRepository.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.domain.trip.repository;
 
+import kr.co.yeogiga.domain.trip.dto.TripFcmTokenInfoDto;
 import kr.co.yeogiga.domain.trip.dto.TripFcmTokenQueryDto;
 
 import java.time.LocalDateTime;
@@ -7,4 +8,6 @@ import java.util.List;
 
 public interface CustomTripRepository {
     List<TripFcmTokenQueryDto> findTripFcmTokensByTime(LocalDateTime time);
+
+    List<TripFcmTokenInfoDto> findTripFcmTokenInfosById(Long tripId);
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripRepositoryImpl.java
@@ -1,7 +1,9 @@
 package kr.co.yeogiga.domain.trip.repository;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.co.yeogiga.domain.trip.dto.TripFcmTokenInfoDto;
 import kr.co.yeogiga.domain.trip.dto.TripFcmTokenQueryDto;
 import kr.co.yeogiga.domain.trip.entity.QTrip;
 import kr.co.yeogiga.domain.trip.entity.QTripMember;
@@ -37,6 +39,25 @@ public class CustomTripRepositoryImpl implements CustomTripRepository {
                         trip.travelStatus.notIn(TravelStatus.IN_PROGRESS, TravelStatus.SETTING),
                         trip.startedAt.loe(time),
                         trip.endedAt.goe(time)
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<TripFcmTokenInfoDto> findTripFcmTokenInfosById(Long tripId) {
+        return jpaQueryFactory
+                .select(Projections.constructor(
+                        TripFcmTokenInfoDto.class,
+                        Expressions.asNumber(tripId).as("tripId"),
+                        trip.title,
+                        user.fcmToken
+                ))
+                .from(tripMember)
+                .join(tripMember.trip, trip)
+                .join(tripMember.user, user)
+                .where(
+                        trip.id.eq(tripId)
+                                .and(user.fcmToken.isNotNull())
                 )
                 .fetch();
     }

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/TripService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/TripService.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.domain.trip.service;
 
+import kr.co.yeogiga.domain.trip.dto.TripFcmTokenInfoDto;
 import kr.co.yeogiga.domain.trip.dto.TripFcmTokenQueryDto;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.repository.TripRepository;
@@ -34,6 +35,10 @@ public class TripService {
 
     public List<TripFcmTokenQueryDto> readTripFcmTokensByTime(LocalDateTime time) {
         return tripRepository.findTripFcmTokensByTime(time);
+    }
+
+    public List<TripFcmTokenInfoDto> readTripFcmTokenInfosById(Long tripId) {
+        return tripRepository.findTripFcmTokenInfosById(tripId);
     }
 
     public boolean existsById(Long tripId) {

--- a/src/main/java/kr/co/yeogiga/presentation/pin/api/PinApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/pin/api/PinApi.java
@@ -76,6 +76,12 @@ public interface PinApi {
                                                   "longitude": "경도는 필수 입력값입니다."
                                               }
                                           }
+                                    """),
+                            @ExampleObject(name = "요청 시간이 현재 시간보다 이전인 경우", value = """
+                                        {
+                                              "code": "G004",
+                                              "message" : "요청 시각은 현재 시각 이전이 될 수 없습니다."
+                                          }
                                     """)
                     })),
             @ApiResponse(responseCode = "404", description = "집결지 핀 생성 실패",

--- a/src/main/java/kr/co/yeogiga/presentation/pin/api/PinApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/pin/api/PinApi.java
@@ -1,4 +1,4 @@
-package kr.co.yeogiga.presentation.pin.controller.api;
+package kr.co.yeogiga.presentation.pin.api;
 
 import api.link.checker.annotation.ApiGroup;
 import api.link.checker.annotation.TrackApi;

--- a/src/main/java/kr/co/yeogiga/presentation/pin/controller/PinController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/pin/controller/PinController.java
@@ -5,7 +5,7 @@ import kr.co.yeogiga.application.pin.dto.PinReq;
 import kr.co.yeogiga.application.pin.service.PinCommandService;
 import kr.co.yeogiga.application.pin.service.PinQueryService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
-import kr.co.yeogiga.presentation.pin.controller.api.PinApi;
+import kr.co.yeogiga.presentation.pin.api.PinApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/test/java/kr/co/yeogiga/application/pin/service/PinCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/pin/service/PinCommandServiceTest.java
@@ -29,7 +29,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -75,7 +74,7 @@ public class PinCommandServiceTest {
 
             when(tripService.existsById(tripId)).thenReturn(true);
             when(tripService.readTripFcmTokenInfosById(tripId)).thenReturn(List.of(fcmTokenInfoDto));
-            doNothing().when(tripPushSender).sendPinPush(anyLong(), anyString(), any(), anyString(), anyList());
+            doNothing().when(tripPushSender).sendPush(anyLong(), anyString(), anyString(), anyList());
 
             try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
                 String date = "2025-05-25T12:00:00Z";
@@ -88,7 +87,7 @@ public class PinCommandServiceTest {
 
                 // then
                 verify(redisRepository, times(1)).set(isA(String.class), isA(Pin.class), isA(Duration.class));
-                verify(tripPushSender, times(1)).sendPinPush(anyLong(), anyString(), any(), anyString(), anyList());
+                verify(tripPushSender, times(1)).sendPush(anyLong(), anyString(), anyString(), anyList());
             }
 
         }
@@ -111,7 +110,7 @@ public class PinCommandServiceTest {
 
                 // then
                 verify(redisRepository, times(1)).set(isA(String.class), isA(Pin.class), isA(Duration.class));
-                verify(tripPushSender,never()).sendPinPush(anyLong(), anyString(), any(), anyString(), anyList());
+                verify(tripPushSender,never()).sendPush(anyLong(), anyString(), anyString(), anyList());
             }
         }
 

--- a/src/test/java/kr/co/yeogiga/application/pin/service/PinCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/pin/service/PinCommandServiceTest.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.application.pin.service;
 import kr.co.yeogiga.application.fcm.service.TripPushSender;
 import kr.co.yeogiga.application.pin.dto.PinReq;
 import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.common.response.error.type.CommonErrorType;
 import kr.co.yeogiga.domain.pin.entity.Pin;
 import kr.co.yeogiga.domain.trip.dto.TripFcmTokenInfoDto;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
@@ -14,10 +15,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 
@@ -71,12 +77,20 @@ public class PinCommandServiceTest {
             when(tripService.readTripFcmTokenInfosById(tripId)).thenReturn(List.of(fcmTokenInfoDto));
             doNothing().when(tripPushSender).sendPinPush(anyLong(), anyString(), any(), anyString(), anyList());
 
-            // when
-            pinCommandService.createPin(tripId, request);
+            try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+                String date = "2025-05-25T12:00:00Z";
+                Clock clock = Clock.fixed(Instant.parse(date), ZoneId.of("UTC"));
+                LocalDateTime mockNow = LocalDateTime.now(clock);
+                mockedLocalDateTime.when(LocalDateTime::now).thenReturn(mockNow);
 
-            // then
-            verify(redisRepository, times(1)).set(isA(String.class), isA(Pin.class), isA(Duration.class));
-            verify(tripPushSender, times(1)).sendPinPush(anyLong(), anyString(), any(), anyString(), anyList());
+                // when
+                pinCommandService.createPin(tripId, request);
+
+                // then
+                verify(redisRepository, times(1)).set(isA(String.class), isA(Pin.class), isA(Duration.class));
+                verify(tripPushSender, times(1)).sendPinPush(anyLong(), anyString(), any(), anyString(), anyList());
+            }
+
         }
 
         @Test
@@ -86,12 +100,19 @@ public class PinCommandServiceTest {
             when(tripService.existsById(tripId)).thenReturn(true);
             when(tripService.readTripFcmTokenInfosById(tripId)).thenReturn(Collections.emptyList());
 
-            // when
-            pinCommandService.createPin(tripId, request);
+            try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+                String date = "2025-05-25T12:00:00Z";
+                Clock clock = Clock.fixed(Instant.parse(date), ZoneId.of("UTC"));
+                LocalDateTime mockNow = LocalDateTime.now(clock);
+                mockedLocalDateTime.when(LocalDateTime::now).thenReturn(mockNow);
 
-            // then
-            verify(redisRepository, times(1)).set(isA(String.class), isA(Pin.class), isA(Duration.class));
-            verify(tripPushSender,never()).sendPinPush(anyLong(), anyString(), any(), anyString(), anyList());
+                // when
+                pinCommandService.createPin(tripId, request);
+
+                // then
+                verify(redisRepository, times(1)).set(isA(String.class), isA(Pin.class), isA(Duration.class));
+                verify(tripPushSender,never()).sendPinPush(anyLong(), anyString(), any(), anyString(), anyList());
+            }
         }
 
         @Test
@@ -106,6 +127,26 @@ public class PinCommandServiceTest {
 
             // then
             assertEquals(TripErrorType.TRIP_NOT_FOUND, exception.getErrorType());
+        }
+
+        @Test
+        @DisplayName("실패 - 요청 시각이 현재 시각보다 이전인 경우")
+        void failIfRequestTimeIsBeforeNow() {
+            when(tripService.existsById(tripId)).thenReturn(true);
+
+            try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+                String date = "2025-07-01T12:00:00Z";
+                Clock clock = Clock.fixed(Instant.parse(date), ZoneId.of("UTC"));
+                LocalDateTime mockNow = LocalDateTime.now(clock);
+                mockedLocalDateTime.when(LocalDateTime::now).thenReturn(mockNow);
+
+                // when
+                CustomException exception = assertThrows(CustomException.class,
+                        () -> pinCommandService.createPin(tripId, request));
+
+                // then
+                assertEquals(CommonErrorType.TIME_SHOULD_NOT_BEFORE_NOW, exception.getErrorType());
+            }
         }
     }
 

--- a/src/test/java/kr/co/yeogiga/application/pin/service/PinCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/pin/service/PinCommandServiceTest.java
@@ -1,8 +1,10 @@
 package kr.co.yeogiga.application.pin.service;
 
+import kr.co.yeogiga.application.fcm.service.TripPushSender;
 import kr.co.yeogiga.application.pin.dto.PinReq;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.pin.entity.Pin;
+import kr.co.yeogiga.domain.trip.dto.TripFcmTokenInfoDto;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.service.TripService;
 import kr.co.yeogiga.infrastructure.redis.RedisRepository;
@@ -16,10 +18,18 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -32,6 +42,9 @@ public class PinCommandServiceTest {
 
     @Mock
     private RedisRepository redisRepository;
+
+    @Mock
+    private TripPushSender tripPushSender;
 
     @InjectMocks
     private PinCommandService pinCommandService;
@@ -52,13 +65,33 @@ public class PinCommandServiceTest {
         @DisplayName("성공")
         void success() {
             // given
+            TripFcmTokenInfoDto fcmTokenInfoDto = new TripFcmTokenInfoDto(1L, "title", "fcm-token");
+
             when(tripService.existsById(tripId)).thenReturn(true);
+            when(tripService.readTripFcmTokenInfosById(tripId)).thenReturn(List.of(fcmTokenInfoDto));
+            doNothing().when(tripPushSender).sendPinPush(anyLong(), anyString(), any(), anyString(), anyList());
 
             // when
             pinCommandService.createPin(tripId, request);
 
             // then
             verify(redisRepository, times(1)).set(isA(String.class), isA(Pin.class), isA(Duration.class));
+            verify(tripPushSender, times(1)).sendPinPush(anyLong(), anyString(), any(), anyString(), anyList());
+        }
+
+        @Test
+        @DisplayName("성공 - FCM 토큰 저장 정보가 없는 경우")
+        void successIfFcmTokenNotFound() {
+            // given
+            when(tripService.existsById(tripId)).thenReturn(true);
+            when(tripService.readTripFcmTokenInfosById(tripId)).thenReturn(Collections.emptyList());
+
+            // when
+            pinCommandService.createPin(tripId, request);
+
+            // then
+            verify(redisRepository, times(1)).set(isA(String.class), isA(Pin.class), isA(Duration.class));
+            verify(tripPushSender,never()).sendPinPush(anyLong(), anyString(), any(), anyString(), anyList());
         }
 
         @Test


### PR DESCRIPTION
## 배경
- 집결지 요청 후 FCM 푸시 알림 필요

## 작업 사항
- 집결지 요청 후 알림용 dto 생성 | (fd3e754938cbfc4b07717d6e80d2f2109b70d71f)
	- 카톡으로 이야기드렸듯이 원래 클래스 안에 dto를 레코드로 나눌까 고민하였지만, 불필요한 변경이 많을 것 같아 다른 클래스로 dto 생성하였습니다.
<br/>

- 여행 id(pk)를 통한 여행 멤버 FcmToken 조회 메서드 추가 | (e53c6ac116589e921a198d53aacf994a2472c773)
<br/>

- 집결지 요청 후 알림 요청 로직 추가 | (323017c3aa03ae4fd5103a75c0fd0e963a999b24)

## 추가 논의
- 현재 `TripPushSender` 내 Slient Push와 여행 시작 시 Notification Push처럼 `sendPush(...)`를 오버로딩할까봐 고민하였지만, 메서드명을 명확하게 나누는 것이 좋을 것 같아 `sendPinPush(...)`로 작성하였습니다.
