### PR TITLE
Feature(IL-102): OAuth 로그인 웹-모바일 환경 분리

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
@@ -19,13 +19,23 @@ public class SignInDto {
     ) {
     }
 
-    @Builder
-    @Schema(name = "OAuthRequest", description = "OAuth 로그인 요청 DTO")
-    public record OAuthRequest(
-            @Schema(description = "OAuth 리소스 서버에서 발급받은 인증 코드", example = "abcd123")
-            @NotBlank(message = "인증 코드값은 필수입니다.")
-            String code
-    ) {
+    
+    public static class OAuthRequest {
+        @Builder
+        @Schema(name = "OAuthRequest.Web", description = "웹 이용자 OAuth 로그인 요청 DTO")
+        public record Web(
+                @Schema(description = "OAuth 리소스 서버에서 발급받은 인증 코드", example = "abcd123")
+                @NotBlank(message = "인증 코드값은 필수입니다.")
+                String code
+        ) { }
+        
+        @Builder
+        @Schema(name = "OAuthRequest.Mobile", description = "모바일 이용자 OAuth 로그인 요청 DTO")
+        public record Mobile(
+                @Schema(description = "OAuth 리소스 서버에서 발급받은 액세스 토큰", example = "xxx.xxx.xxx")
+                @NotBlank(message = "액세스 토큰 값은 필수입니다.")
+                String accessToken
+        ) { }
     }
 
     @Builder

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -31,14 +31,14 @@ public class OAuthManagementService {
     private final UserService userService;
 
     /**
-     * OAuth2 로그인
+     * 웹 이용자 OAuth2 로그인 메서드
      *
      * @param platform      OAuth 로그인 플랫폼
      * @param code          OAuth 리소스 서버 제공 인증 코드
      * @return              로그인 응답 정보 (JWT, 추가 정보 입력 필요 여부)
      */
     @Transactional
-    public SignInDto.Response signIn(OAuthPlatform platform, String code) {
+    public SignInDto.Response signInOnWeb(OAuthPlatform platform, String code) {
         OAuthClient oAuthClient = oAuthClientFactory.getOAuthClient(platform);
 
         String accessToken = oAuthClient.fetchAccessToken(code);
@@ -46,6 +46,24 @@ public class OAuthManagementService {
 
         UserStatusDto userStatus = getUserStatus(platform, userInfo);
 
+        return getSignInResponse(userStatus);
+    }
+    
+    /**
+     * 모바일 이용자 OAuth2 로그인 메서드
+     *
+     * @param platform      OAuth 로그인 플랫폼
+     * @param accessToken   OAuth 리소스 서버 제공 액세스 토큰
+     * @return              로그인 응답 정보 (JWT, 추가 정보 입력 필요 여부)
+     */
+    @Transactional
+    public SignInDto.Response signInOnMobile(OAuthPlatform platform, String accessToken) {
+        OAuthClient oAuthClient = oAuthClientFactory.getOAuthClient(platform);
+        
+        UserInfoDto userInfo = oAuthClient.fetchUserInfo(accessToken);
+        
+        UserStatusDto userStatus = getUserStatus(platform, userInfo);
+        
         return getSignInResponse(userStatus);
     }
 

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.presentation.auth.api;
 import api.link.checker.annotation.ApiGroup;
 import api.link.checker.annotation.TrackApi;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -11,50 +12,22 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
 import kr.co.yeogiga.application.auth.dto.SignUpDto;
-import kr.co.yeogiga.application.auth.type.Device;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 
 @ApiGroup(value = "[OAuth2 인증 API]")
 @Tag(name = "[OAuth2 인증 API]", description = "OAuth2 인증 관련 API")
 public interface OAuthApi {
 
-    @TrackApi(description = "OAuth2 로그인")
-    @Operation(summary = "OAuth2 로그인", description = "OAuth2를 통한 로그인 API 입니다. 처음 로그인하는 사용자는 '여기가'에 유저 정보를 등록합니다.")
+    @TrackApi(description = "OAuth2 로그인 - 웹")
+    @Operation(summary = "OAuth2 로그인 - 웹", description = "OAuth2를 통한 웹 이용자 로그인 API 입니다. 처음 로그인하는 사용자는 '여기가'에 유저 정보를 등록합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "로그인 성공",
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name = "기존 회원가입된 사용자(모바일)", value = """
-                                        {
-                                            "code": 200,
-                                            "message": "요청이 성공하였습니다.",
-                                            "data": {
-                                                "token": {
-                                                    "accessToken": "xxxxx.xxxxx.xxxxx",
-                                                    "refreshToken": "xxxxx.xxxxx.xxxxx"
-                                                },
-                                                "shouldSignup": false
-                                            }
-                                        }
-                                    """),
-                            @ExampleObject(name = "기존 회원가입되지 않은 사용자(모바일)",  description = "추가 정보 입력(회원가입) 후 토큰 갱신 필요", value = """
-                                        {
-                                            "code": 200,
-                                            "message": "요청이 성공하였습니다.",
-                                            "data": {
-                                                "token": {
-                                                    "accessToken": "xxxxx.xxxxx.xxxxx",
-                                                    "refreshToken": "xxxxx.xxxxx.xxxxx"
-                                                },
-                                                "shouldSignup": true
-                                            }
-                                        }
-                                    """),
                             @ExampleObject(name = "기존 회원가입된 사용자(웹)", description = "웹은 refresh token이 쿠키로 전달", value = """
                                         {
                                              "code": 200,
@@ -98,7 +71,69 @@ public interface OAuthApi {
                                     """)
                     }))
     })
