### PR TITLE
Feature(IL-214): 전체 공지사항 조회 기능 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/notice/service/NoticeQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/notice/service/NoticeQueryService.java
@@ -1,0 +1,25 @@
+package kr.co.yeogiga.application.notice.service;
+
+import kr.co.yeogiga.domain.notice.dto.NoticeDto;
+import kr.co.yeogiga.domain.notice.service.NoticeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeQueryService {
+    private final NoticeService noticeService;
+    
+    /**
+     * 특정 여행에 모든 공지를 조회하는 메서드
+     *
+     * @param tripId    여행 ID
+     * @param pageable  Pageable 객체
+     * @return          여행 공지 정보 페이지 객체
+     */
+    public Page<NoticeDto.Detail> getAllNotices(Long tripId, Pageable pageable) {
+        return noticeService.readAllNoticeDetailByTripId(tripId, pageable);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/notice/dto/NoticeDto.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/dto/NoticeDto.java
@@ -1,0 +1,16 @@
+package kr.co.yeogiga.domain.notice.dto;
+
+import java.time.LocalDateTime;
+
+public class NoticeDto {
+    
+    public record Detail(
+            Long id,
+            String title,
+            String description,
+            LocalDateTime createdAt,
+            Long authorId,
+            String nickname,
+            String imageUrl
+    ) { }
+}

--- a/src/main/java/kr/co/yeogiga/domain/notice/dto/NoticeDto.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/dto/NoticeDto.java
@@ -1,9 +1,12 @@
 package kr.co.yeogiga.domain.notice.dto;
 
+import lombok.Builder;
+
 import java.time.LocalDateTime;
 
 public class NoticeDto {
     
+    @Builder
     public record Detail(
             Long id,
             String title,

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepository.java
@@ -1,0 +1,9 @@
+package kr.co.yeogiga.domain.notice.repository;
+
+import kr.co.yeogiga.domain.notice.dto.NoticeDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomNoticeRepository {
+    Page<NoticeDto.Detail> findAllNoticeDetailByTripId(Long tripId, Pageable pageable);
+}

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepositoryImpl.java
@@ -1,0 +1,78 @@
+package kr.co.yeogiga.domain.notice.repository;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.co.yeogiga.domain.notice.dto.NoticeDto;
+import kr.co.yeogiga.domain.notice.entity.QNotice;
+import kr.co.yeogiga.domain.user.entity.QUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomNoticeRepositoryImpl implements CustomNoticeRepository{
+    private final JPAQueryFactory jpaQueryFactory;
+    
+    private final QNotice notice = QNotice.notice;
+    private final QUser user = QUser.user;
+    
+    
+    @Override
+    public Page<NoticeDto.Detail> findAllNoticeDetailByTripId(Long tripId, Pageable pageable) {
+        List<NoticeDto.Detail> noticeDetails = jpaQueryFactory.
+                select(
+                        Projections.constructor(
+                                NoticeDto.Detail.class,
+                                notice.id,
+                                notice.title,
+                                notice.description,
+                                notice.createdAt,
+                                user.id,
+                                user.nickname,
+                                user.imageUrl
+                        )
+                )
+                .from(notice)
+                .join(notice.author, user)
+                .where(notice.tripId.eq(tripId))
+                .orderBy(getOrderSpecifiers(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        
+        JPAQuery<Long> count = jpaQueryFactory
+                .select(notice.count())
+                .from(notice)
+                .where(notice.tripId.eq(tripId));
+        
+        return PageableExecutionUtils.getPage(noticeDetails, pageable, count::fetchOne);
+    }
+    
+    /**
+     * 공지사항(notice) 엔티티 동적 정렬 설정 메서드
+     * - Pageable 객체에 정렬값 미설정 시, 기본적으로 생성날짜 내림차순 정렬
+     *
+     * @param pageable  페이지네이션 객체
+     * @return          정렬 기준 객체 배열
+     */
+    private OrderSpecifier[] getOrderSpecifiers(Pageable pageable) {
+        if (pageable.getSort().isEmpty()) {
+            return new OrderSpecifier[]{new OrderSpecifier(Order.DESC, notice.createdAt)};
+        }
+        
+        return pageable.getSort().stream().map(sort -> {
+            Order order = sort.isAscending() ? Order.ASC : Order.DESC;
+            String property = sort.getProperty();
+            Path<Object> target = Expressions.path(Object.class, notice, property);
+            return new OrderSpecifier(order, target);
+        }).toArray(OrderSpecifier[]::new);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/NoticeRepository.java
@@ -3,5 +3,5 @@ package kr.co.yeogiga.domain.notice.repository;
 import kr.co.yeogiga.domain.notice.entity.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface NoticeRepository extends JpaRepository<Notice, Long> {
+public interface NoticeRepository extends JpaRepository<Notice, Long>, CustomNoticeRepository {
 }

--- a/src/main/java/kr/co/yeogiga/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/service/NoticeService.java
@@ -1,8 +1,11 @@
 package kr.co.yeogiga.domain.notice.service;
 
+import kr.co.yeogiga.domain.notice.dto.NoticeDto;
 import kr.co.yeogiga.domain.notice.entity.Notice;
 import kr.co.yeogiga.domain.notice.repository.NoticeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,5 +15,9 @@ public class NoticeService {
     
     public void save(Notice notice) {
         noticeRepository.save(notice);
+    }
+    
+    public Page<NoticeDto.Detail> readAllNoticeDetailByTripId(Long tripId, Pageable pageable) {
+        return noticeRepository.findAllNoticeDetailByTripId(tripId, pageable);
     }
 }

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/PageConfig.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/PageConfig.java
@@ -1,0 +1,11 @@
+package kr.co.yeogiga.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
+
+@Configuration
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
+public class PageConfig {
+}

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
@@ -12,7 +12,7 @@ import jakarta.validation.Valid;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
 import kr.co.yeogiga.application.auth.dto.SignUpDto;
 import kr.co.yeogiga.application.auth.type.Device;
-import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -143,5 +143,5 @@ public interface OAuthApi {
                     }))
 
     })
-    ResponseEntity<?> register(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody SignUpDto.Register request);
+    ResponseEntity<?> register(@AuthenticationPrincipal CustomUserDetailsImpl userDetails, @RequestBody SignUpDto.Register request);
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
@@ -6,7 +6,7 @@ import kr.co.yeogiga.application.auth.dto.SignUpDto;
 import kr.co.yeogiga.application.auth.service.OAuthManagementService;
 import kr.co.yeogiga.application.auth.type.Device;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
-import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.common.util.CookieUtil;
 import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
 import kr.co.yeogiga.presentation.auth.api.OAuthApi;
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.Duration;
+
 import static kr.co.yeogiga.application.auth.constant.AuthConstants.REFRESH_TOKEN_PREFIX;
 
 @RestController
@@ -43,7 +44,7 @@ public class OAuthController implements OAuthApi {
     @Override
     @PutMapping("/register")
     public ResponseEntity<?> register(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @Valid @RequestBody SignUpDto.Register request) {
         oAuthManagementService.register(userDetails.getUserId(), request);
         return ResponseEntity.ok(SuccessResponse.ok());

--- a/src/main/java/kr/co/yeogiga/presentation/calendar/api/CalendarApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/calendar/api/CalendarApi.java
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.co.yeogiga.application.calendar.dto.CalendarReq;
-import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -64,7 +64,7 @@ public interface CalendarApi {
                     }))
     })
     ResponseEntity<?> createCalendar(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
 
             @Parameter(description = "여행 ID")
             @PathVariable Long tripId,
@@ -102,7 +102,7 @@ public interface CalendarApi {
                     }))
     })
     ResponseEntity<?> getUserAvailability(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
 
             @Parameter(description = "여행 ID")
             @PathVariable Long tripId
@@ -179,7 +179,7 @@ public interface CalendarApi {
                     }))
     })
     ResponseEntity<?> updateAvailableDates(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
 
             @Parameter(description = "여행 ID")
             @PathVariable Long tripId,

--- a/src/main/java/kr/co/yeogiga/presentation/calendar/controller/CalendarController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/calendar/controller/CalendarController.java
@@ -5,7 +5,7 @@ import kr.co.yeogiga.application.calendar.dto.CalendarReq;
 import kr.co.yeogiga.application.calendar.service.CalendarCommandService;
 import kr.co.yeogiga.application.calendar.service.CalendarQueryService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
-import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.presentation.calendar.api.CalendarApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -29,7 +29,7 @@ public class CalendarController implements CalendarApi {
     @Override
     @PostMapping("/{tripId}/calendars")
     public ResponseEntity<?> createCalendar(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @PathVariable Long tripId,
             @Valid @RequestBody CalendarReq calendarReq
     ) {
@@ -40,7 +40,7 @@ public class CalendarController implements CalendarApi {
     @Override
     @GetMapping("/{tripId}/calendars/me")
     public ResponseEntity<?> getUserAvailability(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @PathVariable Long tripId
     ) {
         return ResponseEntity.ok(
@@ -65,7 +65,7 @@ public class CalendarController implements CalendarApi {
     @Override
     @PutMapping("/{tripId}/calendars")
     public ResponseEntity<?> updateAvailableDates(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @PathVariable Long tripId,
             @Valid @RequestBody CalendarReq calendarReq
     ) {

--- a/src/main/java/kr/co/yeogiga/presentation/notice/api/NoticeApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/notice/api/NoticeApi.java
@@ -5,14 +5,19 @@ import api.link.checker.annotation.ApiGroup;
 import api.link.checker.annotation.TrackApi;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.co.yeogiga.application.notice.dto.NoticeReq;
-import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -48,11 +53,67 @@ public interface NoticeApi {
                     }))
     })
     ResponseEntity<?> createNotice(
+            @PathVariable(name = "tripId") Long tripId,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            @Valid @RequestBody NoticeReq.Creation request
+    );
+    
+    @TrackApi(description = "전체 공지사항 조회")
+    @Operation(summary = "전체 공지사항 조회", description = "전체 공지사항 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "전체 공지사항 조회 성공. 기본 페이지 별 공지사항 갯수(size): 10",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                             {
+                                                  "code": 200,
+                                                  "message": "요청이 성공하였습니다.",
+                                                  "data": {
+                                                      "content": [
+                                                          {
+                                                              "id": 24,
+                                                              "title": "준비물 챙기세요.",
+                                                              "description": "수건, 양말...",
+                                                              "createdAt": "2025-07-27T11:56:34.546218",
+                                                              "authorId": 13,
+                                                              "nickname": "nick13",
+                                                              "imageUrl": "https://image.com/image.png"
+                                                          },
+                                                          {
+                                                              "id": 23,
+                                                              "title": "여행 전 주의사항",
+                                                              "description": "여행 전 해당 내용 인지하시길 바랍니다.",
+                                                              "createdAt": "2025-07-27T11:56:29.82594",
+                                                              "authorId": 13,
+                                                              "nickname": "nick13",
+                                                              "imageUrl": "https://image.com/image.png"
+                                                          },
+                                                          {
+                                                              "id": 22,
+                                                              "title": "여행 경비 안내",
+                                                              "description": "여행 경비는 인당...",
+                                                              "createdAt": "2025-07-27T11:56:27.579067",
+                                                              "authorId": 13,
+                                                              "nickname": "nick13",
+                                                              "imageUrl": "https://image.com/image.png"
+                                                          }
+                                                      ],
+                                                      "page": {
+                                                          "size": 10,
+                                                          "number": 0,
+                                                          "totalElements": 12,
+                                                          "totalPages": 4
+                                                      }
+                                                  }
+                                              }
+                                    """)
+                    }))
+    })
+    @Parameter(name = "page", description = "페이지네이션", example = "page=0&size=10&sort=createdAt,desc", schema = @Schema(type = "string"), in = ParameterIn.QUERY)
+    ResponseEntity<?> getNotices(
             @Parameter(description = "여행 ID")
             @PathVariable(name = "tripId") Long tripId,
             
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            
-            @Valid @RequestBody NoticeReq.Creation request
+            @Parameter(example = "page=0&size=10&sort=createdAt,desc", hidden = true)
+            @PageableDefault(size = 10) Pageable pageable
     );
 }

--- a/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
@@ -39,6 +39,7 @@ public class NoticeController implements NoticeApi {
                 .body(SuccessResponse.created());
     }
     
+    @Override
     @GetMapping("/{tripId}/notices")
     public ResponseEntity<?> getNotices(
             @PathVariable(name = "tripId") Long tripId,

--- a/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
@@ -3,13 +3,17 @@ package kr.co.yeogiga.presentation.notice.controller;
 import jakarta.validation.Valid;
 import kr.co.yeogiga.application.notice.dto.NoticeReq;
 import kr.co.yeogiga.application.notice.service.NoticeCommandService;
+import kr.co.yeogiga.application.notice.service.NoticeQueryService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.presentation.notice.api.NoticeApi;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/trip")
 public class NoticeController implements NoticeApi {
     private final NoticeCommandService noticeCommandService;
+    private final NoticeQueryService noticeQueryService;
     
     @Override
     @PostMapping("/{tripId}/notices")
@@ -32,5 +37,14 @@ public class NoticeController implements NoticeApi {
         noticeCommandService.createNotice(userDetails.getUserId(), tripId, request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(SuccessResponse.created());
+    }
+    
+    @GetMapping("/{tripId}/notices")
+    public ResponseEntity<?> getNotices(
+            @PathVariable(name = "tripId") Long tripId,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        return ResponseEntity.ok()
+                .body(SuccessResponse.from(noticeQueryService.getAllNotices(tripId, pageable)));
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
@@ -4,7 +4,7 @@ import jakarta.validation.Valid;
 import kr.co.yeogiga.application.notice.dto.NoticeReq;
 import kr.co.yeogiga.application.notice.service.NoticeCommandService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
-import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.presentation.notice.api.NoticeApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -26,7 +26,7 @@ public class NoticeController implements NoticeApi {
     @PostMapping("/{tripId}/notices")
     public ResponseEntity<?> createNotice(
             @PathVariable(name = "tripId") Long tripId,
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @Valid @RequestBody NoticeReq.Creation request
     ) {
         noticeCommandService.createNotice(userDetails.getUserId(), tripId, request);

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.co.yeogiga.application.trip.dto.TripReq;
-import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -101,7 +101,7 @@ public interface TripApi {
                     }))
     })
     ResponseEntity<?> getMainTrip(
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails
     );
 
     @TrackApi(description = "특정 여행 조회")
@@ -262,7 +262,7 @@ public interface TripApi {
                                     """)
                     }))
     })
