### PR TITLE
Feature(IL-187): 이메일 인증 번호 발송 및 검증

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,8 @@ dependencies {
     implementation 'io.lettuce:lettuce-core:6.5.5.RELEASE'
     implementation 'org.springframework.data:spring-data-redis:3.5.0'
 
+    /* Java Mail */
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     /* JAXB */
     implementation 'javax.xml.bind:jaxb-api:2.3.1'

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/VerificationCodeDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/VerificationCodeDto.java
@@ -10,4 +10,13 @@ public class VerificationCodeDto {
             @Pattern(regexp = "^[\\w!#$%&'*+/=?`{|}~^.-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$", message = "잘못된 이메일 형식입니다.")
             String email
     ) { }
+    
+    public record VerificationDto(
+            @NotBlank(message = "이메일은 필수 입력값입니다.")
+            @Pattern(regexp = "^[\\w!#$%&'*+/=?`{|}~^.-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$", message = "잘못된 이메일 형식입니다.")
+            String email,
+            
+            @NotBlank(message = "인증 코드는 필수 입력값입니다.")
+            String code
+    ) { }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/VerificationCodeDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/VerificationCodeDto.java
@@ -11,7 +11,7 @@ public class VerificationCodeDto {
             String email
     ) { }
     
-    public record VerificationDto(
+    public record VerificationRequest(
             @NotBlank(message = "이메일은 필수 입력값입니다.")
             @Pattern(regexp = "^[\\w!#$%&'*+/=?`{|}~^.-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$", message = "잘못된 이메일 형식입니다.")
             String email,

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/VerificationCodeDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/VerificationCodeDto.java
@@ -1,22 +1,28 @@
 package kr.co.yeogiga.application.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public class VerificationCodeDto {
     
+    @Schema(name = "VerificationDto.SendRequest", description = "이메일 인증 번호 발송 요청 DTO")
     public record SendRequest(
+            @Schema(description = "인증 요청 이메일", example = "test@test.com")
             @NotBlank(message = "이메일은 필수 입력값입니다.")
             @Pattern(regexp = "^[\\w!#$%&'*+/=?`{|}~^.-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$", message = "잘못된 이메일 형식입니다.")
             String email
     ) { }
     
+    @Schema(name = "VerificationDto.VerificationRequest", description = "이메일 인증 번호 검증 요청 DTO")
     public record VerificationRequest(
+            @Schema(description = "인증 요청 이메일", example = "test@test.com")
             @NotBlank(message = "이메일은 필수 입력값입니다.")
             @Pattern(regexp = "^[\\w!#$%&'*+/=?`{|}~^.-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$", message = "잘못된 이메일 형식입니다.")
             String email,
             
-            @NotBlank(message = "인증 코드는 필수 입력값입니다.")
+            @Schema(description = "인증 번호", example = "123456")
+            @NotBlank(message = "인증 번호는 필수 입력값입니다.")
             String code
     ) { }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/VerificationCodeDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/VerificationCodeDto.java
@@ -1,0 +1,13 @@
+package kr.co.yeogiga.application.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public class VerificationCodeDto {
+    
+    public record SendRequest(
+            @NotBlank(message = "이메일은 필수 입력값입니다.")
+            @Pattern(regexp = "^[\\w!#$%&'*+/=?`{|}~^.-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$", message = "잘못된 이메일 형식입니다.")
+            String email
+    ) { }
+}

--- a/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeGenerator.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeGenerator.java
@@ -8,6 +8,12 @@ import java.security.SecureRandom;
 public class VerificationCodeGenerator {
     private final SecureRandom secureRandom = new SecureRandom();
     
+    /**
+     * 6자리 난수를 생성하는 메서드
+     * - 범위: 100,000 ~ 999,999
+     *
+     * @return 6자리 난수
+     */
     public String generate() {
         return String.valueOf(secureRandom.nextInt(900000) + 100000);
     }

--- a/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeGenerator.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeGenerator.java
@@ -1,0 +1,14 @@
+package kr.co.yeogiga.application.auth.service;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+
+@Component
+public class VerificationCodeGenerator {
+    private final SecureRandom secureRandom = new SecureRandom();
+    
+    public String generate() {
+        return String.valueOf(secureRandom.nextInt(900000) + 100000);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeService.java
@@ -13,7 +13,12 @@ public class VerificationCodeService {
     private final VerificationCodeCache verificationCodeCache;
     private final VerificationCodeGenerator verificationCodeGenerator;
     private final VerificationCodeEmailSender verificationCodeEmailSender;
-
+    
+    /**
+     * 사용자가 인증 요청한 이메일로 인증 번호를 발송하는 메서드
+     *
+     * @param email 인증 요청 이메일
+     */
     public void issueCode(String email) {
         String code = verificationCodeGenerator.generate();
         
@@ -22,6 +27,14 @@ public class VerificationCodeService {
         verificationCodeEmailSender.send(email, code);
     }
     
+    /**
+     * 사용자가 요청한 이메일 인증 번호를 검증하는 메서드
+     *
+     * @param email 사용자 인증 요청 이메일
+     * @param code  사용자가 요청한 이메일 인증 번호
+     * @throws CustomException AuthErrorType.EMAIL_VERIFICATION_TIMEOUT - 저장소 내 이메일 존재하지 않거나 인증 시간이 초과된 경우
+     * @throws CustomException AuthErrorType.EMAIL_VERIFICATION_CODE_MISMATCH - 이메일 인증 번호 불일치
+     */
     public void verifyCode(String email, String code) {
         String verifiedCode = verificationCodeCache.getCode(email)
                 .orElseThrow(() -> new CustomException(AuthErrorType.EMAIL_VERIFICATION_TIMEOUT));

--- a/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeService.java
@@ -2,7 +2,7 @@ package kr.co.yeogiga.application.auth.service;
 
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
-import kr.co.yeogiga.domain.auth.repository.VerificationCodeCache;
+import kr.co.yeogiga.domain.auth.repository.VerificationCodeRepository;
 import kr.co.yeogiga.infrastructure.mail.VerificationCodeEmailSender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class VerificationCodeService {
-    private final VerificationCodeCache verificationCodeCache;
+    private final VerificationCodeRepository verificationCodeRepository;
     private final VerificationCodeGenerator verificationCodeGenerator;
     private final VerificationCodeEmailSender verificationCodeEmailSender;
     
@@ -22,7 +22,7 @@ public class VerificationCodeService {
     public void issueCode(String email) {
         String code = verificationCodeGenerator.generate();
         
-        verificationCodeCache.save(email, code);
+        verificationCodeRepository.save(email, code);
         
         verificationCodeEmailSender.send(email, code);
     }
@@ -36,13 +36,13 @@ public class VerificationCodeService {
      * @throws CustomException AuthErrorType.EMAIL_VERIFICATION_CODE_MISMATCH - 이메일 인증 번호 불일치
      */
     public void verifyCode(String email, String code) {
-        String verifiedCode = verificationCodeCache.getCode(email)
+        String verifiedCode = verificationCodeRepository.getCode(email)
                 .orElseThrow(() -> new CustomException(AuthErrorType.EMAIL_VERIFICATION_TIMEOUT));
         
         if (!verifiedCode.equals(code)) {
             throw new CustomException(AuthErrorType.EMAIL_VERIFICATION_CODE_MISMATCH);
         }
         
-        verificationCodeCache.delete(email);
+        verificationCodeRepository.delete(email);
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeService.java
@@ -4,6 +4,7 @@ import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.util.VerificationCodeGenerator;
 import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
 import kr.co.yeogiga.domain.auth.repository.VerificationCodeRepository;
+import kr.co.yeogiga.domain.user.service.UserService;
 import kr.co.yeogiga.infrastructure.mail.VerificationCodeEmailSender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -13,16 +14,22 @@ import org.springframework.stereotype.Component;
 public class VerificationCodeService {
     private final VerificationCodeRepository verificationCodeRepository;
     private final VerificationCodeEmailSender verificationCodeEmailSender;
+    private final UserService userService;
     
     private final Long VERIFICATION_CODE_SEND_TIME_LIMIT = 2 * 60L;
     
     /**
      * 사용자가 인증 요청한 이메일로 인증 번호를 발송하는 메서드
+     * @throws CustomException AuthErrorType.ALREADY_USED_EMAIL - 이미 사용 중인 이메일일 경우
      * @throws CustomException AuthErrorType.EMAIL_VERIFICATION_TIME_LIMIT - 이메일 인증 시도 횟수 초과 (1분 이내 재요청)
      *
      * @param email 인증 요청 이메일
      */
     public void issueCode(String email) {
+        if (userService.existsIncludeDeletedByEmail(email)) {
+            throw new CustomException(AuthErrorType.ALREADY_USED_EMAIL);
+        }
+        
         String code = VerificationCodeGenerator.generate();
         
         Long expiration = verificationCodeRepository.getExpire(email);

--- a/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeService.java
@@ -1,5 +1,7 @@
 package kr.co.yeogiga.application.auth.service;
 
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
 import kr.co.yeogiga.domain.auth.repository.VerificationCodeCache;
 import kr.co.yeogiga.infrastructure.mail.VerificationCodeEmailSender;
 import lombok.RequiredArgsConstructor;
@@ -18,5 +20,16 @@ public class VerificationCodeService {
         verificationCodeCache.save(email, code);
         
         verificationCodeEmailSender.send(email, code);
+    }
+    
+    public void verifyCode(String email, String code) {
+        String verifiedCode = verificationCodeCache.getCode(email)
+                .orElseThrow(() -> new CustomException(AuthErrorType.EMAIL_VERIFICATION_TIMEOUT));
+        
+        if (!verifiedCode.equals(code)) {
+            throw new CustomException(AuthErrorType.EMAIL_VERIFICATION_CODE_MISMATCH);
+        }
+        
+        verificationCodeCache.delete(email);
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeService.java
@@ -14,16 +14,23 @@ public class VerificationCodeService {
     private final VerificationCodeRepository verificationCodeRepository;
     private final VerificationCodeEmailSender verificationCodeEmailSender;
     
+    private final Long VERIFICATION_CODE_SEND_TIME_LIMIT = 2 * 60L;
+    
     /**
      * 사용자가 인증 요청한 이메일로 인증 번호를 발송하는 메서드
+     * @throws CustomException AuthErrorType.EMAIL_VERIFICATION_TIME_LIMIT - 이메일 인증 시도 횟수 초과 (1분 이내 재요청)
      *
      * @param email 인증 요청 이메일
      */
     public void issueCode(String email) {
         String code = VerificationCodeGenerator.generate();
         
-        verificationCodeRepository.save(email, code);
+        Long expiration = verificationCodeRepository.getExpire(email);
+        if (expiration > VERIFICATION_CODE_SEND_TIME_LIMIT) {
+            throw new CustomException(AuthErrorType.EMAIL_VERIFICATION_TIME_LIMIT);
+        }
         
+        verificationCodeRepository.save(email, code);
         verificationCodeEmailSender.send(email, code);
     }
     

--- a/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeService.java
@@ -1,0 +1,22 @@
+package kr.co.yeogiga.application.auth.service;
+
+import kr.co.yeogiga.domain.auth.repository.VerificationCodeCache;
+import kr.co.yeogiga.infrastructure.mail.VerificationCodeEmailSender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class VerificationCodeService {
+    private final VerificationCodeCache verificationCodeCache;
+    private final VerificationCodeGenerator verificationCodeGenerator;
+    private final VerificationCodeEmailSender verificationCodeEmailSender;
+
+    public void issueCode(String email) {
+        String code = verificationCodeGenerator.generate();
+        
+        verificationCodeCache.save(email, code);
+        
+        verificationCodeEmailSender.send(email, code);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeService.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.application.auth.service;
 
 import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.common.util.VerificationCodeGenerator;
 import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
 import kr.co.yeogiga.domain.auth.repository.VerificationCodeRepository;
 import kr.co.yeogiga.infrastructure.mail.VerificationCodeEmailSender;
@@ -11,7 +12,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class VerificationCodeService {
     private final VerificationCodeRepository verificationCodeRepository;
-    private final VerificationCodeGenerator verificationCodeGenerator;
     private final VerificationCodeEmailSender verificationCodeEmailSender;
     
     /**
@@ -20,7 +20,7 @@ public class VerificationCodeService {
      * @param email 인증 요청 이메일
      */
     public void issueCode(String email) {
-        String code = verificationCodeGenerator.generate();
+        String code = VerificationCodeGenerator.generate();
         
         verificationCodeRepository.save(email, code);
         

--- a/src/main/java/kr/co/yeogiga/common/util/VerificationCodeGenerator.java
+++ b/src/main/java/kr/co/yeogiga/common/util/VerificationCodeGenerator.java
@@ -1,12 +1,9 @@
-package kr.co.yeogiga.application.auth.service;
-
-import org.springframework.stereotype.Component;
+package kr.co.yeogiga.common.util;
 
 import java.security.SecureRandom;
 
-@Component
 public class VerificationCodeGenerator {
-    private final SecureRandom secureRandom = new SecureRandom();
+    private static final SecureRandom secureRandom = new SecureRandom();
     
     /**
      * 6자리 난수를 생성하는 메서드
@@ -14,7 +11,7 @@ public class VerificationCodeGenerator {
      *
      * @return 6자리 난수
      */
-    public String generate() {
+    public static String generate() {
         return String.valueOf(secureRandom.nextInt(900000) + 100000);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
@@ -24,7 +24,10 @@ public enum AuthErrorType implements BaseErrorType {
 
     ALREADY_USED_USERNAME(HttpStatus.CONFLICT, "A011", "이미 사용 중인 아이디입니다."),
     ALREADY_USED_NICKNAME(HttpStatus.CONFLICT, "A012", "이미 사용 중인 닉네임입니다."),
-    ALREADY_USED_EMAIL(HttpStatus.CONFLICT, "A013", "이미 사용 중인 이메일입니다.");
+    ALREADY_USED_EMAIL(HttpStatus.CONFLICT, "A013", "이미 사용 중인 이메일입니다."),
+    
+    EMAIL_VERIFICATION_TIMEOUT(HttpStatus.BAD_REQUEST, "A014", "이메일 인증 시간을 초과하였습니다."),
+    EMAIL_VERIFICATION_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "A015", "이메일 인증 번호가 일치하지 않습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
@@ -27,7 +27,8 @@ public enum AuthErrorType implements BaseErrorType {
     ALREADY_USED_EMAIL(HttpStatus.CONFLICT, "A013", "이미 사용 중인 이메일입니다."),
     
     EMAIL_VERIFICATION_TIMEOUT(HttpStatus.BAD_REQUEST, "A014", "이메일 인증 시간을 초과하였습니다."),
-    EMAIL_VERIFICATION_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "A015", "이메일 인증 번호가 일치하지 않습니다.");
+    EMAIL_VERIFICATION_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "A015", "이메일 인증 번호가 일치하지 않습니다."),
+    EMAIL_VERIFICATION_TIME_LIMIT(HttpStatus.BAD_REQUEST, "A016", "이메일 인증 시도 횟수를 초과하였습니다. 잠시 후 시도해주세요.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/co/yeogiga/domain/auth/repository/VerificationCodeCache.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/repository/VerificationCodeCache.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -18,5 +19,17 @@ public class VerificationCodeCache implements VerificationCodeRepository {
     public void save(String email, String code) {
         String key = MailConstant.formatVerificationCodePrefix(email);
         redisRepository.set(key, code, DURATION);
+    }
+    
+    @Override
+    public Optional<String> getCode(String email) {
+        String key = MailConstant.formatVerificationCodePrefix(email);
+        return Optional.ofNullable((String) redisRepository.get(key));
+    }
+    
+    @Override
+    public void delete(String email) {
+        String key = MailConstant.formatVerificationCodePrefix(email);
+        redisRepository.del(key);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/auth/repository/VerificationCodeCache.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/repository/VerificationCodeCache.java
@@ -28,6 +28,12 @@ public class VerificationCodeCache implements VerificationCodeRepository {
     }
     
     @Override
+    public Long getExpire(String email) {
+        String key = MailConstant.formatVerificationCodePrefix(email);
+        return redisRepository.getExpire(key);
+    }
+    
+    @Override
     public void delete(String email) {
         String key = MailConstant.formatVerificationCodePrefix(email);
         redisRepository.del(key);

--- a/src/main/java/kr/co/yeogiga/domain/auth/repository/VerificationCodeCache.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/repository/VerificationCodeCache.java
@@ -1,0 +1,22 @@
+package kr.co.yeogiga.domain.auth.repository;
+
+import kr.co.yeogiga.infrastructure.mail.constant.MailConstant;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class VerificationCodeCache implements VerificationCodeRepository {
+    private final RedisRepository redisRepository;
+    
+    private final Duration DURATION = Duration.ofMinutes(3);
+    
+    @Override
+    public void save(String email, String code) {
+        String key = MailConstant.formatVerificationCodePrefix(email);
+        redisRepository.set(key, code, DURATION);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/auth/repository/VerificationCodeRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/repository/VerificationCodeRepository.java
@@ -7,5 +7,7 @@ public interface VerificationCodeRepository {
     
     Optional<String> getCode(String email);
     
+    Long getExpire(String email);
+    
     void delete(String email);
 }

--- a/src/main/java/kr/co/yeogiga/domain/auth/repository/VerificationCodeRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/repository/VerificationCodeRepository.java
@@ -1,5 +1,11 @@
 package kr.co.yeogiga.domain.auth.repository;
 
+import java.util.Optional;
+
 public interface VerificationCodeRepository {
     void save(String email, String code);
+    
+    Optional<String> getCode(String email);
+    
+    void delete(String email);
 }

--- a/src/main/java/kr/co/yeogiga/domain/auth/repository/VerificationCodeRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/repository/VerificationCodeRepository.java
@@ -1,0 +1,5 @@
+package kr.co.yeogiga.domain.auth.repository;
+
+public interface VerificationCodeRepository {
+    void save(String email, String code);
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/mail/EmailSender.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/mail/EmailSender.java
@@ -1,0 +1,11 @@
+package kr.co.yeogiga.infrastructure.mail;
+
+import org.springframework.beans.factory.annotation.Value;
+
+public abstract class EmailSender {
+    
+    @Value("${spring.mail.username}")
+    protected String username;
+    
+    public abstract void send(String to, String subject, String content);
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/mail/JavaEmailSender.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/mail/JavaEmailSender.java
@@ -1,0 +1,38 @@
+package kr.co.yeogiga.infrastructure.mail;
+
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JavaEmailSender extends EmailSender {
+    private final JavaMailSender javaMailSender;
+    
+    @Async
+    @Override
+    public void send(String to, String subject, String content) {
+        try {
+            MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+            MimeMessageHelper messageHelper
+                    = new MimeMessageHelper(mimeMessage, false, StandardCharsets.UTF_8.name());
+            
+            messageHelper.setSubject(subject);
+            messageHelper.setTo(to);
+            messageHelper.setFrom(username);
+            messageHelper.setText(content, true);
+            
+            javaMailSender.send(mimeMessage);
+        } catch (Exception e) {
+            log.error("[ERROR] Failed to send mail - to: {} | subject: {} | message: {}", to, subject, e.getMessage());
+        }
+        
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/mail/VerificationCodeEmailSender.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/mail/VerificationCodeEmailSender.java
@@ -1,0 +1,21 @@
+package kr.co.yeogiga.infrastructure.mail;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class VerificationCodeEmailSender {
+    private final JavaEmailSender javaEmailSender;
+    private final String SUBJECT = "[여기가] 이메일 인증 코드";
+    // TODO: thymeleaf 템플릿 엔진을 통한 이메일 인증 코드 메일 템플릿 추가 시 삭제 필요
+    private final String CONTENT = """
+                <h1>여기가 이메일 인증 코드</h1>
+                <h2>%s</h2>
+                <p>3분 안에 인증을 진행하세요.</p>
+            """;
+    
+    public void send(String email, String code) {
+        javaEmailSender.send(email, SUBJECT, CONTENT.formatted(code));
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/mail/constant/MailConstant.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/mail/constant/MailConstant.java
@@ -1,0 +1,11 @@
+package kr.co.yeogiga.infrastructure.mail.constant;
+
+public final class MailConstant {
+    private MailConstant() { }
+    
+    private static final String VERIFICATION_CODE_PREFIX_FORMAT = "email-verification-code:%s";
+    
+    public static String formatVerificationCodePrefix(String email) {
+        return VERIFICATION_CODE_PREFIX_FORMAT.formatted(email);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/redis/RedisRepository.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/redis/RedisRepository.java
@@ -19,6 +19,10 @@ public class RedisRepository {
     public Object get(String key) {
         return redisTemplate.opsForValue().get(key);
     }
+    
+    public Long getExpire(String key) {
+        return redisTemplate.getExpire(key);
+    }
 
     public void set(String key, Object value, Duration duration) {
         redisTemplate.opsForValue().set(key, value, duration);

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/VerificationApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/VerificationApi.java
@@ -38,6 +38,12 @@ public interface VerificationApi {
                                                 "email": "잘못된 이메일 형식입니다."
                                             }
                                         }
+                                    """),
+                            @ExampleObject(name = "이메일 인증 요청 시도 횟수 초과", description = "발송 후 1분 이내 재요청한 경우", value = """
+                                        {
+                                            "code": "A016",
+                                            "message": "이메일 인증 시도 횟수를 초과하였습니다. 잠시 후 시도해주세요."
+                                        }
                                     """)
                     }))
     })
@@ -48,7 +54,7 @@ public interface VerificationApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "검증 성공",
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name = "이메일 인증 번호 발송 성공", value = """
+                            @ExampleObject(name = "이메일 인증 번호 검증 성공", value = """
                                         {
                                              "code": 200,
                                              "message": "인증에 성공하였습니다."

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/VerificationApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/VerificationApi.java
@@ -1,0 +1,84 @@
+package kr.co.yeogiga.presentation.auth.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.co.yeogiga.application.auth.dto.VerificationCodeDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@ApiGroup(value = "[이메일 인증 API]")
+@Tag(name = "[이메일 인증 API]", description = "이메일 인증 관련 API")
+public interface VerificationApi {
+    
+    @TrackApi(description = "이메일 인증 번호 발송 요청")
+    @Operation(summary = "이메일 인증 번호 발송 요청", description = "이메일 인증 번호 발송 요청 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "요청 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "이메일 인증 번호 발송 성공", value = """
+                                        {
+                                             "code": 200,
+                                             "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "유효성 검증 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "유효성 검증 실패", description = "이메일 입력 여부 및 형식 검사", value = """
+                                        {
+                                            "code": "G002",
+                                            "errors": {
+                                                "email": "잘못된 이메일 형식입니다."
+                                            }
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> sendEmailVerificationCode(@Valid @RequestBody VerificationCodeDto.SendRequest request);
+    
+    @TrackApi(description = "이메일 인증 번호 검증 요청")
+    @Operation(summary = "이메일 인증 번호 검증 요청", description = "이메일 인증 번호 검증 요청 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "검증 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "이메일 인증 번호 발송 성공", value = """
+                                        {
+                                             "code": 200,
+                                             "message": "인증에 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "검증 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "유효성 검증 실패", description = "인증코드, 이메일 입력 여부 및 형식 검사", value = """
+                                        {
+                                            "code": "G002",
+                                            "errors": {
+                                                "email": "잘못된 이메일 형식입니다.",
+                                                "code": "인증 번호는 필수 입력값입니다."
+                                            }
+                                        }
+                                    """),
+                            @ExampleObject(name = "이메일 인증 시간 초과 및 저장소 내 이메일 미존재", value = """
+                                        {
+                                             "code": "A014",
+                                             "message": "이메일 인증 시간을 초과하였습니다."
+                                         }
+                                    """),
+                            @ExampleObject(name = "이메일 인증 번호 불일치", value = """
+                                        {
+                                              "code": "A015",
+                                              "message": "이메일 인증 번호가 일치하지 않습니다."
+                                         }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> verifyEmailVerificationCode(@Valid @RequestBody VerificationCodeDto.VerificationRequest request);
+}

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/VerificationApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/VerificationApi.java
@@ -45,6 +45,15 @@ public interface VerificationApi {
                                             "message": "이메일 인증 시도 횟수를 초과하였습니다. 잠시 후 시도해주세요."
                                         }
                                     """)
+                    })),
+            @ApiResponse(responseCode = "409", description = "인증번호 발송 요청 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "이미 사용 중인 이메일", value = """
+                                        {
+                                             "code": "A013",
+                                             "message": "이미 사용 중인 이메일입니다."
+                                         }
+                                    """)
                     }))
     })
     ResponseEntity<?> sendEmailVerificationCode(@Valid @RequestBody VerificationCodeDto.SendRequest request);

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/VerificationController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/VerificationController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import kr.co.yeogiga.application.auth.dto.VerificationCodeDto;
 import kr.co.yeogiga.application.auth.service.VerificationCodeService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.presentation.auth.api.VerificationApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,15 +16,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth/email-verification")
-public class VerificationController {
+public class VerificationController implements VerificationApi {
     private final VerificationCodeService verificationCodeService;
     
+    @Override
     @PostMapping("/request")
     public ResponseEntity<?> sendEmailVerificationCode(@Valid @RequestBody VerificationCodeDto.SendRequest request) {
         verificationCodeService.issueCode(request.email());
         return ResponseEntity.ok(SuccessResponse.ok());
     }
     
+    @Override
     @PostMapping("/verify")
     public ResponseEntity<?> verifyEmailVerificationCode(@Valid @RequestBody VerificationCodeDto.VerificationRequest request) {
         verificationCodeService.verifyCode(request.email(), request.code());

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/VerificationController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/VerificationController.java
@@ -25,7 +25,7 @@ public class VerificationController {
     }
     
     @PostMapping("/verify")
-    public ResponseEntity<?> verifyEmailVerificationCode(@Valid @RequestBody VerificationCodeDto.VerificationDto request) {
+    public ResponseEntity<?> verifyEmailVerificationCode(@Valid @RequestBody VerificationCodeDto.VerificationRequest request) {
         verificationCodeService.verifyCode(request.email(), request.code());
         return ResponseEntity.ok(SuccessResponse.builder()
                         .code(HttpStatus.OK.value())

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/VerificationController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/VerificationController.java
@@ -5,6 +5,7 @@ import kr.co.yeogiga.application.auth.dto.VerificationCodeDto;
 import kr.co.yeogiga.application.auth.service.VerificationCodeService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,5 +22,14 @@ public class VerificationController {
     public ResponseEntity<?> sendEmailVerificationCode(@Valid @RequestBody VerificationCodeDto.SendRequest request) {
         verificationCodeService.issueCode(request.email());
         return ResponseEntity.ok(SuccessResponse.ok());
+    }
+    
+    @PostMapping("/verify")
+    public ResponseEntity<?> verifyEmailVerificationCode(@Valid @RequestBody VerificationCodeDto.VerificationDto request) {
+        verificationCodeService.verifyCode(request.email(), request.code());
+        return ResponseEntity.ok(SuccessResponse.builder()
+                        .code(HttpStatus.OK.value())
+                        .message("인증에 성공하였습니다.")
+                        .build());
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/VerificationController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/VerificationController.java
@@ -1,0 +1,25 @@
+package kr.co.yeogiga.presentation.auth.controller;
+
+import jakarta.validation.Valid;
+import kr.co.yeogiga.application.auth.dto.VerificationCodeDto;
+import kr.co.yeogiga.application.auth.service.VerificationCodeService;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth/email-verification")
+public class VerificationController {
+    private final VerificationCodeService verificationCodeService;
+    
+    @PostMapping("/request")
+    public ResponseEntity<?> sendEmailVerificationCode(@Valid @RequestBody VerificationCodeDto.SendRequest request) {
+        verificationCodeService.issueCode(request.email());
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,3 +54,21 @@ jwt:
 --- # firebase
 firebase:
   key: ${FIREBASE_KEY}
+
+--- # email
+spring:
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: false
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000

--- a/src/test/java/kr/co/yeogiga/application/auth/service/VerificationCodeGeneratorTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/VerificationCodeGeneratorTest.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.application.auth.service;
 
+import kr.co.yeogiga.common.util.VerificationCodeGenerator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/kr/co/yeogiga/application/auth/service/VerificationCodeGeneratorTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/VerificationCodeGeneratorTest.java
@@ -1,0 +1,28 @@
+package kr.co.yeogiga.application.auth.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VerificationCodeGeneratorTest {
+    private final VerificationCodeGenerator generator = new VerificationCodeGenerator();
+    
+    @Test
+    @DisplayName("인증 코드는 6자리 난수")
+    void verifyVerificationCode() {
+        String code = generator.generate();
+        assertThat(code).hasSize(6);
+        assertThat(code).matches("\\d{6}");
+    }
+    
+    @RepeatedTest(100)
+    @DisplayName("인증 코드는 항상 6자리 난수를 보장")
+    void verifyRandomCode() {
+        String code = generator.generate();
+        int value = Integer.parseInt(code);
+        assertThat(value).isBetween(100_000, 999_999);
+    }
+    
+}

--- a/src/test/java/kr/co/yeogiga/application/auth/service/VerificationCodeServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/VerificationCodeServiceTest.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.application.auth.service;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
 import kr.co.yeogiga.domain.auth.repository.VerificationCodeCache;
+import kr.co.yeogiga.domain.user.service.UserService;
 import kr.co.yeogiga.infrastructure.mail.VerificationCodeEmailSender;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -32,6 +33,9 @@ public class VerificationCodeServiceTest {
     @Mock
     private VerificationCodeEmailSender verificationCodeEmailSender;
     
+    @Mock
+    private UserService userService;
+    
     @InjectMocks
     private VerificationCodeService verificationCodeService;
     
@@ -45,6 +49,7 @@ public class VerificationCodeServiceTest {
         @DisplayName("성공")
         void success() {
             // given
+            when(userService.existsIncludeDeletedByEmail(anyString())).thenReturn(false);
             doNothing().when(verificationCodeCache).save(anyString(), anyString());
             when(verificationCodeCache.getExpire(anyString())).thenReturn(-1L);
             doNothing().when(verificationCodeEmailSender).send(anyString(), anyString());
@@ -69,6 +74,20 @@ public class VerificationCodeServiceTest {
             
             // then
             assertEquals(AuthErrorType.EMAIL_VERIFICATION_TIME_LIMIT, exception.getErrorType());
+        }
+        
+        @Test
+        @DisplayName("실패 - 이미 가입된 이메일")
+        void failIfEmailAlreadyRegistered() {
+            // given
+            when(userService.existsIncludeDeletedByEmail(anyString())).thenReturn(true);
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> verificationCodeService.issueCode(email));
+            
+            // then
+            assertEquals(AuthErrorType.ALREADY_USED_EMAIL, exception.getErrorType());
         }
     }
     

--- a/src/test/java/kr/co/yeogiga/application/auth/service/VerificationCodeServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/VerificationCodeServiceTest.java
@@ -30,9 +30,6 @@ public class VerificationCodeServiceTest {
     private VerificationCodeCache verificationCodeCache;
     
     @Mock
-    private VerificationCodeGenerator verificationCodeGenerator;
-    
-    @Mock
     private VerificationCodeEmailSender verificationCodeEmailSender;
     
     @InjectMocks
@@ -48,8 +45,6 @@ public class VerificationCodeServiceTest {
         @DisplayName("성공")
         void success() {
             // given
-            
-            when(verificationCodeGenerator.generate()).thenReturn(code);
             doNothing().when(verificationCodeCache).save(anyString(), anyString());
             doNothing().when(verificationCodeEmailSender).send(anyString(), anyString());
             

--- a/src/test/java/kr/co/yeogiga/application/auth/service/VerificationCodeServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/VerificationCodeServiceTest.java
@@ -46,14 +46,29 @@ public class VerificationCodeServiceTest {
         void success() {
             // given
             doNothing().when(verificationCodeCache).save(anyString(), anyString());
+            when(verificationCodeCache.getExpire(anyString())).thenReturn(-1L);
             doNothing().when(verificationCodeEmailSender).send(anyString(), anyString());
             
             // when
             verificationCodeService.issueCode(email);
             
             // then
-            verify(verificationCodeCache, times(1)).save(eq(email), eq(code));
-            verify(verificationCodeEmailSender, times(1)).send(eq(email), eq(code));
+            verify(verificationCodeCache, times(1)).save(eq(email), anyString());
+            verify(verificationCodeEmailSender, times(1)).send(eq(email), anyString());
+        }
+        
+        @Test
+        @DisplayName("실패 - 재요청 횟수 초과 (1분 이내 재요청 시)")
+        void failIfRetryLessThan1Minute() {
+            // given
+            when(verificationCodeCache.getExpire(anyString())).thenReturn(140L);
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> verificationCodeService.issueCode(email));
+            
+            // then
+            assertEquals(AuthErrorType.EMAIL_VERIFICATION_TIME_LIMIT, exception.getErrorType());
         }
     }
     

--- a/src/test/java/kr/co/yeogiga/application/auth/service/VerificationCodeServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/VerificationCodeServiceTest.java
@@ -1,0 +1,113 @@
+package kr.co.yeogiga.application.auth.service;
+
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
+import kr.co.yeogiga.domain.auth.repository.VerificationCodeCache;
+import kr.co.yeogiga.infrastructure.mail.VerificationCodeEmailSender;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class VerificationCodeServiceTest {
+    @Mock
+    private VerificationCodeCache verificationCodeCache;
+    
+    @Mock
+    private VerificationCodeGenerator verificationCodeGenerator;
+    
+    @Mock
+    private VerificationCodeEmailSender verificationCodeEmailSender;
+    
+    @InjectMocks
+    private VerificationCodeService verificationCodeService;
+    
+    private final String email = "test@test.com";
+    private final String code = "123456";
+    
+    @Nested
+    @DisplayName("이메일 인증 코드 발급 요청")
+    class IssueCode {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            
+            when(verificationCodeGenerator.generate()).thenReturn(code);
+            doNothing().when(verificationCodeCache).save(anyString(), anyString());
+            doNothing().when(verificationCodeEmailSender).send(anyString(), anyString());
+            
+            // when
+            verificationCodeService.issueCode(email);
+            
+            // then
+            verify(verificationCodeCache, times(1)).save(eq(email), eq(code));
+            verify(verificationCodeEmailSender, times(1)).send(eq(email), eq(code));
+        }
+    }
+    
+    @Nested
+    @DisplayName("이메일 인증 코드 검증")
+    class VerifyCode {
+        
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            when(verificationCodeCache.getCode(anyString())).thenReturn(Optional.of(code));
+            doNothing().when(verificationCodeCache).delete(anyString());
+            
+            // when
+            verificationCodeService.verifyCode(email, code);
+            
+            // then
+            verify(verificationCodeCache, times(1)).delete(eq(email));
+        }
+        
+        @Test
+        @DisplayName("실패 - 인증 코드 저장소 내 코드 미존재")
+        void failIfCodeNotStoredInRepository() {
+            // given
+            when(verificationCodeCache.getCode(anyString())).thenReturn(Optional.empty());
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> verificationCodeService.verifyCode(email, code));
+            
+            // then
+            assertEquals(AuthErrorType.EMAIL_VERIFICATION_TIMEOUT, exception.getErrorType());
+            verify(verificationCodeCache, never()).delete(anyString());
+        }
+        
+        @Test
+        @DisplayName("실패 - 인증 코드 불일치")
+        void failIfCodeMisMatched() {
+            // given
+            when(verificationCodeCache.getCode(anyString())).thenReturn(Optional.of("999999"));
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> verificationCodeService.verifyCode(email, code));
+            
+            // then
+            assertEquals(AuthErrorType.EMAIL_VERIFICATION_CODE_MISMATCH, exception.getErrorType());
+            verify(verificationCodeCache, never()).delete(anyString());
+        }
+    }
+}

--- a/src/test/java/kr/co/yeogiga/presentation/auth/controller/VerificationControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/auth/controller/VerificationControllerTest.java
@@ -1,0 +1,170 @@
+package kr.co.yeogiga.presentation.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.application.auth.dto.VerificationCodeDto;
+import kr.co.yeogiga.application.auth.service.VerificationCodeService;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
+import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = VerificationController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthenticationFilter.class})
+        }
+)
+public class VerificationControllerTest {
+    @MockBean
+    private VerificationCodeService verificationCodeService;
+    
+    @Autowired
+    private ObjectMapper objectMapper;
+    
+    private MockMvc mockMvc;
+    
+    private final String email = "test@test.com";
+    private final String code = "123456";
+    
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .alwaysDo(print())
+                .build();
+    }
+    
+    @Nested
+    @DisplayName("이메일 인증 코드 발송 요청")
+    class SendEmailVerificationCode {
+        
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            doNothing().when(verificationCodeService).issueCode(anyString());
+            VerificationCodeDto.SendRequest body = new VerificationCodeDto.SendRequest(email);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/email-verification/request")
+                            .content(objectMapper.writeValueAsBytes(body))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
+        
+        @Test
+        @DisplayName("실패 - 유효성 검증")
+        void failValidation() throws Exception {
+            // given
+            doNothing().when(verificationCodeService).issueCode(anyString());
+            VerificationCodeDto.SendRequest body = new VerificationCodeDto.SendRequest(null);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/email-verification/request")
+                            .content(objectMapper.writeValueAsBytes(body))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors.email").exists());
+        }
+    }
+    
+    @Nested
+    @DisplayName("이메일 인증 코드 검증")
+    class VerifyEmailVerificationCode {
+        private VerificationCodeDto.VerificationRequest body
+                = new VerificationCodeDto.VerificationRequest(email, code);
+    
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            doNothing().when(verificationCodeService).verifyCode(anyString(), anyString());
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/email-verification/verify")
+                            .content(objectMapper.writeValueAsBytes(body))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("인증에 성공하였습니다."));
+        }
+    
+        @Test
+        @DisplayName("실패 - 인증 시간 초과 또는 저장소 내 미존재 이메일")
+        void failIfVerificationTimeout () throws Exception {
+            // given
+            doThrow(new CustomException(AuthErrorType.EMAIL_VERIFICATION_TIMEOUT))
+                    .when(verificationCodeService).verifyCode(anyString(), anyString());
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/email-verification/verify")
+                            .content(objectMapper.writeValueAsBytes(body))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(AuthErrorType.EMAIL_VERIFICATION_TIMEOUT.getCode()));
+        }
+        
+        @Test
+        @DisplayName("실패 - 인증 코드 불일치")
+        void failIfCodeMismatched () throws Exception {
+            // given
+            doThrow(new CustomException(AuthErrorType.EMAIL_VERIFICATION_CODE_MISMATCH))
+                    .when(verificationCodeService).verifyCode(anyString(), anyString());
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/email-verification/verify")
+                            .content(objectMapper.writeValueAsBytes(body))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(AuthErrorType.EMAIL_VERIFICATION_CODE_MISMATCH.getCode()));
+        }
+    }
+}


### PR DESCRIPTION
## 배경
- 서비스 회원가입 시 이메일 인증 기능 요구

## 작업 사항
- SpringBoot Mail 디펜던시 추가 | (bd2bd7460438a9aad7ee2accfbe1c83211aa2f48)
- JavaMail을 통한 이메일 발송 클래스 작성 | (908a90a8f1a7b5224aafa9c8dde9ac6a84345422)
	- [구글 GMAIL 문서](https://developers.google.com/workspace/gmail/imap/imap-smtp?hl=ko#protocol)에서 발신 SMTP 서버는 TLS를 지원한다고 하기도 하고, SSL도 되기는 하지만 TLS가 더 안전하다고 하여 TLS 프로토콜(587)을 사용하였습니다.
- 인증 코드 저장소(Reids) 클래스 작성 | (b2a4b6f245c83250ace9740b3902615a55e2d7b9), (cba3a2e107dfdb694ca8105d7c337f51b77cff53)
- 인증 코드 난수 생성기 작성 | (b1ddbd405e65ae91868ce20411f05b84ab3e704b)
- 인증 코드 발송 클래스 작성 | (f41dcad00a8283922be4a28f51c0f5508a34221c)
	- 서비스에서 이메일 인증 외 기타 이메일 서비스가 이용되지 않을 것이라 생각하여 단일 컴포넌트로 설계하였습니다. 차후, 추가 이메일 서비스 필요시 확장성을 고려하여 리팩토링 하겠습니다.
- 인증 코드 관련 서비스 클래스 작성 | (b30c01c097cb021fee6e12eacd000392d82f4ba7), (27707a55d4f6b3abd9638fe1bac759bd530914ad)


## 이메일 발송 결과
<img width="1035" alt="image" src="https://github.com/user-attachments/assets/87179d9a-0e20-485c-8b5f-8b0b662cee17" />



## 추가 논의
1. Thymeleaf 템플릿 엔진 도입
 현재 이메일 양식이 따로 없어 텍스트로 html 코드를 작성하여 전송하였습니다. 차후 Thymeleaf를 통해 이메일 템플릿을 도입하여 개선할 것 같습니다.

2. RabbitMQ
 RabbitMQ를 통해 큐로 이메일 전송에 대한 관리를 생각하였습니다. 그러나 해당 PR의 크기가 커질 것 같기도하고, 이메일 인증 번호 발송은 일정 시간에 과도하게 몰리는게 아닌 랜덤하게 발생되는 이벤트라 생각하여 도입하지 않았습니다. 차후 시간이 남을 때는 도입할까 고민 중이긴 합니다.

3. 이메일 개설 필요
 현재 테스트는 저의 개인 이메일을 통하여 테스트를 진행하였습니다. 
 따라서, 그러나 팀 계정을 따로 생성하여 진행하는 것이 맞을 것 같아 해당 PR 병합 전에 팀 계정 생성 후 알려드리도록 하겠습니다.

4. 이메일 중복 체크
 ~현재 이메일 인증 메서드 내에서 이메일 중복 체크는 따로 진행하고 있지 않습니다.~
 ~피그마 UI를 확인해보면 이메일 중복 확인을 별도로 진행하고, 이메일 중복이 아닌 경우에만 인증코드 발송이 가능하도록 하는 식으로 생각하였습니다. 해당 내용 프론트에게 한 번 더 전달하겠습니다.~ <br/>
 ~또한, 현재 이메일 중복 체크 기능이 없어 다음 PR에서 작업하도록 하겠습니다.~

5. 이메일 발송 횟수
이메일 인증 번호 발송을 너무 많이 요청하게 될 경우는 어떻게 할까라는 개인적인 고민이 있습니다. 
각 메일당 인증 번호 외에 발송 시도 횟수를 기록하여 이를 통해서 제어를 해야할까라는 고민이 있었는데 애매하여 추가 논의에 남깁니다!