### PR TITLE
Feature: 회원 정보 조회 시 프로필 이미지 url 추가

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/user/dto/UserInfoRes.java
+++ b/src/main/java/kr/co/yeogiga/application/user/dto/UserInfoRes.java
@@ -5,17 +5,18 @@ import kr.co.yeogiga.domain.user.entity.User;
 import lombok.Builder;
 
 @Builder
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public record UserInfoRes(
         String username,
         String nickname,
-        String email
+        String email,
+        String imageUrl
 ) {
     public static UserInfoRes fromNormalUser(User user) {
         return UserInfoRes.builder()
                 .username(user.getUsername())
                 .nickname(user.getNickname())
                 .email(user.getEmail())
+                .imageUrl(user.getImageUrl())
                 .build();
     }
 
@@ -23,6 +24,7 @@ public record UserInfoRes(
         return UserInfoRes.builder()
                 .nickname(user.getNickname())
                 .email(user.getEmail())
+                .imageUrl(user.getImageUrl())
                 .build();
     }
 }

--- a/src/main/java/kr/co/yeogiga/common/jwt/TokenParser.java
+++ b/src/main/java/kr/co/yeogiga/common/jwt/TokenParser.java
@@ -17,10 +17,10 @@ public class TokenParser {
 
     @Autowired
     public TokenParser(JwtProperties jwtProperties) {
-        Decoder<InputStream, InputStream> base54UrlDecoder = new CustomBase64UrlDecoder();
+        Decoder<InputStream, InputStream> base64UrlDecoder = new CustomBase64UrlDecoder();
         this.jwtParser = Jwts.parser()
                 .verifyWith(jwtProperties.getSecretKey())
-                .b64Url(base54UrlDecoder)
+                .b64Url(base64UrlDecoder)
                 .build();
     }
 

--- a/src/main/java/kr/co/yeogiga/common/security/filter/AuthenticationEntryPointImpl.java
+++ b/src/main/java/kr/co/yeogiga/common/security/filter/AuthenticationEntryPointImpl.java
@@ -10,6 +10,7 @@ import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
@@ -22,7 +23,7 @@ public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
     private final ObjectMapper objectMapper;
 
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, org.springframework.security.core.AuthenticationException authException) throws IOException, ServletException {
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         BaseErrorType error = AuthErrorType.NOT_AUTHORIZATION;
 
         response.setStatus(HttpStatus.UNAUTHORIZED.value());

--- a/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
@@ -123,8 +123,10 @@ public interface UserApi {
                                             "code": 200,
                                             "message": "요청이 성공하였습니다.",
                                             "data": {
+                                                "username": null,
                                                 "nickname": "test",
-                                                "email": "test@test.com"
+                                                "email": "test@test.com",
+                                                "imageUrl": "https://image.com"
                                             }
                                         }
                                     """),
@@ -135,7 +137,8 @@ public interface UserApi {
                                             "data": {
                                                 "username": "test",
                                                 "nickname": "test",
-                                                "email": "test@test.com"
+                                                "email": "test@test.com",
+                                                "imageUrl": "https://image.com"
                                             }
                                         }
                                     """)


### PR DESCRIPTION
## 배경
- 사용자 프로필 이미지 추가에 따른 회원 정보 조회 시 프로필 이미지 추가 필요
- 기타 오타 수정 필요

## 작업 사항
- 사용자 프로필 조회 응답 dto 내 이미지 url 추가
- `TokenParser` 내 `base64UrlEncoder` 변수명 오타 수정
- `CusotmAuthenticationEntryPoiont` 내 `AuthenticationException` import 구문 분리