-    ResponseEntity<?> signIn(@RequestHeader(value = "device") Device device, @PathVariable(name = "platform") OAuthPlatform platform, @Valid @RequestBody SignInDto.OAuthRequest request);
+    ResponseEntity<?> signIn(
+            @Parameter(description = "소셜 로그인 플랫폼(카카오, 네이버)", example = "KAKAO, NAVER")
+            @PathVariable(name = "platform") OAuthPlatform platform,
+            
+            @Valid @RequestBody SignInDto.OAuthRequest.Web request
+    );
+    
+    @TrackApi(description = "OAuth2 로그인 - 모바일")
+    @Operation(summary = "OAuth2 로그인 - 모바일", description = "OAuth2를 통한 모바일 이용자 로그인 API 입니다. 처음 로그인하는 사용자는 '여기가'에 유저 정보를 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "기존 회원가입된 사용자(모바일)", value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": {
+                                                "token": {
+                                                    "accessToken": "xxxxx.xxxxx.xxxxx",
+                                                    "refreshToken": "xxxxx.xxxxx.xxxxx"
+                                                },
+                                                "shouldSignup": false
+                                            }
+                                        }
+                                    """),
+                            @ExampleObject(name = "기존 회원가입되지 않은 사용자(모바일)",  description = "추가 정보 입력(회원가입) 후 토큰 갱신 필요", value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": {
+                                                "token": {
+                                                    "accessToken": "xxxxx.xxxxx.xxxxx",
+                                                    "refreshToken": "xxxxx.xxxxx.xxxxx"
+                                                },
+                                                "shouldSignup": true
+                                            }
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "유효성 검사 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "인증 코드 유효성 검사 실패", value = """
+                                        {
+                                            "code": "G002",
+                                            "errors": {
+                                                "code": "인증 코드값은 필수입니다."
+                                            }
+                                        }
+                                    """),
+                            @ExampleObject(name = "플랫폼 유효성 검사 실패", value = """
+                                        {
+                                            "code": "G003",
+                                            "message": "지원하지 않는 Path Variable 값입니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> signIn(
+            @Parameter(description = "소셜 로그인 플랫폼(카카오, 네이버)", example = "KAKAO, NAVER")
+            @PathVariable(name = "platform") OAuthPlatform platform,
+            
+            @Valid @RequestBody SignInDto.OAuthRequest.Mobile request
+    );
 
     @TrackApi(description = "게스트 회원 등록")
     @Operation(summary = "게스트 회원 등록", description = "게스트 사용자 회원 등록을 위한 API 입니다.")

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
@@ -4,7 +4,6 @@ import jakarta.validation.Valid;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
 import kr.co.yeogiga.application.auth.dto.SignUpDto;
 import kr.co.yeogiga.application.auth.service.OAuthManagementService;
-import kr.co.yeogiga.application.auth.type.Device;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import kr.co.yeogiga.common.util.CookieUtil;
@@ -18,11 +17,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.Duration;
+
 import static kr.co.yeogiga.application.auth.constant.AuthConstants.REFRESH_TOKEN_PREFIX;
 
 @RestController
