### PR TITLE
Refactor: Trip 엔티티 DTO 생성

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/trip/dto/TripRes.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/dto/TripRes.java
@@ -3,7 +3,6 @@ package kr.co.yeogiga.application.trip.dto;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
-import kr.co.yeogiga.domain.user.entity.User;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -28,31 +27,6 @@ public class TripRes {
                     .day(day)
                     .travelStatus(trip.getTravelStatus())
                     .places(places)
-                    .build();
-        }
-    }
-
-    @Builder
-    public record TripSummary(
-            Long tripId,
-            String title,
-            String city,
-            Long leaderId,
-            LocalDateTime startedAt,
-            LocalDateTime endedAt,
-            TravelStatus status,
-            List<TripMemberRes.MemberInfo> members
-    ) {
-        public static TripSummary from(Trip trip, List<TripMemberRes.MemberInfo> members) {
-            return TripSummary.builder()
-                    .tripId(trip.getId())
-                    .title(trip.getTitle())
-                    .city(trip.getCity())
-                    .leaderId(trip.getLeaderId())
-                    .startedAt(trip.getStartedAt())
-                    .endedAt(trip.getEndedAt())
-                    .status(trip.getTravelStatus())
-                    .members(members)
                     .build();
         }
     }

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
@@ -3,14 +3,13 @@ package kr.co.yeogiga.application.trip.service;
 import kr.co.yeogiga.application.trip.dto.TripRes;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
 import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.dto.TripDto;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.service.TripMemberService;
