### PR TITLE
Refactor: 여행 요약 정보 조회 로직 변경

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripRes.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripRes.java
@@ -43,7 +43,7 @@ public class TripRes {
             TravelStatus status,
             List<TripMemberRes.MemberInfo> members
     ) {
-        public static TripSummary from(Trip trip, List<User> members) {
+        public static TripSummary from(Trip trip, List<TripMemberRes.MemberInfo> members) {
             return TripSummary.builder()
                     .tripId(trip.getId())
                     .title(trip.getTitle())
@@ -52,7 +52,7 @@ public class TripRes {
                     .startedAt(trip.getStartedAt())
                     .endedAt(trip.getEndedAt())
                     .status(trip.getTravelStatus())
-                    .members(members.stream().map(TripMemberRes.MemberInfo::fromEntity).toList())
+                    .members(members)
                     .build();
         }
     }

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
@@ -146,12 +146,8 @@ public class TripQueryService {
      */
     @Transactional(readOnly = true)
     public TripRes.TripSummary getTrip(Long tripId) {
-        Trip trip = tripService.readById(tripId)
+        return tripMemberService.readTripSummaryByTripId(tripId)
                 .orElseThrow(() -> new CustomException(TripErrorType.TRIP_NOT_FOUND));
-
-        List<User> members = tripMemberService.readAllUserByTripId(tripId);
-
-        return TripRes.TripSummary.from(trip, members);
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
@@ -135,12 +135,7 @@ public class TripQueryService {
      */
     @Transactional(readOnly = true)
     public List<TripRes.TripSummary> getAllTrip(Long userId) {
-        return tripMemberService.readAllTripByUserId(userId).stream()
-                .map(trip -> {
-                    List<User> members = tripMemberService.readAllUserByTripId(trip.getId());
-                    return TripRes.TripSummary.from(trip, members);
-                })
-                .toList();
+        return tripMemberService.readAllTripSummaryByUserId(userId);
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepository.java
@@ -3,7 +3,9 @@ package kr.co.yeogiga.domain.trip.repository;
 import kr.co.yeogiga.application.trip.dto.TripRes;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CustomTripMemberRepository {
+    Optional<TripRes.TripSummary> findTripSummaryByTripId(Long tripId);
     List<TripRes.TripSummary> findAllTripSummaryByUserId(Long userId);
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepository.java
@@ -1,0 +1,9 @@
+package kr.co.yeogiga.domain.trip.repository;
+
+import kr.co.yeogiga.application.trip.dto.TripRes;
+
+import java.util.List;
+
+public interface CustomTripMemberRepository {
+    List<TripRes.TripSummary> findAllTripSummaryByUserId(Long userId);
+}

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepositoryImpl.java
@@ -1,0 +1,75 @@
+package kr.co.yeogiga.domain.trip.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.co.yeogiga.application.trip.dto.TripMemberRes;
+import kr.co.yeogiga.application.trip.dto.TripRes;
+import kr.co.yeogiga.domain.trip.entity.QTrip;
+import kr.co.yeogiga.domain.trip.entity.QTripMember;
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.user.entity.QUser;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class CustomTripMemberRepositoryImpl implements CustomTripMemberRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+    
+    private final QTripMember tripMember = QTripMember.tripMember;
+    private final QTrip trip = QTrip.trip;
+    private final QUser user = QUser.user;
+    
+    @Override
+    public List<TripRes.TripSummary> findAllTripSummaryByUserId(Long userId) {
+        List<Trip> tripList = jpaQueryFactory
+                .select(trip)
+                .from(tripMember)
+                .join(tripMember.trip, trip)
+                .where(tripMember.user.id.eq(userId))
+                .fetch();
+        
+        if (tripList.isEmpty()) {
+            return Collections.emptyList();
+        }
+        
+        List<Long> tripIds = tripList.stream()
+                .map(Trip::getId)
+                .toList();
+        
+        List<Tuple> userList = jpaQueryFactory
+                .select(
+                        trip.id,
+                        user.id,
+                        user.imageUrl,
+                        user.nickname
+                )
+                .from(tripMember)
+                .join(tripMember.trip, trip)
+                .join(tripMember.user, user)
+                .where(
+                        tripMember.trip.id.in(tripIds)
+                )
+                .fetch();
+        
+        Map<Long, List<TripMemberRes.MemberInfo>> memberInfoMap = userList.stream()
+                .collect(Collectors.groupingBy(
+                        tuple -> tuple.get(trip.id),
+                        Collectors.mapping(tuple -> TripMemberRes.MemberInfo.builder()
+                                .userId(tuple.get(user.id))
+                                .nickname(tuple.get(user.nickname))
+                                .imageUrl(tuple.get(user.imageUrl))
+                                .build(), Collectors.toList()
+                        )
+                ));
+        
+        return tripList.stream()
+                .map(trip -> TripRes.TripSummary.from(
+                        trip,
+                        memberInfoMap.getOrDefault(trip.getId(), List.of()))
+                ).toList();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepositoryImpl.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.domain.trip.repository;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.co.yeogiga.application.trip.dto.TripMemberRes;
 import kr.co.yeogiga.application.trip.dto.TripRes;
@@ -13,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -22,6 +25,35 @@ public class CustomTripMemberRepositoryImpl implements CustomTripMemberRepositor
     private final QTripMember tripMember = QTripMember.tripMember;
     private final QTrip trip = QTrip.trip;
     private final QUser user = QUser.user;
+    
+    @Override
+    public Optional<TripRes.TripSummary> findTripSummaryByTripId(Long tripId) {
+        Trip tripEntity = jpaQueryFactory
+                .select(trip)
+                .from(trip)
+                .where(trip.id.eq(tripId))
+                .fetchOne();
+        
+        if (Objects.isNull(tripEntity)) {
+            return Optional.empty();
+        }
+        
+        List<TripMemberRes.MemberInfo> members = jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                TripMemberRes.MemberInfo.class,
+                                user.id,
+                                user.nickname,
+                                user.imageUrl
+                        )
+                )
+                .from(tripMember)
+                .join(tripMember.user, user)
+                .where(tripMember.trip.id.eq(tripId))
+                .fetch();
+        
+        return Optional.of(TripRes.TripSummary.from(tripEntity, members));
+    }
     
     @Override
     public List<TripRes.TripSummary> findAllTripSummaryByUserId(Long userId) {

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/TripMemberRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/TripMemberRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
+public interface TripMemberRepository extends JpaRepository<TripMember, Long>, CustomTripMemberRepository {
     boolean existsByTripIdAndUserId(Long tripId, Long userId);
 
     @Query("SELECT tm.trip FROM trip_member tm WHERE tm.user.id = :userId ORDER BY tm.trip.startedAt ASC NULLS LAST")

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +22,10 @@ public class TripMemberService {
 
     public List<Trip> readAllTripByUserId(Long userId) {
         return tripMemberRepository.findAllTripByUserId(userId);
+    }
+    
+    public Optional<TripRes.TripSummary> readTripSummaryByTripId(Long tripId) {
+        return tripMemberRepository.findTripSummaryByTripId(tripId);
     }
     
     public List<TripRes.TripSummary> readAllTripSummaryByUserId(Long userId) {

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.domain.trip.service;
 
+import kr.co.yeogiga.application.trip.dto.TripRes;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.entity.TripMember;
 import kr.co.yeogiga.domain.trip.repository.TripMemberRepository;
@@ -20,6 +21,10 @@ public class TripMemberService {
 
     public List<Trip> readAllTripByUserId(Long userId) {
         return tripMemberRepository.findAllTripByUserId(userId);
+    }
+    
+    public List<TripRes.TripSummary> readAllTripSummaryByUserId(Long userId) {
+        return tripMemberRepository.findAllTripSummaryByUserId(userId);
     }
 
     public List<Trip> readAllSettingTripByUserId(Long userId) {

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
@@ -262,48 +262,45 @@ public class TripQueryServiceTest {
     @Nested
     @DisplayName("특정 여행 조회")
     class GetTrip {
-
-        private User user = User.builder()
-                .username("username")
-                .password("password")
+        private final Long userId = 1L;
+        
+        private TripMemberRes.MemberInfo member = TripMemberRes.MemberInfo.builder()
+                .userId(userId)
                 .nickname("nickname")
-                .email("test@test.com")
-                .role(Role.USER)
+                .imageUrl("https://image.com")
                 .build();
-
-        private Trip trip = Trip.builder()
-                .title("title")
-                .city("대구광역시")
-                .leaderId(1L)
-                .travelStatus(TravelStatus.IN_PROGRESS)
+        
+        private List<TripMemberRes.MemberInfo> members = List.of(member);
+        
+        private TripRes.TripSummary tripSummary = TripRes.TripSummary.builder()
+                .tripId(1L)
+                .title("졸업여행")
+                .city("대구")
+                .leaderId(userId)
+                .startedAt(LocalDateTime.of(2025, 7, 20, 12, 0))
+                .endedAt(LocalDateTime.of(2025, 7, 30, 12, 0))
+                .status(TravelStatus.PLANNED)
+                .members(members)
                 .build();
-
-        @BeforeEach
-        void setUp() {
-            ReflectionTestUtils.setField(trip, "id", 1L);
-        }
 
         @Test
         @DisplayName("성공")
         void success() {
             // given
-            when(tripService.readById(trip.getId())).thenReturn(Optional.of(trip));
-            when(tripMemberService.readAllUserByTripId(trip.getId())).thenReturn((List.of(user)));
+            when(tripMemberService.readTripSummaryByTripId(1L)).thenReturn(Optional.of(tripSummary));
 
             // when
             TripRes.TripSummary result = tripQueryService.getTrip(1L);
 
             // then
-            assertEquals(trip.getId(), result.tripId());
-            assertEquals(trip.getTitle(), result.title());
-            assertThat(result.members()).hasSize(1);
+            assertEquals(tripSummary.tripId(), result.tripId());
         }
 
         @Test
         @DisplayName("실패 - 존재하지 않는 여행")
         void failIfTripNotFound() {
             // given
-            when(tripService.readById(trip.getId())).thenReturn(Optional.empty());
+            when(tripMemberService.readTripSummaryByTripId(1L)).thenReturn(Optional.empty());
 
             // when
             CustomException exception = assertThrows(CustomException.class,

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.application.trip.service;
 
+import kr.co.yeogiga.application.trip.dto.TripMemberRes;
 import kr.co.yeogiga.application.trip.dto.TripRes;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.entity.Trip;
@@ -34,7 +35,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -211,19 +212,23 @@ public class TripQueryServiceTest {
     class GetAllTrip {
         private final Long userId = 1L;
 
-        private Trip trip = Trip.builder()
-                .title("title")
-                .city("대구광역시")
-                .leaderId(userId)
-                .travelStatus(TravelStatus.PLANNED)
-                .build();
-      
-        private User user = User.builder()
-                .username("username")
-                .password("password")
+        private TripMemberRes.MemberInfo member = TripMemberRes.MemberInfo.builder()
+                .userId(userId)
                 .nickname("nickname")
-                .email("test@test.com")
-                .role(Role.USER)
+                .imageUrl("https://image.com")
+                .build();
+        
+        private List<TripMemberRes.MemberInfo> members = List.of(member);
+        
+        private TripRes.TripSummary tripSummary = TripRes.TripSummary.builder()
+                .tripId(1L)
+                .title("졸업여행")
+                .city("대구")
+                .leaderId(userId)
+                .startedAt(LocalDateTime.of(2025, 7, 20, 12, 0))
+                .endedAt(LocalDateTime.of(2025, 7, 30, 12, 0))
+                .status(TravelStatus.PLANNED)
+                .members(members)
                 .build();
 
 
@@ -231,8 +236,7 @@ public class TripQueryServiceTest {
         @DisplayName("성공")
         void success() {
             // given
-            when(tripMemberService.readAllTripByUserId(userId)).thenReturn(List.of(trip));
-            when(tripMemberService.readAllUserByTripId(any())).thenReturn(List.of(user));
+            when(tripMemberService.readAllTripSummaryByUserId(anyLong())).thenReturn(List.of(tripSummary));
 
             // when
             List<TripRes.TripSummary> result = tripQueryService.getAllTrip(userId);
@@ -245,7 +249,7 @@ public class TripQueryServiceTest {
         @DisplayName("성공 - 빈 배열 반환")
         void successEmptyList() {
             // given
-            when(tripMemberService.readAllTripByUserId(userId)).thenReturn(List.of());
+            when(tripMemberService.readAllTripSummaryByUserId(userId)).thenReturn(List.of());
 
             // when
             List<TripRes.TripSummary> result = tripQueryService.getAllTrip(userId);

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
@@ -536,12 +536,14 @@ public class TripControllerTest {
                 .email("test@test.com")
                 .role(Role.USER)
                 .build();
+        
+        private TripMemberRes.MemberInfo member = TripMemberRes.MemberInfo.fromEntity(user);
 
         @Test
         @DisplayName("성공")
         void success() throws Exception {
             // given
-            TripRes.TripSummary tripSummary = TripRes.TripSummary.from(trip, List.of(user));
+            TripRes.TripSummary tripSummary = TripRes.TripSummary.from(trip, List.of(member));
             when(tripQueryService.getTrip(tripId)).thenReturn(tripSummary);
 
             // when


### PR DESCRIPTION
## 배경
- 사용자가 속한 여행 조회 시 속한 여행 수만큼의 쿼리 발생으로 인한 성능 저하 문제 가능성 발견
	- `여행 id 조회 1번` + `멤버 조회를 위한 여행 수만큼의 조회 n번` 쿼리 발생

## 작업 사항
- 사용자가 속한 전체 여행 요약 정보 조회 도메인 로직 변경 | (ed9111b415351a227036b6b0b0ad7f6738f0f650)
	- QueryDsl로 마이그레이션
	⇒ Tuple 프로젝션을 통해 발생 쿼리 수를 `여행 id 조회 1번` + `여행 멤버 조회 1번`으로 줄였습니다.
	```sql
	Hibernate: select u1_0.id,u1_0.created_at,u1_0.deleted_at,u1_0.email,u1_0.fcm_token,u1_0.image_url,u1_0.modified_at,u1_0.nickname,u1_0.password,u1_0.role,u1_0.signed_up,u1_0.username from users u1_0 where u1_0.id=? and (u1_0.deleted_at IS NULL)
	Hibernate: select t1_0.id,t1_0.city,t1_0.deleted_at,t1_0.ended_at,t1_0.leader_id,t1_0.started_at,t1_0.title,t1_0.travel_status from trip_member tm1_0 join trip t1_0 on t1_0.id=tm1_0.trip_id and (t1_0.deleted_at IS NULL) where tm1_0.user_id=?
	```
	- 이에 따른 `TripQueryService` 내 로직 변경 | (29924c366d5695eeba5b643d76d1dfa3f9d20ef5)
		- `TripSummary` 정적 팩토리 메서드 인자 변경: `User` → `MemberInfo`

- `TripSummary` dto 정적 팩토리 메서드 인자 변경에 따른 특정 여행 조회 도메인, 비지니스 로직 변경 | (d749f97f0a679f3f8a533a236774ca7c794a2b97) (dc97a63790f32c14cdd4e0b37a8d8862932b5d29)

## 추가 논의
- 특정 여행에 속한 여행 멤버를 조회하는 과정에서 최소 2번의 쿼리는 필요한 것 같아 해당 방법으로 작업을 진행하였습니다. 더 나은 방법이 있다면 조언 부탁드리겠습니다!