@@ -32,12 +31,30 @@ public class OAuthController implements OAuthApi {
     private final OAuthManagementService oAuthManagementService;
 
     @Override
-    @PostMapping("/sign-in/{platform}")
+    @PostMapping("/sign-in/{platform}/web")
     public ResponseEntity<?> signIn(
-            @RequestHeader(value = "device") Device device,
             @PathVariable(name = "platform") OAuthPlatform platform,
-            @Valid @RequestBody SignInDto.OAuthRequest request) {
-        return createSignInResponse(device, oAuthManagementService.signIn(platform, request.code()));
+            @Valid @RequestBody SignInDto.OAuthRequest.Web request
+    ) {
+        SignInDto.Response response = oAuthManagementService.signInOnWeb(platform, request.code());
+        
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, CookieUtil.createCookie(
+                        REFRESH_TOKEN_PREFIX,
+                        response.token().refreshToken(),
+                        Duration.ofDays(7).toSeconds()).toString())
+                .body(SuccessResponse.from(response.toWebResponse()));
+    }
+    
+    @Override
+    @PostMapping("/sign-in/{platform}/mobile")
+    public ResponseEntity<?> signIn(
+            @PathVariable(name = "platform") OAuthPlatform platform,
+            @Valid @RequestBody SignInDto.OAuthRequest.Mobile request
+    ) {
+        SignInDto.Response response = oAuthManagementService.signInOnMobile(platform, request.accessToken());
+        
+        return ResponseEntity.ok(SuccessResponse.from(response));
     }
 
     @Override
@@ -47,18 +64,6 @@ public class OAuthController implements OAuthApi {
             @Valid @RequestBody SignUpDto.Register request) {
         oAuthManagementService.register(userDetails.getUserId(), request);
         return ResponseEntity.ok(SuccessResponse.ok());
-    }
-
-    private ResponseEntity<?> createSignInResponse(Device device, SignInDto.Response response) {
-        return switch (device) {
-            case MOBILE -> ResponseEntity.ok(SuccessResponse.from(response));
-            case WEB -> ResponseEntity.ok()
-                        .header(HttpHeaders.SET_COOKIE, CookieUtil.createCookie(
-                                REFRESH_TOKEN_PREFIX,
-                                response.token().refreshToken(),
-                                Duration.ofDays(7).toSeconds()).toString())
-                        .body(SuccessResponse.from(response.toWebResponse()));
-        };
     }
 }
 

--- a/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthControllerTest.java
@@ -4,13 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
 import kr.co.yeogiga.application.auth.dto.TokenDto;
 import kr.co.yeogiga.application.auth.service.OAuthManagementService;
