### PR TITLE
Chore: 다음 스마트워크 이메일 사용으로 인한 smtp 플랫폼 변경

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,17 +58,13 @@ firebase:
 --- # email
 spring:
   mail:
-    host: smtp.gmail.com
-    port: 587
+    protocol: smtps
+    host: smtp.daum.net
+    port: 465
     username: ${MAIL_USERNAME}
     password: ${MAIL_PASSWORD}
     properties:
-      mail:
-        smtp:
-          auth: true
-          starttls:
-            enable: true
-            required: false
-          connectiontimeout: 5000
-          timeout: 5000
-          writetimeout: 5000
+      smtp:
+        auth: true
+        starttls:
+          enable: true


### PR DESCRIPTION
## 배경
- 인증번호 발송 이메일 도메인 변경 및 다음 스마트워크 플랫폼 변경
	- 다음 스마트워크를 통한 도메인 이메일 사용: `yeogiga.service@yeogiga.com`

## 작업 사항
- 다음 smtp 사용을 위한 application.yml 설정 프로퍼티 변경
	- [다음 SMTP 공식문서](https://cs.daum.net/faq/266/12145.html#17977) 참고

## 적용 결과
<img width="1103" height="368" alt="image" src="https://github.com/user-attachments/assets/2e98a895-fae3-42ad-8dff-02296c0bddb3" />

## 추가 사항
- ec2 환경변수 설정 변경해놓겠습니다.