### PR TITLE
Refactor: TripRepository QueryDsl 마이그레이션

### DIFF
--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripRepository.java
@@ -5,9 +5,16 @@ import kr.co.yeogiga.domain.trip.dto.TripFcmTokenQueryDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface CustomTripRepository {
     List<TripFcmTokenQueryDto> findTripFcmTokensByTime(LocalDateTime time);
 
     List<TripFcmTokenInfoDto> findTripFcmTokenInfosById(Long tripId);
+
+    Optional<Long> findLeaderIdById(Long tripId);
+
+    void updateTravelStatusInProgress(LocalDateTime time);
+
+    void updateTravelStatusCompleted(LocalDateTime time);
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripRepositoryImpl.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class CustomTripRepositoryImpl implements CustomTripRepository {
@@ -60,5 +61,43 @@ public class CustomTripRepositoryImpl implements CustomTripRepository {
                                 .and(user.fcmToken.isNotNull())
                 )
                 .fetch();
+    }
+
+    @Override
+    public Optional<Long> findLeaderIdById(Long tripId) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .select(trip.leaderId)
+                        .from(trip)
+                        .where(trip.id.eq(tripId))
+                        .fetchOne()
+        );
+    }
+
+    @Override
+    public void updateTravelStatusInProgress(LocalDateTime time) {
+        jpaQueryFactory
+                .update(trip)
+                .set(trip.travelStatus, TravelStatus.IN_PROGRESS)
+                .where(
+                        trip.travelStatus.ne(TravelStatus.IN_PROGRESS),
+                        trip.travelStatus.ne(TravelStatus.SETTING),
+                        trip.startedAt.loe(time),
+                        trip.endedAt.goe(time)
+                )
+                .execute();
+    }
+
+    @Override
+    public void updateTravelStatusCompleted(LocalDateTime time) {
+        jpaQueryFactory
+                .update(trip)
+                .set(trip.travelStatus, TravelStatus.COMPLETED)
+                .where(
+                        trip.travelStatus.ne(TravelStatus.COMPLETED),
+                        trip.travelStatus.ne(TravelStatus.SETTING),
+                        trip.endedAt.loe(time)
+                )
+                .execute();
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripRepositoryImpl.java
@@ -80,8 +80,7 @@ public class CustomTripRepositoryImpl implements CustomTripRepository {
                 .update(trip)
                 .set(trip.travelStatus, TravelStatus.IN_PROGRESS)
                 .where(
-                        trip.travelStatus.ne(TravelStatus.IN_PROGRESS),
-                        trip.travelStatus.ne(TravelStatus.SETTING),
+                        trip.travelStatus.notIn(TravelStatus.IN_PROGRESS, TravelStatus.SETTING),
                         trip.startedAt.loe(time),
                         trip.endedAt.goe(time)
                 )
@@ -94,8 +93,7 @@ public class CustomTripRepositoryImpl implements CustomTripRepository {
                 .update(trip)
                 .set(trip.travelStatus, TravelStatus.COMPLETED)
                 .where(
-                        trip.travelStatus.ne(TravelStatus.COMPLETED),
-                        trip.travelStatus.ne(TravelStatus.SETTING),
+                        trip.travelStatus.notIn(TravelStatus.COMPLETED, TravelStatus.SETTING),
                         trip.endedAt.loe(time)
                 )
                 .execute();

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/TripRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/TripRepository.java
@@ -2,31 +2,11 @@ package kr.co.yeogiga.domain.trip.repository;
 
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 public interface TripRepository extends JpaRepository<Trip, Long>, CustomTripRepository {
 
-    @Modifying
-    @Query("UPDATE trip " +
-            "SET travelStatus = 'IN_PROGRESS' " +
-            "WHERE travelStatus != 'IN_PROGRESS' AND travelStatus != 'SETTING' AND startedAt <= :time AND :time <= endedAt")
-    void updateTravelStatusInProgress(@Param(value = "time") LocalDateTime time);
-
-    @Modifying
-    @Query("UPDATE trip " +
-            "SET travelStatus = 'COMPLETED' " +
-            "WHERE travelStatus != 'COMPLETED' AND travelStatus != 'SETTING' AND endedAt <= :time")
-    void updateTravelStatusCompleted(@Param(value = "time") LocalDateTime time);
-
     List<Trip> findAllByIdIn(Set<Long> ids);
-
-    @Query("SELECT t.leaderId FROM trip t WHERE t.id = :tripId")
-    Optional<Long> findLeaderIdById(@Param(value = "tripId") Long tripId);
 }

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
@@ -17,7 +17,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
                    "FROM users u " +
                    "INNER JOIN oauth o ON u.id = o.user_id " +
                    "WHERE o.platform = :platform AND o.platform_id = :platformId", nativeQuery = true)
-    Optional<User> findUserIncludeDeletedByPlatformAndPlatformId(@Param(value = "platform") OAuthPlatform platform, @Param("platformId") String platformId);
+    Optional<User> findUserIncludeDeletedByPlatformAndPlatformId(@Param(value = "platform") String platform, @Param("platformId") String platformId);
 
     @Query(value = "SELECT * " +
                    "FROM users " +

--- a/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
@@ -40,7 +40,7 @@ public class UserService {
     }
 
     public Optional<User> readIncludeDeletedUserByPlatformAndPlatformId(OAuthPlatform platform, String platformId) {
-        return userRepository.findUserIncludeDeletedByPlatformAndPlatformId(platform, platformId);
+        return userRepository.findUserIncludeDeletedByPlatformAndPlatformId(platform.name(), platformId);
     }
 
     public List<Long> readDeletedUserIdBefore(LocalDate date) {


### PR DESCRIPTION
## 배경
- 네이티브 쿼리 및 JPQL 코드 컴파일 시점 오류 확인 불가 및 가독성 이유로 인한 QueryDsl 마이그레이션 적용 필요성 대두

## 작업 사항
- `TripRepository` 내 JPQL 작성 코드 `CustomTripRepository` 및 `CustomTripRepositoryImpl` 마이그레이션 | (98d5be4f07ea8aa8b6489c5df2c7b9d8586e3cb7)
	- Spring-Data-JPA의 쿼리 메서드로 작성된 메서드는 그대로 두었습니다.

<br/>

- 네이티브 쿼리 사용 시 파라미터로 Enum 값 바인딩 오류로 인한 수정 | (47b7d3988b8caf1b1143d4bbbdc3238c708b7d57)
	- OAuth 로그인 시 오류 발생으로 인한 수정

## 추가 논의
- 해당 작업을 진행하며 찾아보니, QueryDsl 적용 후 벌크 업데이트와 같은 쿼리 동작시 영속성 컨텍스트가 업데이트 되지 않는 문제가 있으며 `@Modifying` 어노테이션을 적용해도 동작이 안 되는 것 같습니다. 
따라서, `entityManger`를 통해 `em.clear()`, `em.flush()`를 진행해주어야하지만 여행 상태 업데이트 메서드 내에서 업데이트 후 바로 사용하는 로직이 없기 때문에 따로 적용하지는 않았습니다.