-import kr.co.yeogiga.application.auth.type.Device;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
 import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
 import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
 import kr.co.yeogiga.presentation.auth.controller.OAuthController;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -24,6 +24,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -47,10 +48,8 @@ public class OAuthControllerTest {
 
     @MockBean
     private OAuthManagementService oAuthManagementService;
-
-    private Device device;
-    private OAuthPlatform oAuthPlatform;
-    private SignInDto.OAuthRequest request;
+    
+    
 
     @BeforeEach
     void setUp(WebApplicationContext webApplicationContext) {
@@ -58,193 +57,122 @@ public class OAuthControllerTest {
                 .webAppContextSetup(webApplicationContext)
                 .alwaysDo(print())
                 .build();
-
-        request = SignInDto.OAuthRequest.builder()
-                .code("testCode")
+    }
+    
+    private SignInDto.Response getSingInResponse(boolean shouldSignUp) {
+        return SignInDto.Response.builder()
+                .token(
+                        TokenDto.builder()
+                                .accessToken("accessToken.xxx.xxx")
+                                .refreshToken("refreshToken.xxx.xxx")
+                                .build()
+                )
+                .shouldSignup(shouldSignUp)
                 .build();
     }
-
-    void setSignInMethod(boolean shouldSignup) {
-        when(oAuthManagementService.signIn(any(), any())).thenReturn(
-                SignInDto.Response.builder()
-                        .token(TokenDto.builder()
-                                .accessToken("test_access_token")
-                                .refreshToken("test_refresh_token")
-                                .build())
-                        .shouldSignup(shouldSignup)
-                        .build()
-        );
-    }
-
-    @Test
-    @DisplayName("처음 로그인한 사용자 (웹)")
-    void signInFirstFromWeb() throws Exception {
-        // given
-        device = Device.WEB;
-        oAuthPlatform = OAuthPlatform.NAVER;
-        setSignInMethod(true);
-
-        // when
-        ResultActions resultActions = mockMvc.perform(
-                post("/api/v1/oauth/sign-in/{platform}", oAuthPlatform)
-                        .header("device", device.name())
-                        .content(objectMapper.writeValueAsBytes(request))
-                        .contentType(MediaType.APPLICATION_JSON)
-        );
-
-        // then
-        resultActions
-                .andExpect(status().isOk())
-                .andExpect(cookie().exists("refreshToken"))
-                .andExpect(jsonPath("$.data.token.accessToken").exists())
-                .andExpect(jsonPath("$.data.shouldSignup").value(true));
-    }
-
-    @Test
-    @DisplayName("처음 로그인한 사용자 (모바일)")
-    void signInFirstFormMobile() throws Exception {
-        // given
-        device = Device.MOBILE;
-        oAuthPlatform = OAuthPlatform.NAVER;
-        setSignInMethod(true);
-
-        // when
-        ResultActions resultActions = mockMvc.perform(
-                post("/api/v1/oauth/sign-in/{platform}", oAuthPlatform)
-                        .header("device", device.name())
-                        .content(objectMapper.writeValueAsBytes(request))
-                        .contentType(MediaType.APPLICATION_JSON)
-        );
-
-        // then
-        resultActions
-                .andExpect(status().isOk())
-                .andExpect(cookie().doesNotExist("refreshToken"))
-                .andExpect(jsonPath("$.data.token.accessToken").exists())
-                .andExpect(jsonPath("$.data.token.refreshToken").exists())
-                .andExpect(jsonPath("$.data.shouldSignup").value(true));
-    }
-
-    @Test
-    @DisplayName("이미 회원가입한 사용자 (웹)")
-    void signInFromWeb() throws Exception {
-        // given
-        device = Device.WEB;
-        oAuthPlatform = OAuthPlatform.NAVER;
-        setSignInMethod(false);
-
-        // when
-        ResultActions resultActions = mockMvc.perform(
-                post("/api/v1/oauth/sign-in/{platform}", oAuthPlatform)
-                        .header("device", device.name())
-                        .content(objectMapper.writeValueAsBytes(request))
-                        .contentType(MediaType.APPLICATION_JSON)
-        );
-
-        // then
-        resultActions
-                .andExpect(status().isOk())
-                .andExpect(cookie().exists("refreshToken"))
-                .andExpect(jsonPath("$.data.token.accessToken").exists())
-                .andExpect(jsonPath("$.data.shouldSignup").value(false));
-    }
-
-    @Test
-    @DisplayName("이미 회원가입한 사용자 (모바일)")
-    void signInFormMobile() throws Exception {
-        // given
-        device = Device.MOBILE;
-        oAuthPlatform = OAuthPlatform.NAVER;
-        setSignInMethod(false);
-
-        // when
-        ResultActions resultActions = mockMvc.perform(
-                post("/api/v1/oauth/sign-in/{platform}", oAuthPlatform)
-                        .header("device", device.name())
-                        .content(objectMapper.writeValueAsBytes(request))
-                        .contentType(MediaType.APPLICATION_JSON)
-        );
-
-        // then
-        resultActions
-                .andExpect(status().isOk())
-                .andExpect(cookie().doesNotExist("refreshToken"))
-                .andExpect(jsonPath("$.data.token.accessToken").exists())
-                .andExpect(jsonPath("$.data.token.refreshToken").exists())
-                .andExpect(jsonPath("$.data.shouldSignup").value(false));
-    }
-
-    @Test
-    @DisplayName("OAuth 인증 코드 누락")
-    void missOAuthCode() throws Exception {
-        // given
-        device = Device.MOBILE;
-        oAuthPlatform = OAuthPlatform.NAVER;
-        SignInDto.OAuthRequest req = SignInDto.OAuthRequest.builder()
-                        .build();
-
-
-        setSignInMethod(false);
-
-        // when
-        ResultActions resultActions = mockMvc.perform(
-                post("/api/v1/oauth/sign-in/{platform}", oAuthPlatform)
-                        .header("device", device.name())
-                        .content(objectMapper.writeValueAsBytes(req))
-                        .contentType(MediaType.APPLICATION_JSON)
-        );
-
-        // then
-        resultActions
-                .andExpect(status().is(400))
-                .andExpect(jsonPath("$.code").value("G002"));
-    }
-
-    @Test
-    @DisplayName("OAuth 인증 코드 공백값")
-    void emptyOAuthCode() throws Exception {
-        // given
-        device = Device.MOBILE;
-        oAuthPlatform = OAuthPlatform.NAVER;
-        SignInDto.OAuthRequest req = SignInDto.OAuthRequest.builder()
-                .code("   ")
+    
+    @Nested
+    @DisplayName("소셜 로그인 - 웹")
+    class SignInOnWeb {
+        private SignInDto.OAuthRequest.Web request = SignInDto.OAuthRequest.Web.builder()
+                .code("authorization_code")
                 .build();
-
-
-        setSignInMethod(false);
-
-        // when
-        ResultActions resultActions = mockMvc.perform(
-                post("/api/v1/oauth/sign-in/{platform}", oAuthPlatform)
-                        .header("device", device.name())
-                        .content(objectMapper.writeValueAsBytes(req))
-                        .contentType(MediaType.APPLICATION_JSON)
-        );
-
-        // then
-        resultActions
-                .andExpect(status().is(400))
-                .andExpect(jsonPath("$.code").value("G002"));
+        
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            when(oAuthManagementService.signInOnWeb(any(OAuthPlatform.class), anyString()))
+                    .thenReturn(getSingInResponse(true));
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/oauth/sign-in/{platform}/web", OAuthPlatform.KAKAO)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.token.accessToken").exists())
+                    .andExpect(cookie().exists("refreshToken"));
+        }
+        
+        @Test
+        @DisplayName("실패 - 유효성 검증")
+        void failValidation() throws Exception {
+            // given
+            SignInDto.OAuthRequest.Web request = SignInDto.OAuthRequest.Web.builder()
+                    .code(" ")
+                    .build();
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/oauth/sign-in/{platform}/web", OAuthPlatform.KAKAO)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.data.accessToken").doesNotExist())
+                    .andExpect(jsonPath("$.errors.code").exists())
+                    .andExpect(cookie().doesNotExist("refreshToken"));
+        }
     }
