### PR TITLE
Refactor: UserRepository QueryDsl 마이그레이션

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ dependencies {
 
     /* QueryDSL */
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    implementation 'com.querydsl:querydsl-sql:5.0.0'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api:2.1.1"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepository.java
@@ -15,5 +15,5 @@ public interface CustomUserRepository {
     boolean existsIncludeDeletedByUsername(String username);
     boolean existsIncludeDeletedByNickname(String nickname);
     boolean existsIdIncludeDeletedByEmail(String email);
-    void deleteHarAllByIdIn(List<Long> ids);
+    void deleteHardAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepository.java
@@ -1,0 +1,19 @@
+package kr.co.yeogiga.domain.user.repository;
+
+import kr.co.yeogiga.domain.user.entity.User;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface CustomUserRepository {
+    Optional<User> findUserIncludeDeletedByPlatformAndPlatformId(String platform, String platformId);
+    Optional<User> findUserIncludeDeletedById(Long id);
+    Optional<User> findUserIncludeDeletedByNickname(String nickname);
+    Optional<User> findUserIncludeDeletedByUsername(String username);
+    List<Long> findDeletedUserIdBefore(LocalDate date);
+    boolean existsIncludeDeletedByUsername(String username);
+    boolean existsIncludeDeletedByNickname(String nickname);
+    boolean existsIdIncludeDeletedByEmail(String email);
+    void deleteHarAllByIdIn(List<Long> ids);
+}

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepositoryImpl.java
@@ -1,0 +1,192 @@
+package kr.co.yeogiga.domain.user.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.core.types.dsl.EntityPathBase;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.querydsl.jpa.sql.JPASQLQuery;
+import com.querydsl.sql.SQLTemplates;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import kr.co.yeogiga.domain.oauth.entity.OAuth;
+import kr.co.yeogiga.domain.user.entity.QUser;
+import kr.co.yeogiga.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class CustomUserRepositoryImpl implements CustomUserRepository {
+    private final SQLTemplates sqlTemplates;
+    private final JPAQueryFactory jpaQueryFactory;
+    
+    @PersistenceContext
+    private final EntityManager entityManager;
+    
+    private final QUser user = QUser.user;
+    
+    private final EntityPath<User> USER_ENTITY_PATH = new EntityPathBase<>(User.class, "users");
+    private final EntityPath<OAuth> OAUTH_ENTITY_PATH = new EntityPathBase<>(OAuth.class, "oauth");
+    
+    private static final class USER_COLUMN {
+        private USER_COLUMN() { }
+        
+        private static final String ID = "id";
+        private static final String NICKNAME = "nickname";
+        private static final String USERNAME = "username";
+        private static final String DELETED_AT = "deleted_at";
+        private static final String EMAIL = "email";
+    }
+    
+    private static final class OAUTH_COLUMN {
+        private OAUTH_COLUMN() { }
+        
+        private static final String USER = "user_id";
+        private static final String PLATFORM = "platform";
+        private static final String PLATFORM_ID = "platform_id";
+    }
+    
+    @Override
+    public Optional<User> findUserIncludeDeletedByPlatformAndPlatformId(String platform, String platformId) {
+        JPASQLQuery<Tuple> jpaSqlQuery = new JPASQLQuery<>(entityManager, sqlTemplates);
+        
+        return Optional.ofNullable(
+                jpaSqlQuery
+                        .select(USER_ENTITY_PATH)
+                        .from(USER_ENTITY_PATH)
+                        .innerJoin(OAUTH_ENTITY_PATH)
+                            .on(Expressions.numberPath(Long.class, USER_ENTITY_PATH, USER_COLUMN.ID)
+                                    .eq(Expressions.numberPath(Long.class, OAUTH_ENTITY_PATH, OAUTH_COLUMN.USER)))
+                        .where(
+                                Expressions.stringPath(OAUTH_ENTITY_PATH, OAUTH_COLUMN.PLATFORM)
+                                        .eq(platform),
+                                Expressions.stringPath(OAUTH_ENTITY_PATH, OAUTH_COLUMN.PLATFORM_ID)
+                                        .eq(platformId)
+                        )
+                        .fetchOne()
+        );
+    }
+    
+    @Override
+    public Optional<User> findUserIncludeDeletedById(Long id) {
+        JPASQLQuery<Tuple> jpaSqlQuery = new JPASQLQuery<>(entityManager, sqlTemplates);
+        
+        return Optional.ofNullable(
+                jpaSqlQuery
+                        .select(USER_ENTITY_PATH)
+                        .from(USER_ENTITY_PATH)
+                        .where(
+                                Expressions.numberPath(Long.class, USER_ENTITY_PATH, USER_COLUMN.ID)
+                                        .eq(id)
+                        )
+                        .fetchOne()
+        );
+    }
+    
+    @Override
+    public Optional<User> findUserIncludeDeletedByNickname(String nickname) {
+        JPASQLQuery<Tuple> jpaSqlQuery = new JPASQLQuery<>(entityManager, sqlTemplates);
+        
+        return Optional.ofNullable(
+                jpaSqlQuery
+                        .select(USER_ENTITY_PATH)
+                        .from(USER_ENTITY_PATH)
+                        .where(
+                                Expressions.stringPath(USER_ENTITY_PATH, USER_COLUMN.NICKNAME)
+                                        .eq(nickname)
+                        )
+                        .fetchOne()
+        );
+    }
+    
+    @Override
+    public Optional<User> findUserIncludeDeletedByUsername(String username) {
+        JPASQLQuery<Tuple> jpaSqlQuery = new JPASQLQuery<>(entityManager, sqlTemplates);
+        
+        return Optional.ofNullable(
+            jpaSqlQuery
+                    .select(USER_ENTITY_PATH)
+                    .from(USER_ENTITY_PATH)
+                    .where(
+                            Expressions.stringPath(USER_ENTITY_PATH, USER_COLUMN.USERNAME)
+                                    .eq(username)
+                    )
+                    .fetchOne()
+        );
+    }
+    
+    @Override
+    public List<Long> findDeletedUserIdBefore(LocalDate date) {
+        JPASQLQuery<Tuple> jpaSqlQuery = new JPASQLQuery<>(entityManager, sqlTemplates);
+        
+        return jpaSqlQuery
+                .select(
+                        Expressions.numberPath(Long.class, USER_ENTITY_PATH, USER_COLUMN.ID)
+                )
+                .from(USER_ENTITY_PATH)
+                .where(
+                        Expressions.datePath(LocalDate.class, USER_ENTITY_PATH, USER_COLUMN.DELETED_AT).isNotNull(),
+                        Expressions.datePath(LocalDate.class, USER_ENTITY_PATH, USER_COLUMN.DELETED_AT).loe(date)
+                        
+                )
+                .fetch();
+    }
+    
+    @Override
+    public boolean existsIncludeDeletedByUsername(String username) {
+        JPASQLQuery<Tuple> jpaSqlQuery = new JPASQLQuery<>(entityManager, sqlTemplates);
+        
+        Integer fetchOne = jpaSqlQuery
+                .select(Expressions.ONE)
+                .from(USER_ENTITY_PATH)
+                .where(
+                        Expressions.stringPath(USER_ENTITY_PATH, USER_COLUMN.USERNAME)
+                                .eq(username)
+                )
+                .fetchFirst();
+        
+        return fetchOne != null;
+    }
+    
+    @Override
+    public boolean existsIncludeDeletedByNickname(String nickname) {
+        JPASQLQuery<Tuple> jpaSqlQuery = new JPASQLQuery<>(entityManager, sqlTemplates);
+        
+        Integer fetchOne = jpaSqlQuery
+                .select(Expressions.ONE)
+                .from(USER_ENTITY_PATH)
+                .where(
+                        Expressions.stringPath(USER_ENTITY_PATH, USER_COLUMN.NICKNAME)
+                                .eq(nickname)
+                )
+                .fetchFirst();
+        
+        return fetchOne != null;
+    }
+    
+    @Override
+    public boolean existsIdIncludeDeletedByEmail(String email) {
+        JPASQLQuery<Tuple> jpaSqlQuery = new JPASQLQuery<>(entityManager, sqlTemplates);
+        
+        Integer fetchOne = jpaSqlQuery
+                .select(Expressions.ONE)
+                .from(USER_ENTITY_PATH)
+                .where(
+                        Expressions.stringPath(USER_ENTITY_PATH, USER_COLUMN.EMAIL)
+                                .eq(email)
+                )
+                .fetchFirst();
+        
+        return fetchOne != null;
+    }
+    
+    @Override
+    public void deleteHarAllByIdIn(List<Long> ids) {
+        jpaQueryFactory
+                .delete(user)
+                .where(user.id.in(ids)).execute();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepositoryImpl.java
@@ -184,7 +184,7 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
     }
     
     @Override
-    public void deleteHarAllByIdIn(List<Long> ids) {
+    public void deleteHardAllByIdIn(List<Long> ids) {
         jpaQueryFactory
                 .delete(user)
                 .where(user.id.in(ids)).execute();

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/UserRepository.java
@@ -1,66 +1,13 @@
 package kr.co.yeogiga.domain.user.repository;
 
-import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
 import kr.co.yeogiga.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Long> {
-
-    @Query(value = "SELECT u.id, u.username, u.password, u.email, u.nickname,  u.image_url, u.fcm_token, u.signed_up, u.role, u.deleted_at, u.created_at, u.modified_at " +
-                   "FROM users u " +
-                   "INNER JOIN oauth o ON u.id = o.user_id " +
-                   "WHERE o.platform = :platform AND o.platform_id = :platformId", nativeQuery = true)
-    Optional<User> findUserIncludeDeletedByPlatformAndPlatformId(@Param(value = "platform") String platform, @Param("platformId") String platformId);
-
-    @Query(value = "SELECT * " +
-                   "FROM users " +
-                   "WHERE id = :id", nativeQuery = true)
-    Optional<User> findUserIncludeDeletedById(@Param(value = "id") Long id);
-
-    @Query(value = "SELECT * " +
-            "FROM users " +
-            "WHERE nickname = :nickname", nativeQuery = true)
-    Optional<User> findUserIncludeDeletedByNickname(String nickname);
-
-    @Query(value = "SELECT * " +
-            "FROM users " +
-            "WHERE username = :username", nativeQuery = true)
-    Optional<User> findUserIncludeDeletedByUsername(@Param(value = "username") String username);
-
-    @Query(value = "SELECT id " +
-                   "FROM users " +
-                   "WHERE deleted_at IS NOT NULL AND deleted_at <= :date", nativeQuery = true)
-    List<Long> findDeletedUserIdBefore(@Param(value = "date") LocalDate date);
-
-    @Query(value = "SELECT id " +
-                   "FROM users " +
-                   "WHERE username = :username LIMIT 1", nativeQuery = true)
-    Optional<Long> findUserIdIncludeDeletedByUsername(@Param(value = "username") String username);
-
-    @Query(value = "SELECT id " +
-                   "FROM users " +
-                   "WHERE nickname = :nickname LIMIT 1", nativeQuery = true)
-    Optional<Long> findUserIdIncludeDeletedByNickname(@Param(value = "nickname") String nickname);
-
-    @Query(value = "SELECT id " +
-            "FROM users " +
-            "WHERE email = :email LIMIT 1", nativeQuery = true)
-    Optional<Long> findUserIdIncludeDeletedByEmail(@Param(value = "email") String email);
-
+public interface UserRepository extends JpaRepository<User, Long>, CustomUserRepository {
     Optional<User> findByFcmToken(String fcmToken);
     
     List<User> findAllByIdIn(List<Long> ids);
-
-    @Modifying
-    @Query(value = "DELETE " +
-            "FROM users " +
-            "WHERE id IN :ids", nativeQuery = true)
-    void deleteHardAllByIds(List<Long> ids);
 }

--- a/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
@@ -68,6 +68,6 @@ public class UserService {
     }
 
     public void deleteHardAllByIds(List<Long> ids) {
-        userRepository.deleteHarAllByIdIn(ids);
+        userRepository.deleteHardAllByIdIn(ids);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
@@ -52,15 +52,15 @@ public class UserService {
     }
 
     public boolean existsIncludeDeletedByUsername(String username) {
-        return userRepository.findUserIdIncludeDeletedByUsername(username).isPresent();
+        return userRepository.existsIncludeDeletedByUsername(username);
     }
 
     public boolean existsIncludeDeletedByNickname(String nickname) {
-        return userRepository.findUserIdIncludeDeletedByNickname(nickname).isPresent();
+        return userRepository.existsIncludeDeletedByNickname(nickname);
     }
 
     public boolean existsIncludeDeletedByEmail(String email) {
-        return userRepository.findUserIdIncludeDeletedByEmail(email).isPresent();
+        return userRepository.existsIdIncludeDeletedByEmail(email);
     }
 
     public void deleteById(Long userId) {
@@ -68,6 +68,6 @@ public class UserService {
     }
 
     public void deleteHardAllByIds(List<Long> ids) {
-        userRepository.deleteHardAllByIds(ids);
+        userRepository.deleteHarAllByIdIn(ids);
     }
 }

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/QueryDslConfig.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/QueryDslConfig.java
@@ -1,6 +1,8 @@
 package kr.co.yeogiga.infrastructure.config;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.querydsl.sql.MySQLTemplates;
+import com.querydsl.sql.SQLTemplates;
 import jakarta.persistence.EntityManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,5 +13,10 @@ public class QueryDslConfig {
     @Bean
     public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
         return new JPAQueryFactory(entityManager);
+    }
+    
+    @Bean
+    public SQLTemplates sqlTemplates()  {
+        return new MySQLTemplates();
     }
 }


### PR DESCRIPTION
## 배경
- 네이티브 쿼리 및 JPQL 코드 컴파일 시점 오류 확인 불가, 가독성 이유로 인한 QueryDsl 마이그레이션 적용 필요성 대두

## 작업 사항
- 네이티브 쿼리 사용을 위한 `QueryDsl-SQL` 디펜던시 추가 | (02adc189b405a71a824865657d85855ddfae794f)
- `MySQLTemplates` 빈 등록 | (f5f1ea7b0348647f83d2869c52018e03106166a0)
- UserRepository 내 네이티브 쿼리 메서드 QueryDsl로 마이그레이션 | (82fe1761652c9407d016fbf1b51dfaa31acda042)
	- [QueryDsl 공식 문서](http://querydsl.com/static/querydsl/3.7.2/reference/ko-KR/html/ch02.html)를 참고해서 JPA 네이티브 쿼리를 사용하는 방식으로 마이그레이션 하였습니다. 
	- 네이티브 쿼리를 사용하기 때문에 테이블명이나 컬럼명의 경우 직접 String 값을 삽입해주었습니다.
		- 정확히는 `JPASQLQuery` 사용 시 `QUser user`, `QOAuth oAuth` 사용 시 변수명으로 그대로 문자열로 사용하여 "user", "oAuth"로 컬럼 및 테이블을 조회하여 조회가 되지 않았습니다 (엔티티 정의 시 설정한 테이블명이나 대소문자 변환 X). 
		따라서, `EntityPath`와 내부 클래스로 테이블명, 컬럼명을 정의하여 사용하였습니다.


## 추가 논의
#### 1. `deleteHardAllByIdIn(List<Long> ids)` 사용을 위한 QUser 클래스 및 `JPAQueryFactory` 사용
우선, `JPASQLQuery` 에서는 단순히 조회 쿼리만 지원합니다. [참고 링크]( http://querydsl.com/static/querydsl/4.4.0/apidocs/com/querydsl/jpa/sql/JPASQLQuery.html)
따라서, Spring-Data-JPA의 `@Query` 사용 / QueryDsl의 `JPADeleteClause` / QueryDsl의 `JpaQueryFactory.delete()` 방법을 통해 삭제 연산을 구현해야 합니다.
3가지 방법 RDB에 직접 쿼리를 날려 hard delete는 동일하게 적용이 됩니다.

현재는 3번째 방법을 사용하여 구현하였기에 `CustomUserRepositoryImpl` 내 삭제 연산을 위해서만 사용되는 `JpAQueryFactory` 및 `QUser`를 정의하였습니다. 그렇다 보니 아래와 같은 고민들이 생겼습니다.
- "`CustomUserRepositoryImpl` 내 네이티브 쿼리 밖에 없는데, 굳이 삭제 연산을 위해서만 `JpaQueryFactory` 및 `QUser`를 정의해야할까?" 
- "어차피 같은 QueryDsl 코드인데 한 클래스에 같이 놔둬도 상관없으려나?"
- "querydsl-native query용 클래스와 querydsl-jpa용 클래스를 분리할까?"

기능적인 문제보다는 구조적으로 개인적인 궁금증이라 의견이 궁금하여 추가 논의에 남깁니다!