### PR TITLE
Feature(IL-210): 공지사항 생성 기능 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/notice/dto/NoticeReq.java
+++ b/src/main/java/kr/co/yeogiga/application/notice/dto/NoticeReq.java
@@ -1,12 +1,16 @@
 package kr.co.yeogiga.application.notice.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 public class NoticeReq {
     
     @Builder
     public record Creation(
+            @NotBlank(message = "제목은 필수 입력값입니다.")
             String title,
+            
+            @NotBlank(message = "내용은 필수 입력값입니다.")
             String description
     ) {
     }

--- a/src/main/java/kr/co/yeogiga/application/notice/dto/NoticeReq.java
+++ b/src/main/java/kr/co/yeogiga/application/notice/dto/NoticeReq.java
@@ -1,15 +1,19 @@
 package kr.co.yeogiga.application.notice.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 public class NoticeReq {
     
     @Builder
+    @Schema(name = "NoticeReq.Creation", description = "여행 생성 요청 DTO")
     public record Creation(
+            @Schema(description = "제목", example = "필수 준비물")
             @NotBlank(message = "제목은 필수 입력값입니다.")
             String title,
             
+            @Schema(description = "내용", example = "준비물 다시 확인하시고 꼭 챙기십시오.")
             @NotBlank(message = "내용은 필수 입력값입니다.")
             String description
     ) {

--- a/src/main/java/kr/co/yeogiga/application/notice/dto/NoticeReq.java
+++ b/src/main/java/kr/co/yeogiga/application/notice/dto/NoticeReq.java
@@ -1,0 +1,13 @@
+package kr.co.yeogiga.application.notice.dto;
+
+import lombok.Builder;
+
+public class NoticeReq {
+    
+    @Builder
+    public record Creation(
+            String title,
+            String description
+    ) {
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/notice/service/NoticeCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/notice/service/NoticeCommandService.java
@@ -1,0 +1,32 @@
+package kr.co.yeogiga.application.notice.service;
+
+import kr.co.yeogiga.application.notice.dto.NoticeReq;
+import kr.co.yeogiga.domain.notice.entity.Notice;
+import kr.co.yeogiga.domain.notice.service.NoticeService;
+import kr.co.yeogiga.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeCommandService {
+    private final NoticeService noticeService;
+    
+    /**
+     * 여행 공지사항을 생성하는 메서드
+     *
+     * @param userId    작성자 ID
+     * @param tripId    여행 ID
+     * @param dto       공지사항 요청 DTO
+     */
+    public void createNotice(Long userId, Long tripId, NoticeReq.Creation dto) {
+        Notice notice = Notice.builder()
+                .title(dto.title())
+                .description(dto.description())
+                .author(User.builder().id(userId).build())
+                .tripId(tripId)
+                .build();
+        
+        noticeService.save(notice);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/notice/entity/Notice.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/entity/Notice.java
@@ -2,7 +2,6 @@ package kr.co.yeogiga.domain.notice.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -11,15 +10,12 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import kr.co.yeogiga.domain.common.entity.BaseTimeEntity;
 import kr.co.yeogiga.domain.user.entity.User;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Entity
@@ -30,8 +26,7 @@ import java.time.LocalDateTime;
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
-public class Notice {
+public class Notice extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -48,10 +43,6 @@ public class Notice {
     
     @Column(name = "trip_id", nullable = false)
     private Long tripId;
-    
-    @CreatedDate
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
     
     @Builder
     public Notice(String title, User author, String description, Long tripId) {

--- a/src/main/java/kr/co/yeogiga/domain/notice/entity/Notice.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/entity/Notice.java
@@ -1,0 +1,63 @@
+package kr.co.yeogiga.domain.notice.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import kr.co.yeogiga.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(
+        name = "notice",
+        indexes = {
+                @Index(name = "idx_trip_id", columnList = "trip_id")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Notice {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false)
+    private String title;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id")
+    private User author;
+    
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String description;
+    
+    @Column(name = "trip_id", nullable = false)
+    private Long tripId;
+    
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+    
+    @Builder
+    public Notice(String title, User author, String description, Long tripId) {
+        this.title = title;
+        this.author = author;
+        this.description = description;
+        this.tripId = tripId;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/NoticeRepository.java
@@ -1,0 +1,7 @@
+package kr.co.yeogiga.domain.notice.repository;
+
+import kr.co.yeogiga.domain.notice.entity.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+}

--- a/src/main/java/kr/co/yeogiga/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/service/NoticeService.java
@@ -1,0 +1,16 @@
+package kr.co.yeogiga.domain.notice.service;
+
+import kr.co.yeogiga.domain.notice.entity.Notice;
+import kr.co.yeogiga.domain.notice.repository.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+    private final NoticeRepository noticeRepository;
+    
+    public void save(Notice notice) {
+        noticeRepository.save(notice);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -60,7 +60,8 @@ public class User extends BaseTimeEntity {
     private LocalDateTime deletedAt;
 
     @Builder
-    public User(String username, String password, String nickname, String email, Role role) {
+    public User(Long id, String username, String password, String nickname, String email, Role role) {
+        this.id = id;
         this.username = username;
         this.password = password;
         this.nickname = nickname;

--- a/src/main/java/kr/co/yeogiga/presentation/notice/api/NoticeApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/notice/api/NoticeApi.java
@@ -1,0 +1,58 @@
+package kr.co.yeogiga.presentation.notice.api;
+
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.co.yeogiga.application.notice.dto.NoticeReq;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@ApiGroup(value = "[공지사항 API]")
+@Tag(name = "[공지사항 API]", description = "공지사항 관련 API")
+public interface NoticeApi {
+    
+    @TrackApi(description = "공지사항 생성")
+    @Operation(summary = "공지사항 생성", description = "공지사항 생성 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "공지사항 생성 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                             {
+                                                     "code": 201,
+                                                     "message": "요청이 성공하였습니다."
+                                             }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "공지사항 생성 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "유효성 검사 실패",value = """
+                                             {
+                                                     "code":"G002",
+                                                     "errors": {
+                                                          "description": "내용은 필수 입력값입니다.",
+                                                          "title": "제목은 필수 입력값입니다."
+                                                     }
+                                             }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> createNotice(
+            @Parameter(description = "여행 ID")
+            @PathVariable(name = "tripId") Long tripId,
+            
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            
+            @Valid @RequestBody NoticeReq.Creation request
+    );
+}

--- a/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
@@ -1,0 +1,34 @@
+package kr.co.yeogiga.presentation.notice.controller;
+
+import jakarta.validation.Valid;
+import kr.co.yeogiga.application.notice.dto.NoticeReq;
+import kr.co.yeogiga.application.notice.service.NoticeCommandService;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/trip")
+public class NoticeController {
+    private final NoticeCommandService noticeCommandService;
+    
+    @PostMapping("/{tripId}/notices")
+    public ResponseEntity<?> createNotice(
+            @PathVariable(name = "tripId") Long tripId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody NoticeReq.Creation request
+    ) {
+        noticeCommandService.createNotice(userDetails.getUserId(), tripId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(SuccessResponse.created());
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
@@ -5,6 +5,7 @@ import kr.co.yeogiga.application.notice.dto.NoticeReq;
 import kr.co.yeogiga.application.notice.service.NoticeCommandService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.presentation.notice.api.NoticeApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,9 +19,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/trip")
-public class NoticeController {
+public class NoticeController implements NoticeApi {
     private final NoticeCommandService noticeCommandService;
     
+    @Override
     @PostMapping("/{tripId}/notices")
     public ResponseEntity<?> createNotice(
             @PathVariable(name = "tripId") Long tripId,

--- a/src/test/java/kr/co/yeogiga/application/notice/service/NoticeCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/notice/service/NoticeCommandServiceTest.java
@@ -1,0 +1,59 @@
+package kr.co.yeogiga.application.notice.service;
+
+import kr.co.yeogiga.application.notice.dto.NoticeReq;
+import kr.co.yeogiga.domain.notice.entity.Notice;
+import kr.co.yeogiga.domain.notice.service.NoticeService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.assertArg;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class NoticeCommandServiceTest {
+    
+    @Mock
+    private NoticeService noticeService;
+    
+    @InjectMocks
+    private NoticeCommandService noticeCommandService;
+    
+    @Nested
+    @DisplayName("공지사항 생성")
+    class CreateNotice {
+        
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            Long userId = 1L;
+            Long tripId = 2L;
+            
+            NoticeReq.Creation dto = NoticeReq.Creation.builder()
+                    .title("title")
+                    .description("description")
+                    .build();
+            
+            doNothing().when(noticeService).save(any(Notice.class));
+            
+            // when
+            noticeCommandService.createNotice(userId, tripId, dto);
+            
+            // then
+            verify(noticeService, times(1)).save(assertArg(notice -> {
+                assertEquals(userId, notice.getAuthor().getId());
+                assertEquals(tripId, notice.getTripId());
+            }));
+        }
+    }
+    
+}

--- a/src/test/java/kr/co/yeogiga/presentation/notice/controller/NoticeControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/notice/controller/NoticeControllerTest.java
@@ -1,0 +1,129 @@
+package kr.co.yeogiga.presentation.notice.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.application.notice.dto.NoticeReq;
+import kr.co.yeogiga.application.notice.service.NoticeCommandService;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
+import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.type.Role;
+import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = NoticeController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthenticationFilter.class})
+        }
+)
+public class NoticeControllerTest {
+    
+    private MockMvc mockMvc;
+    
+    private CustomUserDetails userDetails;
+    
+    @Autowired
+    private ObjectMapper objectMapper;
+    
+    @MockBean
+    private NoticeCommandService noticeCommandService;
+    
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .alwaysDo(print())
+                .build();
+        
+        User user = User.builder()
+                .username("username")
+                .password("password")
+                .nickname("nickname")
+                .email("email")
+                .role(Role.USER)
+                .build();
+        
+        ReflectionTestUtils.setField(user, "id", 1L);
+        
+        userDetails = new CustomUserDetailsImpl(user);
+    }
+    
+    @Nested
+    @DisplayName("공지사항 생성")
+    class CreateNotice {
+        private final Long tripId = 1L;
+        
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            NoticeReq.Creation request = NoticeReq.Creation.builder()
+                    .title("title")
+                    .description("description")
+                    .build();
+            
+            doNothing().when(noticeCommandService).createNotice(anyLong(), anyLong(), any(NoticeReq.Creation.class));
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/trip/{tripId}/notices", tripId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isCreated());
+        }
+        
+        @Test
+        @DisplayName("실패 - 유효성 검사")
+        void failValidation() throws Exception {
+            // given
+            NoticeReq.Creation request = NoticeReq.Creation.builder()
+                    .title(" ")
+                    .description(" ")
+                    .build();
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/trip/{tripId}/notices", tripId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors.title").exists())
+                    .andExpect(jsonPath("$.errors.description").exists());
+            
+        }
+    }
+}


### PR DESCRIPTION
## 배경
- 여행 내 공지사항 기능 요구: 공지사항 엔티티 및 공지사항 생성 기능 구현 필요

## 작업 사항
- 공지사항 엔티티 정의 | (d05fa62fdfd8a3afe26b97bae19b0495c607e6cc)
	- 공지사항 자체에서 여행을 조회하게 되는 일은 없을 것 같아 단순 여행 id(trip_id)만 컬럼으로 정의해놓았습니다. 
	- 나중에 여행과 공지사항이 많아지게 된다면 조회 성능에 영향이 있을 것 같아 인덱스 적용시켰습니다. 
<br/>

- 공지사항 생성 로직 구현 | (c6a6ca87bd22257227bcb12615277ef7df8ab84e)
	- 공지사항 생성 시에 요청을 보낸 사용자가 곧 공지사항의 작성자(author)이기에 굳이 서비스 단에서 사용자를 한 번 더 조회할 필요는 없지 않을까라는 생각에 단순히 요청을 보낸 사용자의 id(pk) 값만 가지는 `User` 객체를 매핑하였습니다. 따라서, `User` 엔티티의 빌더 내에 id 필드를 추가하였습니다.
	- 여행의 경우에도 여행 내에서 공지사항을 생성하게 될텐데 불필요한 여행 존재 확인 등의 로직은 추가하지 않았습니다.