### PR TITLE
Feature(IL-176): 여행 일정 변경 시, MongoDB 일정 데이터 동기화

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
@@ -10,6 +10,8 @@ import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.service.TripMemberService;
 import kr.co.yeogiga.domain.trip.service.TripService;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
+import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
+import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.exception.UserErrorType;
 import kr.co.yeogiga.domain.user.service.UserService;
@@ -20,7 +22,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -31,6 +36,7 @@ import java.util.stream.Collectors;
 public class TripCommandService {
     private final TripService tripService;
     private final TripMemberService tripMemberService;
+    private final TripDayPlaceService tripDayPlaceService;
     private final UserService userService;
     private final RedisRepository redisRepository;
     private final TripPushSender tripPushSender;
@@ -65,6 +71,7 @@ public class TripCommandService {
     /**
      * 여행 시간 수정 메서드
      * - 여행 일정과 목적지까지 확정이 나지 않은 상태(SETTING)일 경우, 여행 상태(TravelStatus)값 미변경
+     * - 기존 일정에서 일차 수의 변화가 생긴다면, 일차 정보를 담은 MongoDB 동기화
      *
      * @param tripId        여행 ID
      * @param userId        요청자 ID
@@ -87,12 +94,59 @@ public class TripCommandService {
             throw new CustomException(TripErrorType.PERMISSION_DENIED_NOT_LEADER);
         }
 
+        // 날짜 변경에 따른 MongoDB 동기화 (기존 값이 null이 아닌 경우만)
+        if (trip.getStartedAt() != null && trip.getEndedAt() != null) {
+            restructureTripDayPlaces(tripId, trip.getStartedAt(), trip.getEndedAt(), time.start(), time.end());
+        }
+
         if (trip.getTravelStatus() != TravelStatus.SETTING) {
             TravelStatus status = TravelStatus.resolveStatus(time.start(), time.end());
             trip.updateStatus(status);
         }
 
         trip.updateTime(time.start(), time.end());
+    }
+
+    /**
+     * 여행 시작일/종료일 변경 시, 일차별 장소(trip_day_place)를 동기화하는 메서드
+     * - 기존보다 늘어나면 새로 생성하고, 줄어들면 해당 날짜 이후의 데이터를 삭제
+     *
+     * @param tripId          여행 ID
+     * @param currentStart    기존 시작일
+     * @param currentEnd      기존 종료일
+     * @param newStart        변경된 시작일
+     * @param newEnd          변경된 종료일
+     */
+    private void restructureTripDayPlaces(
+            Long tripId,
+            LocalDateTime currentStart,
+            LocalDateTime currentEnd,
+            LocalDateTime newStart,
+            LocalDateTime newEnd
+    ) {
+        int currentDays = calculateTripDays(currentStart.toLocalDate(), currentEnd.toLocalDate());
+        int newDays = calculateTripDays(newStart.toLocalDate(), newEnd.toLocalDate());
+
+        if (newDays > currentDays) {    // 여행일이 늘어난 경우, 부족한 일차 추가
+            for (int day = currentDays + 1 ; day <= newDays; day++) {
+                TripDayPlace newDayPlace = TripDayPlace.builder()
+                        .tripId(tripId)
+                        .day(day)
+                        .places(new ArrayList<>())
+                        .build();
+                tripDayPlaceService.save(newDayPlace);
+            }
+        } else if (newDays < currentDays) {     // 여행일이 줄어든 경우, 초과된 일차 삭제
+            tripDayPlaceService.deleteByTripIdAndDayGreaterThan(tripId, newDays);
+        }
+    }
+
+    /**
+     * 시작일과 종료일을 기준으로 여행 총 일수 계산 메서드
+     * @return 여행 총 일수
+     */
+    private int calculateTripDays(LocalDate start, LocalDate end) {
+        return (int) ChronoUnit.DAYS.between(start, end) + 1;
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripCommandService.java
@@ -94,6 +94,8 @@ public class TripCommandService {
             throw new CustomException(TripErrorType.PERMISSION_DENIED_NOT_LEADER);
         }
 
+        // TODO : 앞당겨진 일정의 경우, 앞에 일차 추가 고려
+
         // 날짜 변경에 따른 MongoDB 동기화 (기존 값이 null이 아닌 경우만)
         if (trip.getStartedAt() != null && trip.getEndedAt() != null) {
             restructureTripDayPlaces(tripId, trip.getStartedAt(), trip.getEndedAt(), time.start(), time.end());

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/TripDayPlaceRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/TripDayPlaceRepository.java
@@ -3,8 +3,6 @@ package kr.co.yeogiga.domain.tripplace.repository;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-import java.util.List;
-
 public interface TripDayPlaceRepository extends MongoRepository<TripDayPlace, String>, CustomTripDayPlaceRepository {
-    List<TripDayPlace> findByTripId(Long tripId);
+    void deleteByTripIdAndDayGreaterThan(Long tripId, int day);
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
@@ -94,4 +94,8 @@ public class TripDayPlaceService {
     public void deleteImagesByTripId(Long tripId, List<String> imageIds) {
         tripDayPlaceRepository.deleteImagesByTripId(tripId, imageIds);
     }
+
+    public void deleteByTripIdAndDayGreaterThan(Long tripId, int day) {
+        tripDayPlaceRepository.deleteByTripIdAndDayGreaterThan(tripId, day);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,8 +6,8 @@ spring:
 spring:
   servlet:
     multipart:
-      max-file-size: 20MB
-      max-request-size: 20MB
+      max-file-size: 30MB
+      max-request-size: 30MB
 
 --- # api link checker
 api:

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripCommandServiceTest.java
@@ -9,6 +9,7 @@ import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.service.TripMemberService;
 import kr.co.yeogiga.domain.trip.service.TripService;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
+import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.service.UserService;
 import kr.co.yeogiga.domain.user.type.Role;
@@ -38,6 +39,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -55,6 +57,9 @@ public class TripCommandServiceTest {
 
     @Mock
     private TripMemberService tripMemberService;
+
+    @Mock
+    private TripDayPlaceService tripDayPlaceService;
 
     @Mock
     private UserService userService;
@@ -215,6 +220,60 @@ public class TripCommandServiceTest {
                 // then
                 assertEquals(TravelStatus.COMPLETED, trip.getTravelStatus());
             }
+        }
+
+        @Test
+        @DisplayName("여행 기간이 늘어난 경우 - 부족한 일차 데이터를 생성")
+        void tripDayPlaceIncreaseTest() {
+            // given
+            LocalDateTime currentStart = LocalDateTime.of(2025, 6, 1, 0, 0);
+            LocalDateTime currentEnd = LocalDateTime.of(2025, 6, 3, 0, 0);
+            LocalDateTime newStart = LocalDateTime.of(2025, 6, 1, 0, 0);
+            LocalDateTime newEnd = LocalDateTime.of(2025, 6, 5, 0, 0);
+
+            Trip trip = Trip.builder()
+                    .leaderId(userId)
+                    .travelStatus(TravelStatus.SETTING)
+                    .build();
+            trip.updateTime(currentStart, currentEnd);
+
+            TripReq.Time time = new TripReq.Time(newStart, newEnd);
+
+            given(tripService.readById(tripId)).willReturn(Optional.of(trip));
+
+            // when
+            tripCommandService.updateTime(tripId, userId, time);
+
+            // then
+            verify(tripDayPlaceService, times(2)).save(any());
+            verify(tripDayPlaceService, never()).deleteByTripIdAndDayGreaterThan(anyLong(), anyInt());
+        }
+
+        @Test
+        @DisplayName("여행 기간이 줄어든 경우 - 초과 일차 데이터를 삭제")
+        void tripDayPlaceDecreaseTest() {
+            // given
+            LocalDateTime currentStart = LocalDateTime.of(2025, 6, 1, 0, 0);
+            LocalDateTime currentEnd = LocalDateTime.of(2025, 6, 5, 0, 0);
+            LocalDateTime newStart = LocalDateTime.of(2025, 6, 1, 0, 0);
+            LocalDateTime newEnd = LocalDateTime.of(2025, 6, 3, 0, 0);
+
+            Trip trip = Trip.builder()
+                    .leaderId(userId)
+                    .travelStatus(TravelStatus.SETTING)
+                    .build();
+            trip.updateTime(currentStart, currentEnd);
+
+            TripReq.Time time = new TripReq.Time(newStart, newEnd);
+
+            given(tripService.readById(tripId)).willReturn(Optional.of(trip));
+
+            // when
+            tripCommandService.updateTime(tripId, userId, time);
+
+            // then
+            verify(tripDayPlaceService, never()).save(any());
+            verify(tripDayPlaceService, times(1)).deleteByTripIdAndDayGreaterThan(anyLong(), anyInt());
         }
 
         @Test


### PR DESCRIPTION
## 배경
여행의 일정을 변경하면, MongoDB에서 관리하고 있는 일정 데이터에 대한 동기화가 필요

## 작업 사항
- day보다 큰 일정 삭제 메서드 추가 - 몽고DB 네이밍메서드 (2568432b11689d6add5d9aefc88cd930f4d8ebfc)
- 여행 일정 변경 시, 일수에 따른 MongoDB 일정 데이터 동기화 (5020996b3a0be52af29caef8ea36fddb1f9092ae)
    - 현재 일정이 없을 시, 실행 x (null로 확인)
    - 여행 일수가 늘어날 시, 해당 일수(day) 추가
    - 여행 일수가 줄어들 시, 그 이상의 일수 삭제

## 기타
multipart 용량을 임시적으로 최대 30MB로 증가하였습니다. (고해상도 이미지 3장을 고려)