-    ResponseEntity<?> getAllTrip(@AuthenticationPrincipal CustomUserDetails userDetails);
+    ResponseEntity<?> getAllTrip(@AuthenticationPrincipal CustomUserDetailsImpl userDetails);
 
     @TrackApi(description = "준비 중 여행 조회")
     @Operation(summary = "준비 중 여행 조회", description = "준비 중 여행 조회 API")
@@ -284,7 +284,7 @@ public interface TripApi {
                                     """)
                     }))
     })
-    ResponseEntity<?> getSettingTrip(@AuthenticationPrincipal CustomUserDetails userDetails);
+    ResponseEntity<?> getSettingTrip(@AuthenticationPrincipal CustomUserDetailsImpl userDetails);
 
     @TrackApi(description = "여행 생성")
     @Operation(summary = "여행 생성", description = "여행 생성 API")
@@ -322,7 +322,7 @@ public interface TripApi {
                     }))
     })
     ResponseEntity<?> createTrip(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @RequestBody TripReq.Creation request
     );
 
@@ -433,7 +433,7 @@ public interface TripApi {
                     })),
     })
     ResponseEntity<?> updateTripTime(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
 
             @Parameter(description = "여행 ID")
             @PathVariable Long tripId,

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripMemberApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripMemberApi.java
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -96,7 +96,7 @@ public interface TripMemberApi {
                     }))
     })
     ResponseEntity<?> joinTrip(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
 
             @Parameter(description = "여행 ID")
             @PathVariable Long tripId
@@ -131,7 +131,7 @@ public interface TripMemberApi {
                     }))
     })
     ResponseEntity<?> leaveTrip(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
 
             @Parameter(description = "여행 ID")
             @PathVariable Long tripId
@@ -169,7 +169,7 @@ public interface TripMemberApi {
                     }))
     })
     ResponseEntity<?> leaveTrip(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
 
             @Parameter(description = "여행 ID")
             @PathVariable Long tripId,

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
@@ -7,6 +7,7 @@ import kr.co.yeogiga.application.trip.service.TripCommandService;
 import kr.co.yeogiga.application.trip.service.TripQueryService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.presentation.trip.api.TripApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -34,7 +35,7 @@ public class TripController implements TripApi {
     @Override
     @GetMapping("/main")
     public ResponseEntity<?> getMainTrip(
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails
     ) {
         TripRes.TripMainInfo tripMainInfo = tripQueryService.getTripMainInfo(userDetails.getUserId());
         return ResponseEntity.ok().body(SuccessResponse.from(tripMainInfo));
@@ -49,14 +50,14 @@ public class TripController implements TripApi {
 
     @Override
     @GetMapping
-    public ResponseEntity<?> getAllTrip(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<?> getAllTrip(@AuthenticationPrincipal CustomUserDetailsImpl userDetails) {
         List<TripRes.TripSummary> tripList = tripQueryService.getAllTrip(userDetails.getUserId());
         return ResponseEntity.ok().body(SuccessResponse.from(tripList));
     }
 
     @Override
     @GetMapping("/setting")
-    public ResponseEntity<?> getSettingTrip(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<?> getSettingTrip(@AuthenticationPrincipal CustomUserDetailsImpl userDetails) {
         return ResponseEntity.ok()
                 .body(SuccessResponse.from(tripQueryService.getSettingTrip(userDetails.getUserId())));
     }
@@ -64,7 +65,7 @@ public class TripController implements TripApi {
     @Override
     @PostMapping
     public ResponseEntity<?> createTrip(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @Valid @RequestBody TripReq.Creation request
     ) {
         Long tripId = tripCommandService.create(userDetails.getUserId(), request);
@@ -84,7 +85,7 @@ public class TripController implements TripApi {
     @Override
     @PutMapping("/{tripId}/time")
     public ResponseEntity<?> updateTripTime(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @PathVariable Long tripId,
             @Valid @RequestBody TripReq.Time request
     ) {

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripMemberController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripMemberController.java
@@ -3,7 +3,7 @@ package kr.co.yeogiga.presentation.trip.controller;
 import kr.co.yeogiga.application.trip.service.TripMemberCommandService;
 import kr.co.yeogiga.application.trip.service.TripMemberQueryService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
-import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.presentation.trip.api.TripMemberApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -32,7 +32,7 @@ public class TripMemberController implements TripMemberApi {
     @Override
     @PostMapping("/{tripId}/members")
     public ResponseEntity<?> joinTrip(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @PathVariable Long tripId
     ) {
         tripMemberCommandService.joinTrip(tripId, userDetails.getUserId());
@@ -42,7 +42,7 @@ public class TripMemberController implements TripMemberApi {
     @Override
     @DeleteMapping("/{tripId}/members")
     public ResponseEntity<?> leaveTrip(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @PathVariable Long tripId
     ) {
         tripMemberCommandService.leaveTrip(tripId, userDetails.getUserId());
@@ -52,7 +52,7 @@ public class TripMemberController implements TripMemberApi {
     @Override
     @DeleteMapping("/{tripId}/members/{memberId}")
     public ResponseEntity<?> leaveTrip(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @PathVariable Long tripId,
             @PathVariable Long memberId
     ) {

--- a/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/api/UserApi.java
@@ -13,7 +13,7 @@ import jakarta.validation.Valid;
 import kr.co.yeogiga.application.user.dto.FcmTokenReq;
 import kr.co.yeogiga.application.user.dto.PasswordUpdateReq;
 import kr.co.yeogiga.application.user.dto.UserInfoUpdateReq;
-import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -74,7 +74,7 @@ public interface UserApi {
                     }))
     })
     ResponseEntity<?> updatePassword(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @Valid @RequestBody PasswordUpdateReq passwordUpdateReq
     );
 
@@ -110,7 +110,7 @@ public interface UserApi {
                     }))
     })
     ResponseEntity<?> withdraw(
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails
     );
 
     @TrackApi(description = "회원 정보 조회")
@@ -154,7 +154,7 @@ public interface UserApi {
                     }))
     })
     ResponseEntity<?> getUserInfo(
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails
     );
 
     @TrackApi(description = "회원 정보 수정")
@@ -186,7 +186,7 @@ public interface UserApi {
                     }))
     })
     ResponseEntity<?> update(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @Valid @RequestBody UserInfoUpdateReq userInfoUpdateReq
     );
 
@@ -213,7 +213,7 @@ public interface UserApi {
                     }))
     })
     ResponseEntity<?> updateProfile(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
 
             @Parameter(description = "업로드할 이미지")
             @RequestPart(name = "image") MultipartFile image
@@ -242,7 +242,7 @@ public interface UserApi {
                     }))
     })
     ResponseEntity<?> registerFcmToken(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @RequestBody FcmTokenReq fcmTokenReq
     );
 
@@ -269,6 +269,6 @@ public interface UserApi {
                     }))
     })
     ResponseEntity<?> deleteFcmToken(
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails
     );
 }

--- a/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/user/controller/UserController.java
@@ -8,7 +8,7 @@ import kr.co.yeogiga.application.user.dto.UserInfoUpdateReq;
 import kr.co.yeogiga.application.user.service.UserFcmTokenService;
 import kr.co.yeogiga.application.user.service.UserManagementService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
-import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.common.util.CookieUtil;
 import kr.co.yeogiga.presentation.user.api.UserApi;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +39,7 @@ public class UserController implements UserApi {
     @Override
     @PatchMapping("/password")
     public ResponseEntity<?> updatePassword(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @Valid @RequestBody PasswordUpdateReq passwordUpdateReq
     ) {
         userManagementService.updatePassword(userDetails.getUserId(), passwordUpdateReq);
@@ -49,7 +49,7 @@ public class UserController implements UserApi {
     @Override
     @DeleteMapping
     public ResponseEntity<?> withdraw(
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails
     ) {
         userManagementService.withdraw(userDetails.getUserId());
         return ResponseEntity.ok()
@@ -60,7 +60,7 @@ public class UserController implements UserApi {
     @Override
     @GetMapping("/my")
     public ResponseEntity<?> getUserInfo(
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails
     ) {
         return ResponseEntity.ok()
                 .body(SuccessResponse.from(userManagementService.getUserInfo(userDetails.getUserId())));
@@ -69,7 +69,7 @@ public class UserController implements UserApi {
     @Override
     @PutMapping
     public ResponseEntity<?> update(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @Valid @RequestBody UserInfoUpdateReq userInfoUpdateReq
     ) {
         userManagementService.updateUserInfo(userDetails.getUserId(), userInfoUpdateReq);
@@ -79,7 +79,7 @@ public class UserController implements UserApi {
     @Override
     @PutMapping("/profile")
     public ResponseEntity<?> updateProfile(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @RequestPart(name = "image") MultipartFile image
     ) {
         imageUploadProcessor.uploadProfileImage(image, userDetails.getUserId());
@@ -89,7 +89,7 @@ public class UserController implements UserApi {
     @Override
     @PostMapping("/fcm-token")
     public ResponseEntity<?> registerFcmToken(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @RequestBody FcmTokenReq fcmTokenReq
     ) {
         userFcmTokenService.registerFcmToken(userDetails.getUserId(), fcmTokenReq);
@@ -99,7 +99,7 @@ public class UserController implements UserApi {
     @Override
     @DeleteMapping("/fcm-token")
     public ResponseEntity<?> deleteFcmToken(
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails
     ) {
         userFcmTokenService.deleteFcmToken(userDetails.getUserId());
         return ResponseEntity.ok(SuccessResponse.ok());

--- a/src/test/java/kr/co/yeogiga/application/notice/service/NoticeQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/notice/service/NoticeQueryServiceTest.java
@@ -1,0 +1,63 @@
+package kr.co.yeogiga.application.notice.service;
+
+import kr.co.yeogiga.domain.notice.dto.NoticeDto;
+import kr.co.yeogiga.domain.notice.service.NoticeService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class NoticeQueryServiceTest {
+    
+    @Mock
+    private NoticeService noticeService;
+    
+    @InjectMocks
+    private NoticeQueryService noticeQueryService;
+    
+    @Nested
+    @DisplayName("전체 공지사항 조회")
+    class GetAllNotices {
+        private final Long noticeId = 1L;
+        private final Long userId = 2L;
+        private final Long tripId = 3L;
+        private Pageable pageable = PageRequest.of(0, 10);
+        private NoticeDto.Detail noticeDetail = NoticeDto.Detail.builder()
+                .id(noticeId)
+                .title("title")
+                .description("description")
+                .nickname("nickname")
+                .imageUrl("image")
+                .createdAt(LocalDateTime.of(2025, 7, 27, 16, 30))
+                .authorId(userId)
+                .build();
+        
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            when(noticeService.readAllNoticeDetailByTripId(tripId, pageable)).thenReturn(new PageImpl<>(List.of(noticeDetail)));
+            
+            // when
+            Page<NoticeDto.Detail> noticeDetails = noticeQueryService.getAllNotices(tripId, pageable);
+            
+            // then
+            assertThat(noticeDetails.getContent()).hasSize(1);
+            assertThat(noticeDetails.getContent().get(0)).usingRecursiveComparison().isEqualTo(noticeDetail);
+        }
+    }
+}

--- a/src/test/java/kr/co/yeogiga/presentation/notice/controller/NoticeControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/notice/controller/NoticeControllerTest.java
@@ -37,7 +37,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -69,6 +71,8 @@ public class NoticeControllerTest {
     void setUp(WebApplicationContext webApplicationContext) {
         this.mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .defaultRequest(post("/**").with(csrf()))
                 .alwaysDo(print())
                 .build();
         

--- a/src/test/java/kr/co/yeogiga/presentation/notice/controller/NoticeControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/notice/controller/NoticeControllerTest.java
@@ -3,9 +3,11 @@ package kr.co.yeogiga.presentation.notice.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.notice.dto.NoticeReq;
 import kr.co.yeogiga.application.notice.service.NoticeCommandService;
+import kr.co.yeogiga.application.notice.service.NoticeQueryService;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.domain.notice.dto.NoticeDto;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.type.Role;
 import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
@@ -18,6 +20,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
@@ -25,11 +30,16 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -51,6 +61,9 @@ public class NoticeControllerTest {
     
     @MockBean
     private NoticeCommandService noticeCommandService;
+    
+    @MockBean
+    private NoticeQueryService noticeQueryService;
     
     @BeforeEach
     void setUp(WebApplicationContext webApplicationContext) {
@@ -124,6 +137,43 @@ public class NoticeControllerTest {
                     .andExpect(jsonPath("$.errors.title").exists())
                     .andExpect(jsonPath("$.errors.description").exists());
             
+        }
+    }
+    
+    @Nested
+    @DisplayName("전체 공지사항 조회")
+    class getNotices {
+        private final Long noticeId = 1L;
+        private final Long userId = 2L;
+        private final Long tripId = 3L;
+        private Pageable pageable = PageRequest.of(0, 10);
+        private NoticeDto.Detail noticeDetail = NoticeDto.Detail.builder()
+                .id(noticeId)
+                .title("title")
+                .description("description")
+                .nickname("nickname")
+                .imageUrl("image")
+                .createdAt(LocalDateTime.of(2025, 7, 27, 16, 30))
+                .authorId(userId)
+                .build();
+        
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            when(noticeQueryService.getAllNotices(tripId, pageable)).thenReturn(new PageImpl<>(List.of(noticeDetail)));
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip/{tripId}/notices", tripId)
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content[0].id").value(noticeDetail.id()))
+                    .andExpect(jsonPath("$.data.content.length()").value(1));
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
@@ -45,9 +45,12 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -80,6 +83,9 @@ public class TripControllerTest {
     void setUp(WebApplicationContext webApplicationContext) {
         this.mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .defaultRequest(put("/**").with(csrf()))
+                .defaultRequest(delete("/**").with(csrf()))
                 .alwaysDo(print())
                 .build();
 
@@ -378,6 +384,7 @@ public class TripControllerTest {
             // when
             ResultActions resultActions = mockMvc.perform(
                     get("/api/v1/trip")
+                            .with(user(userDetails))
             );
 
             // then

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripMemberControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripMemberControllerTest.java
@@ -5,7 +5,6 @@ import kr.co.yeogiga.application.trip.service.TripMemberCommandService;
 import kr.co.yeogiga.application.trip.service.TripMemberQueryService;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
-import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
@@ -36,9 +35,12 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -61,12 +63,15 @@ public class TripMemberControllerTest {
     @MockBean
     private TripMemberQueryService tripMemberQueryService;
 
-    private CustomUserDetails userDetails;
+    private CustomUserDetailsImpl userDetails;
 
     @BeforeEach
     void setUp(WebApplicationContext webApplicationContext) {
         this.mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .defaultRequest(patch("/**").with(csrf()))
+                .defaultRequest(delete("/**").with(csrf()))
                 .alwaysDo(print())
                 .build();
 


### PR DESCRIPTION
## 배경
- 여행 내 전체 공지사항 조회 기능 필요

## 작업 사항
- 페이지네이션 응답 객체 Json 직렬화를 위한 설정 어노테이션 추가 | (5a559c6514b692fd834c2a58c3fb785fab57cde9)
	- `@EnableSpringDataWebSupport` 적용으로 인한 인터페이스 타입 파라미터 `CustomUserDetails` 값 바인딩 불가 오류로 인한 변경
		→ 해당 내용 맨 아래에 "**📌 CustomUserDetails 바인딩 문제**"로 별도로 남겨놓겠습니다.
<br/>

- 공지사항 조회 로직 구현 | (d3985301594d5729aa7243308521d72fb56afad0) (cfbc0076ee745501a4b44f160b24b06a68ca9e1e)
	- 페이지네이션 적용
	- QueryDsl의 `OrderSpecifiter`를 사용하여 동적 정렬이 가능하도록 구현하였습니다. 기본적으로는 공지사항 생성 날짜(createdAt) 기준으로 내림차순(Desc) 정렬되도록 하였습니다.
	- 반환값으로 `PageableExecutionUtils.getPage()`를 사용하였는데, 내부에서 `PageImpl` 객체를 반환하되 이를 한 번 더 추상화하여 전체 요소(totalElements)에 대한 카운트 쿼리를 보낼 필요가 없는 경우(첫 페이지 내에 모든 엔티티가 다 포함되는 경우 등)에는 카운트 쿼리를 보내지 않도록 한다고 합니다.
	- 커밋이 약간 잘못된 것 같네요.
<br/>

## 추가 논의
- 현재 QueryDsl의 Projection을 통해서 데이터를 원하는 형태의 dto로 바로 가져올 수 있다보니 NoticeQueryService 내에 아주 단순한 조회 로직만 있는 것 같습니다. 추가적으로 해당 사용자가 여행에 포함된 사용자인지 여부 등에 대한 확인 로직을 추가할 수는 있지만 다른 기능들에는 해당 검증 로직을 추가하지 않아 우선은 추가하지 않은 상태로 구현하였습니다. 검증 로직을 일괄적으로 추가하여야할지 아니면 NoticeQeuryService 내에 메서드 로직이 단순해도 크게 상관없을지 의견이 궁금합니다~


```java
    /**
     * 특정 여행에 모든 공지를 조회하는 메서드
     *
     * @param tripId    여행 ID
     * @param pageable  Pageable 객체
     * @return          여행 공지 정보 페이지 객체
     */
    public Page<NoticeDto.Detail> getAllNotices(Long tripId, Pageable pageable) {
        return noticeService.readAllNoticeDetailByTripId(tripId, pageable);
    }
```

## 📌 CustomUserDetails 바인딩 문제

우선, `UserDetails`는 Spring Security에서 제공하는 **AuthenticationPrincipalArgumentResolver**에 의해서 리졸브되어 파라미터가 바인딩됩니다. 또한, 해당 리졸버는 `WebMvcSecurityConfiguration`(WebMvcConfigurer 구현체)에 의해서 등록됩니다.

그런데, `@EnableSpringDataWebSupport`를 설정 하니  **AuthenticationPrincipalArgumentResolver**가 아닌 **ProxingHandlerMethodArgumentResolver**가 리졸버가 선택되어 `CustomUserDetails userDetails` 인자를 바인딩하게 됩니다. 이는 `WebMvcConfigurer` 구현체들이 등록되는 순서에 따라 ArgumentResolver의 순서가 달라지게 되어 그러는데 정확하게 `@EnableSpringDataWebSupport`를 사용하면 `WebMvcConfigurer`가 등록되는 순서가 왜 바뀌는지는 아직 모르겠습니다.

즉, `UserDetails`를 바인딩 할 때 <ins>잘못된 리졸버가 바인딩</ins>시키다보니 결국 null 값이 바인딩되어 `CustomUserDetails userDetails`를 인자로 사용하는 모든 컨트롤러  메서드에서 문제가 발생합니다.

**ProxingHandlerMethodArgumentResolver**는 spring-data-common에서 제공하는 리졸버이고, 역할은  `인터페이스로 되어있는 파라미터를 임의의 객체로 만들어서 바인딩`시켜줍니다. 왜 해당 리졸버가 존재하는지 알아보니 인터페이스를 사용하여 다형성을 지원하면서, 불필요한 DTO 객체가 많이 생기지 않도록 인터페이스만으로도 파라미터가 바인딩될 수 있도록 임의의 인스턴스를 만들어주기 위함이라고 합니다.

따라서, 파라미터를 인터페이스 `CustomUserDetails`가 아닌 구현체 `CustomUserDetailsImpl`로 타입을 바꿔주어야지 제대로 동작할 수 있게 됩니다. 따라서 `@AuthenticationPrincipla CustomUserDetails userDetails` 파라미터는 모두 변경하였습니다.

또한, 이를 적용한 뒤 컨틀롤러 테스트 코드 내 `springSecurity()` 를 설정하지 않으면 테스트 코드가 실패하는 문제가 있어 해당 설정 코드도 테스트 코드 내 적용시켰습니다.

해당 내용과 일치하지는 않지만 비슷하게 발생했던 상황을 예전에 [블로그 포스팅](https://hky035.github.io/web/mvc-security-test/)으로 작성한 적이 있어서 혹시나 해당 링크 첨부하겠습니다.