-
-    @Test
-    @DisplayName("지원하지 않는 플랫폼")
-    void unsupportedPlatform() throws Exception {
-        // given
-        device = Device.MOBILE;
-        setSignInMethod(false);
-
-        // when
-        ResultActions resultActions = mockMvc.perform(
-                post("/api/v1/oauth/sign-in/{platform}", "MISS_VALUE")
-                        .header("device", device.name())
-                        .content(objectMapper.writeValueAsBytes(request))
-                        .contentType(MediaType.APPLICATION_JSON)
-        );
-
-        // then
-        resultActions
-                .andExpect(status().is(400))
-                .andExpect(jsonPath("$.code").value("G003"));
+    
+    @Nested
+    @DisplayName("소셜 로그인 - 모바일")
+    class SignInOnMobile {
+        private SignInDto.OAuthRequest.Mobile request = SignInDto.OAuthRequest.Mobile.builder()
+                .accessToken("xxx.xxx.xxx")
+                .build();
+        
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            when(oAuthManagementService.signInOnMobile(any(OAuthPlatform.class), anyString()))
+                    .thenReturn(getSingInResponse(true));
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/oauth/sign-in/{platform}/mobile", OAuthPlatform.KAKAO)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.token.accessToken").exists())
+                    .andExpect(jsonPath("$.data.token.refreshToken").exists())
+                    .andExpect(cookie().doesNotExist("refreshToken"));
+        }
+        
+        @Test
+        @DisplayName("실패 - 유효성 검증")
+        void failValidation() throws Exception {
+            // given
+            SignInDto.OAuthRequest.Mobile request = SignInDto.OAuthRequest.Mobile.builder()
+                    .accessToken(" ")
+                    .build();
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/oauth/sign-in/{platform}/mobile", OAuthPlatform.KAKAO)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.data.accessToken").doesNotExist())
+                    .andExpect(jsonPath("$.errors.accessToken").exists())
+                    .andExpect(cookie().doesNotExist("refreshToken"));
+        }
     }
 }


### PR DESCRIPTION
## 배경
- 모바일 카카오 소셜 로그인 시 Flutter SDK 사용을 위한 OAuth 소셜 로그인 디바이스(웹, 모바일) 별 환경 분리
	- Flutter SDK 내 인가 코드 획득 불가
	- Flutter SDK를 사용하여 카카오톡 설치 사용자의 경우 앱을 통한 로그인 기능 고려
	- 차후 애플 로그인 등 기타 소셜 로그인 플랫폼 별 호환성을 위한 환경별 로직 분리 필요

## 작업 사항
- 모바일 환경 소셜 로그인 로직 분리 | (985e2a5af97ca8a461ca3466dc37375d334910fd)
	- 액세스 토큰 획득 로직 불필요