### PR TITLE
Refactor: 목적지 카테고리 설정 변경

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripDaySummaryRes.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripDaySummaryRes.java
@@ -46,7 +46,7 @@ public class TripDaySummaryRes {
                     place.getName(),
                     place.getLatitude(),
                     place.getLongitude(),
-                    place.getPlaceType(),
+                    place.getPlaceType().getLabel(),
                     place.getImages().stream()
                             .findFirst()
                             .map(ImageDto::from)

--- a/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceReq.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceReq.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 public class TripPlaceReq {
 
     @Builder
-    @Schema(name = "TripPlaceDto.Request", description = "여행 목적지 추가 DTO")
+    @Schema(name = "TripPlaceReq.Request", description = "여행 목적지 추가 DTO")
     public record Request(
             @Schema(description = "목적지 이름", example = "광화문")
             String name,
@@ -19,16 +19,27 @@ public class TripPlaceReq {
             double latitude,
             @Schema(description = "목적지 경도", example = "123.123")
             double longitude,
-            @Schema(description = "목적지 타입(카테고리)", example = "관광명소")
-            String placeType
+            @Schema(description = "목적지 타입(카테고리)", example = "RESTAURANT, TOURISM, LODGING, ETC")
+            PlaceCategory placeType
     ) {
+        public Place toEntity(Double order) {
+            return Place.builder()
+                    .id(UUID.randomUUID().toString())
+                    .name(name)
+                    .latitude(latitude)
+                    .longitude(longitude)
+                    .order(order)
+                    .placeType(placeType)
+                    .build();
+        }
+
         public StoredFormat toStoredFormat() {
             return new StoredFormat(
                     UUID.randomUUID().toString(),
                     name,
                     latitude,
                     longitude,
-                    PlaceCategory.fromLabel(placeType).getGroupName()
+                    placeType
             );
         }
     }
@@ -38,40 +49,16 @@ public class TripPlaceReq {
             String name,
             double latitude,
             double longitude,
-            String placeCategory
+            PlaceCategory placeCategory
     ) { }
 
-    @Schema(name = "TripPlaceDto.CompleteRequest", description = "여행 목적지 선택 완료 요청 DTO")
+    @Schema(name = "TripPlaceReq.CompleteRequest", description = "여행 목적지 선택 완료 요청 DTO")
     public record CompleteRequest(
             @Schema(description = "편집 완료된 마지막 일차", example = "5")
             int lastDay
     ) { }
 
-    @Builder
-    @Schema(name = "TripPlaceDto.InsertRequest", description = "삽입 위치를 포함한 새로운 목적지 추가 요청 DTO")
-    public record InsertRequest(
-            @Schema(description = "목적지 이름", example = "광화문")
-            String name,
-            @Schema(description = "위도", example = "37.57")
-            double latitude,
-            @Schema(description = "경도", example = "126.98")
-            double longitude,
-            @Schema(description = "장소 타입", example = "관광명소")
-            String placeType
-    ) {
-        public Place toEntity(Double order) {
-            return Place.builder()
-                    .id(UUID.randomUUID().toString())
-                    .name(name)
-                    .latitude(latitude)
-                    .longitude(longitude)
-                    .order(order)
-                    .placeType(PlaceCategory.fromLabel(placeType).getGroupName())
-                    .build();
-        }
-    }
-
-    @Schema(name = "TripPlaceDto.ReorderRequest", description = "여행 목적지 순서 변경 요청 DTO")
+    @Schema(name = "TripPlaceReq.ReorderRequest", description = "여행 목적지 순서 변경 요청 DTO")
     public record ReorderRequest(
             @Schema(description = "정렬된 목적지 ID 리스트", example = "[\"place3-id\", \"place1-id\", \"place2-id\"]")
             List<String> orderedPlaceIds

--- a/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceRes.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceRes.java
@@ -28,7 +28,10 @@ public class TripPlaceRes {
             boolean isVisited
     ) {
         public static PlaceSummary from(Place place) {
-            return new PlaceSummary(place.getId(), place.getName(), place.getPlaceType(), place.isVisited());
+            return new PlaceSummary(
+                    place.getId(), place.getName(),
+                    place.getPlaceType().getLabel(), place.isVisited()
+            );
         }
     }
 
@@ -41,8 +44,25 @@ public class TripPlaceRes {
             boolean isVisited
     ) {
         public static PlaceDetails from(Place place) {
-            return new PlaceDetails(place.getId(), place.getName(), place.getLatitude(),
-                    place.getLongitude(), place.getPlaceType(), place.isVisited());
+            return new PlaceDetails(
+                    place.getId(), place.getName(), place.getLatitude(),
+                    place.getLongitude(), place.getPlaceType().getLabel(), place.isVisited()
+            );
+        }
+    }
+
+    public record TempPlaceInfo(
+            String id,
+            String name,
+            double latitude,
+            double longitude,
+            String placeCategory
+    ) {
+        public static TempPlaceInfo from(TripPlaceReq.StoredFormat place) {
+            return new TempPlaceInfo(
+                    place.id(), place.name(), place.latitude(),
+                    place.longitude(), place.placeCategory().getLabel()
+            );
         }
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/TripPlaceImageRes.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/TripPlaceImageRes.java
@@ -26,7 +26,7 @@ public class TripPlaceImageRes {
                     place.getName(),
                     place.getLatitude(),
                     place.getLongitude(),
-                    place.getPlaceType(),
+                    place.getPlaceType().getLabel(),
                     place.getImages().stream()
                             .map(ImageDto::from)
                             .collect(Collectors.toList())

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandService.java
@@ -27,9 +27,10 @@ public class TripPlaceCommandService {
      * @param tripDayPlaceId 여행 일차(TripDayPlace)의 ID
      * @param insertRequest  삽입할 장소 정보 및 위치 기준 정보
      */
-    public void addNewPlace(String tripDayPlaceId, TripPlaceReq.InsertRequest insertRequest) {
+    public void addNewPlace(String tripDayPlaceId, TripPlaceReq.Request insertRequest) {
         Double maxPlaceOrder = tripDayPlaceService.readMaxOrderById(tripDayPlaceId);
 
+        // TODO : 중복여행 못담기게
         tripDayPlaceService.savePlace(
                 tripDayPlaceId,
                 createPlace(insertRequest, maxPlaceOrder)
@@ -42,12 +43,12 @@ public class TripPlaceCommandService {
      * 1. maxPlaceOrder : 0.0 => 존재하는 목적지가 없는 상황
      * 2. maxPlaceOrder : 0.0 x => 마지막 목적지 뒤에 추가하는 상화
      *
-     * @param insertRequest 사용자 요청 정보
+     * @param request       사용자 요청 정보
      * @param maxPlaceOrder 현재 목적지 order 중 최대값 (nullable)
      * @return 생성된 Place 객체
      */
-    private Place createPlace(TripPlaceReq.InsertRequest insertRequest, Double maxPlaceOrder) {
-        return insertRequest.toEntity(maxPlaceOrder + 10.0);
+    private Place createPlace(TripPlaceReq.Request request, Double maxPlaceOrder) {
+        return request.toEntity(maxPlaceOrder + 10.0);
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingService.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.application.tripplace.service;
 
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.infrastructure.redis.RedisRepository;
@@ -52,11 +53,14 @@ public class TripPlaceEditingService {
      *
      * @param tripId : 여행 ID
      * @param day    : 여행 일차 (1일차, 2일차 등)
-     * @return : 저장된 TripPlaceDto.StoredFormat 리스트
+     * @return : 저장된 TripPlaceRes.TempPlaceInfo 리스트
      */
-    public List<TripPlaceReq.StoredFormat> getAssignedPlaces(Long tripId, int day) {
+    public List<TripPlaceRes.TempPlaceInfo> getAssignedPlaces(Long tripId, int day) {
         String dayPlacesKey = PlaceConstant.dayPlacesKey(tripId, day);
-        return redisRepository.getList(dayPlacesKey, TripPlaceReq.StoredFormat.class);
+        List<TripPlaceReq.StoredFormat> places =
+                redisRepository.getList(dayPlacesKey, TripPlaceReq.StoredFormat.class);
+
+        return places.stream().map(TripPlaceRes.TempPlaceInfo::from).toList();
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortService.java
@@ -2,6 +2,7 @@ package kr.co.yeogiga.application.tripplace.service;
 
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
 import kr.co.yeogiga.common.util.DistanceUtils;
+import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
 import kr.co.yeogiga.infrastructure.redis.RedisRepository;
 import kr.co.yeogiga.infrastructure.redis.constant.PlaceConstant;
 import lombok.RequiredArgsConstructor;
@@ -68,7 +69,7 @@ public class TripPlaceSortService {
             List<TripPlaceReq.StoredFormat> lodgings
     ) {
         for (TripPlaceReq.StoredFormat place : places) {
-            if ("숙소".equals(place.placeCategory())) {
+            if (PlaceCategory.LODGING == place.placeCategory()) {
                 lodgings.add(place);
             } else {
                 otherPlaces.add(place);
@@ -166,6 +167,6 @@ public class TripPlaceSortService {
      * @return true = 식당, false = 식당 아님
      */
     private boolean isRestaurant(TripPlaceReq.StoredFormat place) {
-        return "식당".equals(place.placeCategory());
+        return PlaceCategory.RESTAURANT == place.placeCategory();
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/entity/Place.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.domain.tripplace.entity;
 
+import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.mongodb.core.mapping.Field;
@@ -14,14 +15,14 @@ public class Place {
     private String name;
     private Double latitude;
     private Double longitude;
-    private String placeType;
+    private PlaceCategory placeType;
     private Double order;
     private List<Image> images;
     private boolean isVisited;
 
     @Builder
     public Place(String id, String name, Double latitude,
-                 Double longitude, String placeType, Double order) {
+                 Double longitude, PlaceCategory placeType, Double order) {
         this.id = id;
         this.name = name;
         this.latitude = latitude;

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/type/PlaceCategory.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/type/PlaceCategory.java
@@ -1,60 +1,18 @@
 package kr.co.yeogiga.domain.tripplace.type;
 
-import kr.co.yeogiga.common.exception.CustomException;
-import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @Getter
 @RequiredArgsConstructor
 public enum PlaceCategory {
 
-    RESTAURANT("음식점", CategoryGroup.식당),
-    CAFE("카페", CategoryGroup.식당),
-
-    TOURIST_SPOT("관광명소", CategoryGroup.관광지),
-    CULTURE_FACILITY("문화시설", CategoryGroup.관광지),
-
-    LODGING("숙박", CategoryGroup.숙소),
-
-    ETC("기타", CategoryGroup.기타)
-    ;
+    RESTAURANT("식당"),
+    TOURISM("관광지"),
+    LODGING("숙소"),
+    ETC("기타");
 
     private final String label;
-    private final CategoryGroup group;
 
-    private static final Map<String, PlaceCategory> LABEL_MAP = new HashMap<>();
-
-    static {
-        for (PlaceCategory type : values()) {
-            LABEL_MAP.put(type.label, type);
-        }
-    }
-
-    /**
-     * 전달된 문자열 라벨에 해당하는 PlaceCategory enum을 반환
-     *
-     * @param label : 클라이언트가 전달한 키워드 문자열
-     * @return : 해당 키워드에 대응하는 PlaceCategory enum
-     * @throws CustomException INVALID_PLACE : 유효하지 않은 장소일 경우 예외 발생
-     */
-    public static PlaceCategory fromLabel(String label) {
-        PlaceCategory placeCategory = LABEL_MAP.get(label);
-        if (placeCategory == null) {
-            throw new CustomException(TripErrorType.INVALID_PLACE);
-        }
-        return placeCategory;
-    }
-
-    public String getGroupName() {
-        return group.name();
-    }
-
-    enum CategoryGroup {
-        식당, 관광지, 숙소, 기타
-    }
 }
 

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/api/TripPlaceApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/api/TripPlaceApi.java
@@ -61,7 +61,7 @@ public interface TripPlaceApi {
             @PathVariable String tripDayPlaceId,
 
             @Parameter(description = "추가할 목적지 정보")
-            @RequestBody TripPlaceReq.InsertRequest insertRequest
+            @RequestBody TripPlaceReq.Request request
     );
 
     @TrackApi(description = "여행 일정 정보 불러오기 (여행 목적지 지정 확정 후)")

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceController.java
@@ -41,9 +41,9 @@ public class TripPlaceController implements TripPlaceApi {
     @PostMapping("/{tripId}/day-place/{tripDayPlaceId}/places")
     public ResponseEntity<?> addNewPlace(@PathVariable Long tripId,
                                          @PathVariable String tripDayPlaceId,
-                                         @RequestBody TripPlaceReq.InsertRequest insertRequest) {
+                                         @RequestBody TripPlaceReq.Request request) {
 
-        tripPlaceCommandService.addNewPlace(tripDayPlaceId, insertRequest);
+        tripPlaceCommandService.addNewPlace(tripDayPlaceId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
     }
 

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
@@ -11,6 +11,7 @@ import kr.co.yeogiga.domain.trip.type.TravelStatus;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
+import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.type.Role;
 import org.junit.jupiter.api.BeforeEach;
@@ -89,7 +90,7 @@ public class TripQueryServiceTest {
                     .latitude(11.11)
                     .longitude(12.12)
                     .order(10.0)
-                    .placeType("관광 명소")
+                    .placeType(PlaceCategory.TOURISM)
                     .build();
 
             when(tripMemberService.readAllTripByUserId(userId)).thenReturn(List.of(trip1, trip2));
@@ -159,7 +160,7 @@ public class TripQueryServiceTest {
                     .latitude(11.11)
                     .longitude(12.12)
                     .order(10.0)
-                    .placeType("관광 명소")
+                    .placeType(PlaceCategory.TOURISM)
                     .build();
 
             TripDayPlace tripDayPlace = TripDayPlace.builder()

--- a/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageAssignmentServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageAssignmentServiceTest.java
@@ -4,6 +4,7 @@ import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
+import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
 import kr.co.yeogiga.domain.triproute.service.TripRouteService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -46,7 +47,7 @@ class TripPlaceImageAssignmentServiceTest {
                 .name("Place1")
                 .latitude(12.34)
                 .longitude(56.78)
-                .placeType("식당")
+                .placeType(PlaceCategory.RESTAURANT)
                 .order(1.0)
                 .build();
 

--- a/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageMovementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageMovementServiceTest.java
@@ -8,6 +8,7 @@ import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import kr.co.yeogiga.domain.tripplace.exception.ImageErrorType;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
+import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -50,7 +51,7 @@ public class TripPlaceImageMovementServiceTest {
     private Place buildPlace(String id, String name, List<Image> images) {
         Place place = Place.builder()
                 .id(id).name(name).latitude(1.0).longitude(1.0)
-                .placeType("카페")
+                .placeType(PlaceCategory.RESTAURANT)
                 .build();
         place.addImages(images);
         return place;

--- a/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageQueryServiceTest.java
@@ -7,6 +7,7 @@ import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
+import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -49,7 +50,7 @@ public class TripPlaceImageQueryServiceTest {
             .name("카페")
             .latitude(1.1)
             .longitude(2.2)
-            .placeType("식당")
+            .placeType(PlaceCategory.RESTAURANT)
             .order(10.0)
             .build();
 

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandServiceTest.java
@@ -6,6 +6,7 @@ import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
+import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -50,15 +51,15 @@ public class TripPlaceCommandServiceTest {
         void addPlaceFirst() {
             // given
             given(tripDayPlaceService.readMaxOrderById(tripDayPlaceId)).willReturn(0.0);
-            TripPlaceReq.InsertRequest insertRequest = TripPlaceReq.InsertRequest.builder()
+            TripPlaceReq.Request request = TripPlaceReq.Request.builder()
                     .name("목적지1")
                     .latitude(0.0)
                     .longitude(0.0)
-                    .placeType("카페")
+                    .placeType(PlaceCategory.RESTAURANT)
                     .build();
 
             // when
-            tripPlaceCommandService.addNewPlace(tripDayPlaceId, insertRequest);
+            tripPlaceCommandService.addNewPlace(tripDayPlaceId, request);
 
             // then
             verify(tripDayPlaceService).savePlace(eq(tripDayPlaceId), placeCaptor.capture());
@@ -72,15 +73,15 @@ public class TripPlaceCommandServiceTest {
         void addPlaceBack() {
             // given
             given(tripDayPlaceService.readMaxOrderById(tripDayPlaceId)).willReturn(20.0);
-            TripPlaceReq.InsertRequest insertRequest = TripPlaceReq.InsertRequest.builder()
+            TripPlaceReq.Request request = TripPlaceReq.Request.builder()
                     .name("목적지1")
                     .latitude(0.0)
                     .longitude(0.0)
-                    .placeType("카페")
+                    .placeType(PlaceCategory.RESTAURANT)
                     .build();
 
             // when
-            tripPlaceCommandService.addNewPlace(tripDayPlaceId, insertRequest);
+            tripPlaceCommandService.addNewPlace(tripDayPlaceId, request);
 
             // then
             verify(tripDayPlaceService).savePlace(eq(tripDayPlaceId), placeCaptor.capture());
@@ -101,9 +102,9 @@ public class TripPlaceCommandServiceTest {
         void reorderSuccess() {
             // given
             List<Place> places = List.of(
-                    Place.builder().id("id1").name("목적지1").latitude(0.0).longitude(0.0).placeType("식당").order(10.0).build(),
-                    Place.builder().id("id2").name("목적지2").latitude(0.0).longitude(0.0).placeType("식당").order(20.0).build(),
-                    Place.builder().id("id3").name("목적지3").latitude(0.0).longitude(0.0).placeType("식당").order(30.0).build()
+                    Place.builder().id("id1").name("목적지1").latitude(0.0).longitude(0.0).placeType(PlaceCategory.RESTAURANT).order(10.0).build(),
+                    Place.builder().id("id2").name("목적지2").latitude(0.0).longitude(0.0).placeType(PlaceCategory.RESTAURANT).order(20.0).build(),
+                    Place.builder().id("id3").name("목적지3").latitude(0.0).longitude(0.0).placeType(PlaceCategory.RESTAURANT).order(30.0).build()
             );
             TripDayPlace tripDayPlace = TripDayPlace.builder().day(1).places(places).build();
             TripPlaceReq.ReorderRequest reorderRequest = new TripPlaceReq.ReorderRequest(List.of("id3", "id1", "id2"));

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingServiceTest.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.application.tripplace.service;
 
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
@@ -49,15 +50,13 @@ public class TripPlaceEditingServiceTest {
                 .name("목적지1")
                 .latitude(0.0)
                 .longitude(0.0)
-                .placeType("카페")
+                .placeType(PlaceCategory.RESTAURANT)
                 .build();
 
         @Test
         @DisplayName("성공")
         void addPlaceInEditingSuccess() {
             // given
-
-
             String dayPlaceSetKey = PlaceConstant.dayPlaceSetKey(tripId, day);
             given(redisRepository.existsInSet(eq(dayPlaceSetKey), anyString())).willReturn(false);
 
@@ -97,7 +96,7 @@ public class TripPlaceEditingServiceTest {
         void deletePlaceInEditingSuccess() {
             // given
             TripPlaceReq.StoredFormat place = new TripPlaceReq.StoredFormat(
-                    placeId, "목적지1", 33.123, 126.456, PlaceCategory.RESTAURANT.getGroupName()
+                    placeId, "목적지1", 33.123, 126.456, PlaceCategory.RESTAURANT
             );
 
             given(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class)))
@@ -132,9 +131,9 @@ public class TripPlaceEditingServiceTest {
     void reorderPlacesInEditingSuccess() {
         // given
         List<TripPlaceReq.StoredFormat> storedPlace = List.of(
-                new TripPlaceReq.StoredFormat("place1-id", "목적지1", 33.1, 126.1, PlaceCategory.CAFE.getGroupName()),
-                new TripPlaceReq.StoredFormat("place2-id", "목적지2", 33.2, 126.2, PlaceCategory.CAFE.getGroupName()),
-                new TripPlaceReq.StoredFormat("place3-id", "목적지3", 33.3, 126.3, PlaceCategory.CAFE.getGroupName())
+                new TripPlaceReq.StoredFormat("place1-id", "목적지1", 33.1, 126.1, PlaceCategory.RESTAURANT),
+                new TripPlaceReq.StoredFormat("place2-id", "목적지2", 33.2, 126.2, PlaceCategory.RESTAURANT),
+                new TripPlaceReq.StoredFormat("place3-id", "목적지3", 33.3, 126.3, PlaceCategory.RESTAURANT)
         );
 
         TripPlaceReq.ReorderRequest request =
@@ -158,17 +157,17 @@ public class TripPlaceEditingServiceTest {
     void getPlacesInEditingSuccess() {
         // given
         List<TripPlaceReq.StoredFormat> mockPlaces = List.of(
-                new TripPlaceReq.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.CAFE.getGroupName())
+                new TripPlaceReq.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.RESTAURANT)
         );
 
         given(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class))).willReturn(mockPlaces);
 
         // when
-        List<TripPlaceReq.StoredFormat> result = tripPlaceEditingService.getAssignedPlaces(tripId, day);
+        List<TripPlaceRes.TempPlaceInfo> result = tripPlaceEditingService.getAssignedPlaces(tripId, day);
 
         // then
         assertEquals(1, result.size());
         assertEquals("목적지1", result.get(0).name());
-        assertEquals(PlaceCategory.CAFE.getGroupName(), result.get(0).placeCategory());
+        assertEquals(PlaceCategory.RESTAURANT.getLabel(), result.get(0).placeCategory());
     }
 }

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceQueryServiceTest.java
@@ -8,6 +8,7 @@ import kr.co.yeogiga.domain.tripplace.entity.Image;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
+import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -33,8 +34,8 @@ public class TripPlaceQueryServiceTest {
     @InjectMocks
     private TripPlaceQueryService tripPlaceQueryService;
 
-    private final Place place1 = Place.builder().id("id1").name("목적지1").latitude(0.0).longitude(1.1).placeType("카페").order(10.0).build();
-    private final Place place2 = Place.builder().id("id2").name("목적지2").latitude(2.2).longitude(3.3).placeType("카페").order(20.0).build();
+    private final Place place1 = Place.builder().id("id1").name("목적지1").latitude(0.0).longitude(1.1).placeType(PlaceCategory.RESTAURANT).order(10.0).build();
+    private final Place place2 = Place.builder().id("id2").name("목적지2").latitude(2.2).longitude(3.3).placeType(PlaceCategory.RESTAURANT).order(20.0).build();
 
     private final Long tripId = 1L;
     private final String tripDayPlaceId = "day1";
@@ -117,7 +118,7 @@ public class TripPlaceQueryServiceTest {
                 .name("목적지")
                 .latitude(1.0)
                 .longitude(2.0)
-                .placeType("음식")
+                .placeType(PlaceCategory.RESTAURANT)
                 .build();
         place.addImages(List.of(image));
 

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingServiceTest.java
@@ -5,6 +5,7 @@ import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.service.TripService;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
+import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
 import kr.co.yeogiga.infrastructure.redis.RedisRepository;
 import kr.co.yeogiga.infrastructure.redis.constant.PlaceConstant;
 import org.junit.jupiter.api.DisplayName;
@@ -61,10 +62,10 @@ public class TripPlaceSavingServiceTest {
     void completeTripSuccessPlanned() {
         // given
         TripPlaceReq.StoredFormat place1 = new TripPlaceReq.StoredFormat(
-                "id1", "장소1", 33.123, 126.456, "관광지"
+                "id1", "장소1", 33.123, 126.456, PlaceCategory.TOURISM
         );
         TripPlaceReq.StoredFormat place2 = new TripPlaceReq.StoredFormat(
-                "id2", "장소2", 33.789, 126.987, "식당"
+                "id2", "장소2", 33.789, 126.987, PlaceCategory.RESTAURANT
         );
 
         when(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class)))
@@ -103,10 +104,10 @@ public class TripPlaceSavingServiceTest {
     void completeTripSuccessInProgress() {
         // given
         TripPlaceReq.StoredFormat place1 = new TripPlaceReq.StoredFormat(
-                "id1", "장소1", 33.123, 126.456, "관광지"
+                "id1", "장소1", 33.123, 126.456, PlaceCategory.TOURISM
         );
         TripPlaceReq.StoredFormat place2 = new TripPlaceReq.StoredFormat(
-                "id2", "장소2", 33.789, 126.987, "식당"
+                "id2", "장소2", 33.789, 126.987, PlaceCategory.RESTAURANT
         );
 
         when(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class)))
@@ -145,10 +146,10 @@ public class TripPlaceSavingServiceTest {
     void completeTripSuccessCompleted() {
         // given
         TripPlaceReq.StoredFormat place1 = new TripPlaceReq.StoredFormat(
-                "id1", "장소1", 33.123, 126.456, "관광지"
+                "id1", "장소1", 33.123, 126.456, PlaceCategory.TOURISM
         );
         TripPlaceReq.StoredFormat place2 = new TripPlaceReq.StoredFormat(
-                "id2", "장소2", 33.789, 126.987, "식당"
+                "id2", "장소2", 33.789, 126.987, PlaceCategory.RESTAURANT
         );
 
         when(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class)))

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortServiceTest.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.application.tripplace.service;
 
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
 import kr.co.yeogiga.infrastructure.redis.RedisRepository;
 import kr.co.yeogiga.infrastructure.redis.constant.PlaceConstant;
 import org.junit.jupiter.api.DisplayName;
@@ -60,9 +61,9 @@ class TripPlaceSortServiceTest {
         String listKey = PlaceConstant.dayPlacesKey(tripId, day);
 
         List<TripPlaceReq.StoredFormat> input = List.of(
-                new TripPlaceReq.StoredFormat("1", "PlaceA", 35.1, 128.1, "식당"),
-                new TripPlaceReq.StoredFormat("2", "PlaceB", 35.2, 128.2, "관광지"),
-                new TripPlaceReq.StoredFormat("3", "PlaceC", 35.3, 128.3, "숙소")
+                new TripPlaceReq.StoredFormat("1", "PlaceA", 35.1, 128.1, PlaceCategory.RESTAURANT),
+                new TripPlaceReq.StoredFormat("2", "PlaceB", 35.2, 128.2, PlaceCategory.TOURISM),
+                new TripPlaceReq.StoredFormat("3", "PlaceC", 35.3, 128.3, PlaceCategory.LODGING)
         );
 
         given(redisRepository.getList(eq(listKey), eq(TripPlaceReq.StoredFormat.class)))
@@ -78,7 +79,7 @@ class TripPlaceSortServiceTest {
         verify(redisRepository, times(1)).setListAll(eq(listKey), captor.capture());
 
         List<TripPlaceReq.StoredFormat> saved = new ArrayList<>(captor.getValue());
-        assertEquals("숙소", saved.get(2).placeCategory());
+        assertEquals(PlaceCategory.LODGING, saved.get(2).placeCategory());
     }
 
     @Test
@@ -88,11 +89,11 @@ class TripPlaceSortServiceTest {
         String listKey = PlaceConstant.dayPlacesKey(tripId, day);
 
         List<TripPlaceReq.StoredFormat> input = List.of(
-                new TripPlaceReq.StoredFormat("1", "A", 35.0, 128.0, "식당"),
-                new TripPlaceReq.StoredFormat("2", "B", 35.1, 128.1, "식당"),
-                new TripPlaceReq.StoredFormat("3", "C", 35.2, 128.2, "식당"),
-                new TripPlaceReq.StoredFormat("4", "D", 35.3, 128.3, "숙소"),
-                new TripPlaceReq.StoredFormat("5", "E", 35.4, 128.4, "관광지")
+                new TripPlaceReq.StoredFormat("1", "A", 35.0, 128.0, PlaceCategory.RESTAURANT),
+                new TripPlaceReq.StoredFormat("2", "B", 35.1, 128.1, PlaceCategory.RESTAURANT),
+                new TripPlaceReq.StoredFormat("3", "C", 35.2, 128.2, PlaceCategory.RESTAURANT),
+                new TripPlaceReq.StoredFormat("4", "D", 35.3, 128.3, PlaceCategory.LODGING),
+                new TripPlaceReq.StoredFormat("5", "E", 35.4, 128.4, PlaceCategory.TOURISM)
         );
 
         given(redisRepository.getList(eq(listKey), eq(TripPlaceReq.StoredFormat.class)))
@@ -111,7 +112,7 @@ class TripPlaceSortServiceTest {
         int maxConsecutiveRestaurants = 0;
         int currentCount = 0;
         for (TripPlaceReq.StoredFormat place : saved) {
-            if ("식당".equals(place.placeCategory())) {
+            if (PlaceCategory.RESTAURANT == place.placeCategory()) {
                 currentCount++;
                 maxConsecutiveRestaurants = Math.max(maxConsecutiveRestaurants, currentCount);
             } else {

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
@@ -16,6 +16,7 @@ import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
+import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.type.Role;
 import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
@@ -267,7 +268,7 @@ public class TripControllerTest {
                 .latitude(11.11)
                 .longitude(12.12)
                 .order(10.0)
-                .placeType("관광 명소")
+                .placeType(PlaceCategory.TOURISM)
                 .build();
 
         private TripPlaceRes.PlaceSummary placeSummary = TripPlaceRes.PlaceSummary.from(place);

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceControllerTest.java
@@ -11,6 +11,7 @@ import kr.co.yeogiga.application.tripplace.service.TripPlaceSavingService;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
 import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -100,19 +101,19 @@ public class TripPlaceControllerTest {
     @DisplayName("목적지 추가 성공")
     void addNewPlaceSuccess() throws Exception {
         // given
-        TripPlaceReq.InsertRequest insertRequest = TripPlaceReq.InsertRequest.builder()
+        TripPlaceReq.Request request = TripPlaceReq.Request.builder()
                 .name("목적지1")
                 .latitude(0.0)
                 .longitude(0.0)
-                .placeType("카페")
+                .placeType(PlaceCategory.RESTAURANT)
                 .build();
-        doNothing().when(tripPlaceCommandService).addNewPlace(tripDayPlaceId, insertRequest);
+        doNothing().when(tripPlaceCommandService).addNewPlace(tripDayPlaceId, request);
 
         // when
         ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/trip/{tripId}/day-place/{tripDayPlaceId}/places", tripId, tripDayPlaceId)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(insertRequest))
+                        .content(objectMapper.writeValueAsString(request))
         );
 
         // then

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingControllerTest.java
@@ -2,6 +2,7 @@ package kr.co.yeogiga.presentation.tripplace.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
 import kr.co.yeogiga.application.tripplace.service.TripPlaceEditingService;
 import kr.co.yeogiga.application.tripplace.service.TripPlaceSortService;
 import kr.co.yeogiga.common.exception.CustomException;
@@ -79,7 +80,7 @@ public class TripPlaceEditingControllerTest {
                 .name("목적지1")
                 .latitude(0.0)
                 .longitude(0.0)
-                .placeType("카페")
+                .placeType(PlaceCategory.RESTAURANT)
                 .build();
 
         @Test
@@ -170,8 +171,8 @@ public class TripPlaceEditingControllerTest {
     @DisplayName("목적지 조회 성공")
     void getAssignedPlacesSuccess() throws Exception {
         // given
-        List<TripPlaceReq.StoredFormat> mockPlaces = List.of(
-                new TripPlaceReq.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.CAFE.getGroupName())
+        List<TripPlaceRes.TempPlaceInfo> mockPlaces = List.of(
+                new TripPlaceRes.TempPlaceInfo("place-id", "목적지1", 33.123, 126.456, PlaceCategory.RESTAURANT.getLabel())
         );
         given(tripPlaceEditingService.getAssignedPlaces(tripId, day)).willReturn(mockPlaces);
 
@@ -185,7 +186,7 @@ public class TripPlaceEditingControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data[0].name").value("목적지1"))
-                .andExpect(jsonPath("$.data[0].placeCategory").value("식당"));
+                .andExpect(jsonPath("$.data[0].placeCategory").value(PlaceCategory.RESTAURANT.getLabel()));
     }
 
     @Test


### PR DESCRIPTION
## 배경
카카오 지도에 플러터 SDK가 없어 네이버 지도로 변경
-> 카카오 지도에 맞춘 목적지 카테고리 포맷 변경 필요

## 작업 사항
- 여행 카테고리 enum 수정 (5ba58545665f2ecf4e5b2cd097d92818325ccaa9)
  - 목적지 카테고리 저장 타입 변경 (5980d9c5b860b1df64447407cb2d67d520a470bd)
- 확정되지 않은 목적지 조회 dto 추가 (f8ee2957fe77d929928b62693c7e117638b193d2)
  - 임시 목적지 조회 메서드 반환형 변경 (59fb052ac5ce08a6d9765322f33bf5223a1a3ad7)
- 중복 dto 삭제 (513befefe4d87da56d969cbc92c48509690420c3)에 포함
  - 목적지 요청 dto 변경 (c1963a851ad342df89108230fe44af36f23c6cdb)
  - 목적지 삽입 REST API 요청 dto 변경 (6304785a3898ad39d97abebc8823339f738f5960)

## 추가 논의
카테고리 설정에 대해 프론트 및 앱 팀에 인지 시켰고, PR이 승인 된다면 다시 말씀드리겠습니다.