### PR TITLE
Fix: 사용자 프로필 이미지 업로드 과정 중 삭제 처리 오류 해결

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/image/service/ImageProcessingService.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/ImageProcessingService.java
@@ -12,6 +12,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
 import java.util.Optional;
 
 @Slf4j
@@ -61,7 +62,9 @@ public class ImageProcessingService {
 
         if (user.isEmpty()) return;
 
-        awsS3Storage.deleteImage(user.get().getImageUrl());
+        if (Objects.nonNull(user.get().getImageUrl())) {
+            awsS3Storage.deleteImage(user.get().getImageUrl());
+        }
 
         String url = awsS3Storage.upload(imageUploadRequest.toAwsUploadInfo(), ImageUploadRequest.ImageType.PROFILE);
 


### PR DESCRIPTION
## 배경
- 사용자 프로필 이미지 업로드 시 s3 내 기존 이미지 삭제 과정 중 기존에 이미지가 존재하지 않아 `imageUrl`이 null인 경우 NPE 발생

## 작업 사항
- 이미지 삭제 처리 시 `user.imageUrl` null 여부 확인

## 추가 논의
x