-import kr.co.yeogiga.domain.trip.service.TripService;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
-import kr.co.yeogiga.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +24,6 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class TripQueryService {
-    private final TripService tripService;
     private final TripMemberService tripMemberService;
     private final TripDayPlaceService tripDayPlaceService;
 
@@ -134,7 +132,7 @@ public class TripQueryService {
      * @return              사용자가 속한 여행 목록
      */
     @Transactional(readOnly = true)
-    public List<TripRes.TripSummary> getAllTrip(Long userId) {
+    public List<TripDto.Summary> getAllTrip(Long userId) {
         return tripMemberService.readAllTripSummaryByUserId(userId);
     }
 
@@ -145,7 +143,7 @@ public class TripQueryService {
      * @return              여행 정보
      */
     @Transactional(readOnly = true)
-    public TripRes.TripSummary getTrip(Long tripId) {
+    public TripDto.Summary getTrip(Long tripId) {
         return tripMemberService.readTripSummaryByTripId(tripId)
                 .orElseThrow(() -> new CustomException(TripErrorType.TRIP_NOT_FOUND));
     }

--- a/src/main/java/kr/co/yeogiga/domain/trip/dto/TripDto.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/dto/TripDto.java
@@ -1,0 +1,43 @@
+package kr.co.yeogiga.domain.trip.dto;
+
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.type.TravelStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class TripDto {
+    
+    @Builder
+    public record Summary(
+            Long tripId,
+            String title,
+            String city,
+            Long leaderId,
+            LocalDateTime startedAt,
+            LocalDateTime endedAt,
+            TravelStatus status,
+            List<MemberInfo> members
+    ) {
+        public static Summary from(Trip trip, List<MemberInfo> members) {
+            return Summary.builder()
+                    .tripId(trip.getId())
+                    .title(trip.getTitle())
+                    .city(trip.getCity())
+                    .leaderId(trip.getLeaderId())
+                    .startedAt(trip.getStartedAt())
+                    .endedAt(trip.getEndedAt())
+                    .status(trip.getTravelStatus())
+                    .members(members)
+                    .build();
+        }
+    }
+    
+    @Builder
+    public record MemberInfo(
+            Long userId,
+            String nickname,
+            String imageUrl
+    ) { }
+}

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepository.java
@@ -1,11 +1,11 @@
 package kr.co.yeogiga.domain.trip.repository;
 
-import kr.co.yeogiga.application.trip.dto.TripRes;
+import kr.co.yeogiga.domain.trip.dto.TripDto;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface CustomTripMemberRepository {
-    Optional<TripRes.TripSummary> findTripSummaryByTripId(Long tripId);
-    List<TripRes.TripSummary> findAllTripSummaryByUserId(Long userId);
+    Optional<TripDto.Summary> findTripSummaryByTripId(Long tripId);
+    List<TripDto.Summary> findAllTripSummaryByUserId(Long userId);
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepositoryImpl.java
@@ -3,8 +3,7 @@ package kr.co.yeogiga.domain.trip.repository;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import kr.co.yeogiga.application.trip.dto.TripMemberRes;
-import kr.co.yeogiga.application.trip.dto.TripRes;
+import kr.co.yeogiga.domain.trip.dto.TripDto;
 import kr.co.yeogiga.domain.trip.entity.QTrip;
 import kr.co.yeogiga.domain.trip.entity.QTripMember;
 import kr.co.yeogiga.domain.trip.entity.Trip;
@@ -27,7 +26,7 @@ public class CustomTripMemberRepositoryImpl implements CustomTripMemberRepositor
     private final QUser user = QUser.user;
     
     @Override
-    public Optional<TripRes.TripSummary> findTripSummaryByTripId(Long tripId) {
+    public Optional<TripDto.Summary> findTripSummaryByTripId(Long tripId) {
         Trip tripEntity = jpaQueryFactory
                 .select(trip)
                 .from(trip)
@@ -38,10 +37,10 @@ public class CustomTripMemberRepositoryImpl implements CustomTripMemberRepositor
             return Optional.empty();
         }
         
-        List<TripMemberRes.MemberInfo> members = jpaQueryFactory
+        List<TripDto.MemberInfo> members = jpaQueryFactory
                 .select(
                         Projections.constructor(
-                                TripMemberRes.MemberInfo.class,
+                                TripDto.MemberInfo.class,
                                 user.id,
                                 user.nickname,
                                 user.imageUrl
@@ -52,11 +51,11 @@ public class CustomTripMemberRepositoryImpl implements CustomTripMemberRepositor
                 .where(tripMember.trip.id.eq(tripId))
                 .fetch();
         
-        return Optional.of(TripRes.TripSummary.from(tripEntity, members));
+        return Optional.of(TripDto.Summary.from(tripEntity, members));
     }
     
     @Override
-    public List<TripRes.TripSummary> findAllTripSummaryByUserId(Long userId) {
+    public List<TripDto.Summary> findAllTripSummaryByUserId(Long userId) {
         List<Trip> tripList = jpaQueryFactory
                 .select(trip)
                 .from(tripMember)
@@ -87,10 +86,10 @@ public class CustomTripMemberRepositoryImpl implements CustomTripMemberRepositor
                 )
                 .fetch();
         
-        Map<Long, List<TripMemberRes.MemberInfo>> memberInfoMap = userList.stream()
+        Map<Long, List<TripDto.MemberInfo>> memberInfoMap = userList.stream()
                 .collect(Collectors.groupingBy(
                         tuple -> tuple.get(trip.id),
-                        Collectors.mapping(tuple -> TripMemberRes.MemberInfo.builder()
+                        Collectors.mapping(tuple -> TripDto.MemberInfo.builder()
                                 .userId(tuple.get(user.id))
                                 .nickname(tuple.get(user.nickname))
                                 .imageUrl(tuple.get(user.imageUrl))
@@ -99,7 +98,7 @@ public class CustomTripMemberRepositoryImpl implements CustomTripMemberRepositor
                 ));
         
         return tripList.stream()
-                .map(trip -> TripRes.TripSummary.from(
+                .map(trip -> TripDto.Summary.from(
                         trip,
                         memberInfoMap.getOrDefault(trip.getId(), List.of()))
                 ).toList();

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.domain.trip.service;
 
-import kr.co.yeogiga.application.trip.dto.TripRes;
+import kr.co.yeogiga.domain.trip.dto.TripDto;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.entity.TripMember;
 import kr.co.yeogiga.domain.trip.repository.TripMemberRepository;
@@ -24,11 +24,11 @@ public class TripMemberService {
         return tripMemberRepository.findAllTripByUserId(userId);
     }
     
-    public Optional<TripRes.TripSummary> readTripSummaryByTripId(Long tripId) {
+    public Optional<TripDto.Summary> readTripSummaryByTripId(Long tripId) {
         return tripMemberRepository.findTripSummaryByTripId(tripId);
     }
     
-    public List<TripRes.TripSummary> readAllTripSummaryByUserId(Long userId) {
+    public List<TripDto.Summary> readAllTripSummaryByUserId(Long userId) {
         return tripMemberRepository.findAllTripSummaryByUserId(userId);
     }
 

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
@@ -6,8 +6,8 @@ import kr.co.yeogiga.application.trip.dto.TripRes;
 import kr.co.yeogiga.application.trip.service.TripCommandService;
 import kr.co.yeogiga.application.trip.service.TripQueryService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
-import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
+import kr.co.yeogiga.domain.trip.dto.TripDto;
 import kr.co.yeogiga.presentation.trip.api.TripApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -51,7 +51,7 @@ public class TripController implements TripApi {
     @Override
     @GetMapping
     public ResponseEntity<?> getAllTrip(@AuthenticationPrincipal CustomUserDetailsImpl userDetails) {
-        List<TripRes.TripSummary> tripList = tripQueryService.getAllTrip(userDetails.getUserId());
+        List<TripDto.Summary> tripList = tripQueryService.getAllTrip(userDetails.getUserId());
         return ResponseEntity.ok().body(SuccessResponse.from(tripList));
     }
 

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
@@ -1,19 +1,16 @@
 package kr.co.yeogiga.application.trip.service;
 
-import kr.co.yeogiga.application.trip.dto.TripMemberRes;
 import kr.co.yeogiga.application.trip.dto.TripRes;
 import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.dto.TripDto;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.service.TripMemberService;
-import kr.co.yeogiga.domain.trip.service.TripService;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import kr.co.yeogiga.domain.tripplace.type.PlaceCategory;
-import kr.co.yeogiga.domain.user.entity.User;
-import kr.co.yeogiga.domain.user.type.Role;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -42,9 +39,6 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class TripQueryServiceTest {
-
-    @Mock
-    private TripService tripService;
 
     @Mock
     private TripMemberService tripMemberService;
@@ -213,15 +207,15 @@ public class TripQueryServiceTest {
     class GetAllTrip {
         private final Long userId = 1L;
 
-        private TripMemberRes.MemberInfo member = TripMemberRes.MemberInfo.builder()
+        private TripDto.MemberInfo member = TripDto.MemberInfo.builder()
                 .userId(userId)
                 .nickname("nickname")
                 .imageUrl("https://image.com")
                 .build();
         
-        private List<TripMemberRes.MemberInfo> members = List.of(member);
+        private List<TripDto.MemberInfo> members = List.of(member);
         
-        private TripRes.TripSummary tripSummary = TripRes.TripSummary.builder()
+        private TripDto.Summary tripSummary = TripDto.Summary.builder()
                 .tripId(1L)
                 .title("졸업여행")
                 .city("대구")
@@ -240,7 +234,7 @@ public class TripQueryServiceTest {
             when(tripMemberService.readAllTripSummaryByUserId(anyLong())).thenReturn(List.of(tripSummary));
 
             // when
-            List<TripRes.TripSummary> result = tripQueryService.getAllTrip(userId);
+            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId);
 
             // then
             assertThat(result).hasSize(1);
@@ -253,7 +247,7 @@ public class TripQueryServiceTest {
             when(tripMemberService.readAllTripSummaryByUserId(userId)).thenReturn(List.of());
 
             // when
-            List<TripRes.TripSummary> result = tripQueryService.getAllTrip(userId);
+            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId);
 
             // then
             assertThat(result).hasSize(0);
@@ -265,15 +259,15 @@ public class TripQueryServiceTest {
     class GetTrip {
         private final Long userId = 1L;
         
-        private TripMemberRes.MemberInfo member = TripMemberRes.MemberInfo.builder()
+        private TripDto.MemberInfo member = TripDto.MemberInfo.builder()
                 .userId(userId)
                 .nickname("nickname")
                 .imageUrl("https://image.com")
                 .build();
         
-        private List<TripMemberRes.MemberInfo> members = List.of(member);
+        private List<TripDto.MemberInfo> members = List.of(member);
         
-        private TripRes.TripSummary tripSummary = TripRes.TripSummary.builder()
+        private TripDto.Summary tripSummary = TripDto.Summary.builder()
                 .tripId(1L)
                 .title("졸업여행")
                 .city("대구")
@@ -291,7 +285,7 @@ public class TripQueryServiceTest {
             when(tripMemberService.readTripSummaryByTripId(1L)).thenReturn(Optional.of(tripSummary));
 
             // when
-            TripRes.TripSummary result = tripQueryService.getTrip(1L);
+            TripDto.Summary result = tripQueryService.getTrip(1L);
 
             // then
             assertEquals(tripSummary.tripId(), result.tripId());

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
@@ -1,7 +1,6 @@
 package kr.co.yeogiga.presentation.trip.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.co.yeogiga.application.trip.dto.TripMemberRes;
 import kr.co.yeogiga.application.trip.dto.TripReq;
 import kr.co.yeogiga.application.trip.dto.TripRes;
 import kr.co.yeogiga.application.trip.service.TripCommandService;
@@ -12,6 +11,7 @@ import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.domain.trip.dto.TripDto;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
@@ -50,7 +50,6 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -359,24 +358,21 @@ public class TripControllerTest {
     @Nested
     @DisplayName("사용자가 속한 여행 조회")
     class GetAllTrip {
-        private User user = User.builder()
-                .username("username")
-                .password("password")
-                .email("test@test.com")
-                .nickname("nickname")
-                .role(Role.USER)
-                .build();
         @Test
         @DisplayName("성공")
         void success() throws Exception {
             // given
-            TripRes.TripSummary tripSummary = TripRes.TripSummary.builder()
+            TripDto.Summary tripSummary = TripDto.Summary.builder()
                     .tripId(1L)
                     .title("title")
                     .startedAt(LocalDateTime.of(2025, 5, 19, 12, 0))
                     .endedAt(LocalDateTime.of(2025, 5, 20, 12, 0))
                     .status(TravelStatus.IN_PROGRESS)
-                    .members(List.of(TripMemberRes.MemberInfo.fromEntity(user)))
+                    .members(List.of(TripDto.MemberInfo.builder()
+                                    .userId(1L)
+                                    .nickname("nickname")
+                                    .imageUrl("https://imgee.com/image")
+                                    .build()))
                     .build();
 
             when(tripQueryService.getAllTrip(any())).thenReturn(List.of(tripSummary));
@@ -537,21 +533,17 @@ public class TripControllerTest {
                 .travelStatus(TravelStatus.IN_PROGRESS)
                 .build();
 
-        private User user = User.builder()
-                .username("username")
-                .password("password")
+        private TripDto.MemberInfo member = TripDto.MemberInfo.builder()
+                .userId(1L)
                 .nickname("nickname")
-                .email("test@test.com")
-                .role(Role.USER)
+                .imageUrl("https://image.com/image")
                 .build();
-        
-        private TripMemberRes.MemberInfo member = TripMemberRes.MemberInfo.fromEntity(user);
 
         @Test
         @DisplayName("성공")
         void success() throws Exception {
             // given
-            TripRes.TripSummary tripSummary = TripRes.TripSummary.from(trip, List.of(member));
+            TripDto.Summary tripSummary = TripDto.Summary.from(trip, List.of(member));
             when(tripQueryService.getTrip(tripId)).thenReturn(tripSummary);
 
             // when
@@ -564,7 +556,7 @@ public class TripControllerTest {
             resultActions
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.title").value(trip.getTitle()))
-                    .andExpect(jsonPath("$.data.members[0].nickname").value(user.getNickname()));
+                    .andExpect(jsonPath("$.data.members[0].nickname").value(member.nickname()));
         }
 
         @Test


### PR DESCRIPTION
## 배경
- QueryDsl의 Projection을 통해 조회하는 엔티티 dto를 application 레이어의 `TripRes.TripSummary`, `TripMemberRes.MemberInfo`를 사용하여 `domain` → `application` 레이어간 역의존성 수립 문제 식별

## 작업 사항
- domain 레이어 내 별도의 엔티티 dto `TripDto.Summary`, `TripDto.MemberInfo` 생성
- 그에 따른 코드 변경