### PR TITLE
Feature(IL-220): 공지사항 수정 기능 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/notice/service/NoticeCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/notice/service/NoticeCommandService.java
@@ -47,7 +47,7 @@ public class NoticeCommandService {
         Notice notice = noticeService.readByIdJoinUser(noticeId)
                 .orElseThrow(() -> new CustomException(NoticeErrorType.NOT_FOUND));
         
-        if (!userId.equals(notice.getAuthorId())) {
+        if (!notice.isAuthor(userId)) {
             throw new CustomException(NoticeErrorType.UNAUTHORIZED_AUTHOR);
         }
         

--- a/src/main/java/kr/co/yeogiga/application/notice/service/NoticeCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/notice/service/NoticeCommandService.java
@@ -47,7 +47,7 @@ public class NoticeCommandService {
         Notice notice = noticeService.readByIdJoinUser(noticeId)
                 .orElseThrow(() -> new CustomException(NoticeErrorType.NOT_FOUND));
         
-        if (!userId.equals(notice.getAuthor().getId())) {
+        if (!userId.equals(notice.getAuthorId())) {
             throw new CustomException(NoticeErrorType.UNAUTHORIZED_AUTHOR);
         }
         

--- a/src/main/java/kr/co/yeogiga/application/notice/service/NoticeCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/notice/service/NoticeCommandService.java
@@ -44,7 +44,7 @@ public class NoticeCommandService {
      */
     @Transactional
     public void updateNotice(Long noticeId, Long userId, NoticeReq.Creation dto) {
-        Notice notice = noticeService.readByIdJoinUser(noticeId)
+        Notice notice = noticeService.readById(noticeId)
                 .orElseThrow(() -> new CustomException(NoticeErrorType.NOT_FOUND));
         
         if (!notice.isAuthor(userId)) {

--- a/src/main/java/kr/co/yeogiga/application/notice/service/NoticeCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/notice/service/NoticeCommandService.java
@@ -1,11 +1,14 @@
 package kr.co.yeogiga.application.notice.service;
 
 import kr.co.yeogiga.application.notice.dto.NoticeReq;
+import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.notice.entity.Notice;
+import kr.co.yeogiga.domain.notice.exception.NoticeErrorType;
 import kr.co.yeogiga.domain.notice.service.NoticeService;
 import kr.co.yeogiga.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,5 +31,26 @@ public class NoticeCommandService {
                 .build();
         
         noticeService.save(notice);
+    }
+    
+    /**
+     * 여행 공지사항을 수정하는 메서드
+     *
+     * @param noticeId  공지사항 ID
+     * @param userId    사용자 ID
+     * @param dto       공자사항 요청 DTO
+     *
+     * @throws CustomException  NoticeErrorType.UNAUTHORIZED_AUTHOR - 공지사항 작성자가 아닌 경우
+     */
+    @Transactional
+    public void updateNotice(Long noticeId, Long userId, NoticeReq.Creation dto) {
+        Notice notice = noticeService.readByIdJoinUser(noticeId)
+                .orElseThrow(() -> new CustomException(NoticeErrorType.NOT_FOUND));
+        
+        if (!userId.equals(notice.getAuthor().getId())) {
+            throw new CustomException(NoticeErrorType.UNAUTHORIZED_AUTHOR);
+        }
+        
+        notice.update(dto.title(), dto.description());
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/notice/entity/Notice.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/entity/Notice.java
@@ -38,6 +38,9 @@ public class Notice extends BaseTimeEntity {
     @JoinColumn(name = "author_id")
     private User author;
     
+    @Column(name = "author_id", insertable = false, updatable = false)
+    private Long authorId;
+    
     @Column(columnDefinition = "TEXT", nullable = false)
     private String description;
     

--- a/src/main/java/kr/co/yeogiga/domain/notice/entity/Notice.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/entity/Notice.java
@@ -59,4 +59,8 @@ public class Notice extends BaseTimeEntity {
         this.title = title;
         this.description = description;
     }
+    
+    public boolean isAuthor(Long userId) {
+        return this.author != null && this.authorId.equals(userId);
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/notice/entity/Notice.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/entity/Notice.java
@@ -51,4 +51,9 @@ public class Notice extends BaseTimeEntity {
         this.description = description;
         this.tripId = tripId;
     }
+    
+    public void update(String title, String description) {
+        this.title = title;
+        this.description = description;
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/notice/exception/NoticeErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/exception/NoticeErrorType.java
@@ -1,0 +1,31 @@
+package kr.co.yeogiga.domain.notice.exception;
+
+import kr.co.yeogiga.common.response.error.type.BaseErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum NoticeErrorType implements BaseErrorType {
+    NOT_FOUND(HttpStatus.NOT_FOUND, "N000", "존재하지 않는 공지사항입니다."),
+    UNAUTHORIZED_AUTHOR(HttpStatus.FORBIDDEN, "N001", "공지사항의 작성자가 아닙니다.")
+    ;
+    
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+    
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+    
+    @Override
+    public String getCode() {
+        return code;
+    }
+    
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepository.java
@@ -1,13 +1,9 @@
 package kr.co.yeogiga.domain.notice.repository;
 
 import kr.co.yeogiga.domain.notice.dto.NoticeDto;
-import kr.co.yeogiga.domain.notice.entity.Notice;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.Optional;
-
 public interface CustomNoticeRepository {
     Page<NoticeDto.Detail> findAllNoticeDetailByTripId(Long tripId, Pageable pageable);
-    Optional<Notice> findByIdJoinUser(Long id);
 }

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepository.java
@@ -1,9 +1,13 @@
 package kr.co.yeogiga.domain.notice.repository;
 
 import kr.co.yeogiga.domain.notice.dto.NoticeDto;
+import kr.co.yeogiga.domain.notice.entity.Notice;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Optional;
+
 public interface CustomNoticeRepository {
     Page<NoticeDto.Detail> findAllNoticeDetailByTripId(Long tripId, Pageable pageable);
+    Optional<Notice> findByIdJoinUser(Long id);
 }

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepositoryImpl.java
@@ -8,6 +8,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.co.yeogiga.domain.notice.dto.NoticeDto;
+import kr.co.yeogiga.domain.notice.entity.Notice;
 import kr.co.yeogiga.domain.notice.entity.QNotice;
 import kr.co.yeogiga.domain.user.entity.QUser;
 import lombok.RequiredArgsConstructor;
@@ -16,14 +17,26 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
-public class CustomNoticeRepositoryImpl implements CustomNoticeRepository{
+public class CustomNoticeRepositoryImpl implements CustomNoticeRepository {
     private final JPAQueryFactory jpaQueryFactory;
     
     private final QNotice notice = QNotice.notice;
     private final QUser user = QUser.user;
     
+    @Override
+    public Optional<Notice> findByIdJoinUser(Long id) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .select(notice)
+                        .from(notice)
+                        .join(notice.author, user)
+                        .where(notice.id.eq(id))
+                        .fetchFirst()
+        );
+    }
     
     @Override
     public Page<NoticeDto.Detail> findAllNoticeDetailByTripId(Long tripId, Pageable pageable) {

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepositoryImpl.java
@@ -32,7 +32,6 @@ public class CustomNoticeRepositoryImpl implements CustomNoticeRepository {
                 jpaQueryFactory
                         .select(notice)
                         .from(notice)
-                        .join(notice.author, user)
                         .where(notice.id.eq(id))
                         .fetchFirst()
         );

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepositoryImpl.java
@@ -8,7 +8,6 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.co.yeogiga.domain.notice.dto.NoticeDto;
-import kr.co.yeogiga.domain.notice.entity.Notice;
 import kr.co.yeogiga.domain.notice.entity.QNotice;
 import kr.co.yeogiga.domain.user.entity.QUser;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +16,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
-import java.util.Optional;
 
 @RequiredArgsConstructor
 public class CustomNoticeRepositoryImpl implements CustomNoticeRepository {
@@ -25,17 +23,6 @@ public class CustomNoticeRepositoryImpl implements CustomNoticeRepository {
     
     private final QNotice notice = QNotice.notice;
     private final QUser user = QUser.user;
-    
-    @Override
-    public Optional<Notice> findByIdJoinUser(Long id) {
-        return Optional.ofNullable(
-                jpaQueryFactory
-                        .select(notice)
-                        .from(notice)
-                        .where(notice.id.eq(id))
-                        .fetchFirst()
-        );
-    }
     
     @Override
     public Page<NoticeDto.Detail> findAllNoticeDetailByTripId(Long tripId, Pageable pageable) {

--- a/src/main/java/kr/co/yeogiga/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/service/NoticeService.java
@@ -8,6 +8,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class NoticeService {
@@ -15,6 +17,10 @@ public class NoticeService {
     
     public void save(Notice notice) {
         noticeRepository.save(notice);
+    }
+    
+    public Optional<Notice> readByIdJoinUser(Long id) {
+        return noticeRepository.findByIdJoinUser(id);
     }
     
     public Page<NoticeDto.Detail> readAllNoticeDetailByTripId(Long tripId, Pageable pageable) {

--- a/src/main/java/kr/co/yeogiga/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/service/NoticeService.java
@@ -19,8 +19,8 @@ public class NoticeService {
         noticeRepository.save(notice);
     }
     
-    public Optional<Notice> readByIdJoinUser(Long id) {
-        return noticeRepository.findByIdJoinUser(id);
+    public Optional<Notice> readById(Long id) {
+        return noticeRepository.findById(id);
     }
     
     public Page<NoticeDto.Detail> readAllNoticeDetailByTripId(Long tripId, Pageable pageable) {

--- a/src/main/java/kr/co/yeogiga/presentation/notice/api/NoticeApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/notice/api/NoticeApi.java
@@ -116,4 +116,53 @@ public interface NoticeApi {
             @Parameter(example = "page=0&size=10&sort=createdAt,desc", hidden = true)
             @PageableDefault(size = 10) Pageable pageable
     );
+    
+    @TrackApi(description = "공지사항 수정")
+    @Operation(summary = "공지사항 수정", description = "공지사항 수정 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "공지사항 수정 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                             {
+                                                  "code": 200,
+                                                  "message": "요청이 성공하였습니다."
+                                              }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "공지사항 수정 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "유효성 검증 실패", value = """
+                                             {
+                                                   "code": "G002",
+                                                   "errors": {
+                                                       "description": "내용은 필수 입력값입니다.",
+                                                       "title": "제목은 필수 입력값입니다."
+                                                   }
+                                               }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "공지사항 수정 실패 - 공지사항의 작성자가 아닌 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "공지사항 작성자가 아닌 경우", value = """
+                                             {
+                                                    "code": "N001",
+                                                    "message": "공지사항의 작성자가 아닙니다."
+                                                }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "공지사항 수정 실패 - 존재하지 않는 공지사항",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "공지사항이 존재하지 않는 경우", value = """
+                                             {
+                                                     "code": "N000",
+                                                     "message": "존재하지 않는 공지사항입니다."
+                                                 }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> updateNotice(
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            @PathVariable(name = "noticeId") Long noticeId,
+            @Valid @RequestBody NoticeReq.Creation request
+    );
 }

--- a/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
@@ -50,6 +50,7 @@ public class NoticeController implements NoticeApi {
                 .body(SuccessResponse.from(noticeQueryService.getAllNotices(tripId, pageable)));
     }
     
+    @Override
     @PutMapping("/{tripId}/notices/{noticeId}")
     public ResponseEntity<?> updateNotice(
             @AuthenticationPrincipal CustomUserDetailsImpl userDetails,

--- a/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
@@ -16,6 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -47,5 +48,15 @@ public class NoticeController implements NoticeApi {
     ) {
         return ResponseEntity.ok()
                 .body(SuccessResponse.from(noticeQueryService.getAllNotices(tripId, pageable)));
+    }
+    
+    @PutMapping("/{tripId}/notices/{noticeId}")
+    public ResponseEntity<?> updateNotice(
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            @PathVariable(name = "noticeId") Long noticeId,
+            @Valid @RequestBody NoticeReq.Creation request
+    ) {
+        noticeCommandService.updateNotice(noticeId, userDetails.getUserId(), request);
+        return ResponseEntity.ok(SuccessResponse.ok());
     }
 }

--- a/src/test/java/kr/co/yeogiga/application/notice/service/NoticeCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/notice/service/NoticeCommandServiceTest.java
@@ -7,6 +7,7 @@ import kr.co.yeogiga.domain.notice.exception.NoticeErrorType;
 import kr.co.yeogiga.domain.notice.service.NoticeService;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.type.Role;
+import org.aspectj.util.Reflection;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -120,6 +121,7 @@ public class NoticeCommandServiceTest {
         @DisplayName("실패 - 작성자가 아닌 경우")
         void failUnauthorizedAuthor() {
             // given
+            ReflectionTestUtils.setField(notice, "authorId", 1L);
             when(noticeService.readByIdJoinUser(anyLong())).thenReturn(Optional.of(notice));
             
             // when

--- a/src/test/java/kr/co/yeogiga/application/notice/service/NoticeCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/notice/service/NoticeCommandServiceTest.java
@@ -1,8 +1,12 @@
 package kr.co.yeogiga.application.notice.service;
 
 import kr.co.yeogiga.application.notice.dto.NoticeReq;
+import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.notice.entity.Notice;
+import kr.co.yeogiga.domain.notice.exception.NoticeErrorType;
 import kr.co.yeogiga.domain.notice.service.NoticeService;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.type.Role;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -11,12 +15,17 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class NoticeCommandServiceTest {
@@ -56,4 +65,67 @@ public class NoticeCommandServiceTest {
         }
     }
     
+    @Nested
+    @DisplayName("공지사항 수정")
+    class UpdateNotice {
+        User user = User.builder()
+                .id(1L)
+                .nickname("nickname")
+                .role(Role.USER)
+                .build();
+        
+        Notice notice = Notice.builder()
+                .tripId(2L)
+                .title("title")
+                .description("description")
+                .author(user)
+                .build();
+        
+        NoticeReq.Creation dto = NoticeReq.Creation.builder()
+                .title("new title")
+                .description("new description")
+                .build();
+        
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            when(noticeService.readByIdJoinUser(2L)).thenReturn(Optional.of(notice));
+            
+            // when
+            noticeCommandService.updateNotice(2L, 1L, dto);
+            
+            // when
+            assertEquals(dto.title(), notice.getTitle());
+            assertEquals(dto.description(), notice.getDescription());
+        }
+        
+        @Test
+        @DisplayName("실패 - 존재하지 않는 공지사항")
+        void failIfNoticeNotFound() {
+            // given
+            when(noticeService.readByIdJoinUser(anyLong())).thenReturn(Optional.empty());
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> noticeCommandService.updateNotice(2L, 1L, dto));
+            
+            // then
+            assertEquals(NoticeErrorType.NOT_FOUND, exception.getErrorType());
+        }
+        
+        @Test
+        @DisplayName("실패 - 작성자가 아닌 경우")
+        void failUnauthorizedAuthor() {
+            // given
+            when(noticeService.readByIdJoinUser(anyLong())).thenReturn(Optional.of(notice));
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> noticeCommandService.updateNotice(2L, 3L, dto));
+            
+            // then
+            assertEquals(NoticeErrorType.UNAUTHORIZED_AUTHOR, exception.getErrorType());
+        }
+    }
 }

--- a/src/test/java/kr/co/yeogiga/application/notice/service/NoticeCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/notice/service/NoticeCommandServiceTest.java
@@ -7,7 +7,6 @@ import kr.co.yeogiga.domain.notice.exception.NoticeErrorType;
 import kr.co.yeogiga.domain.notice.service.NoticeService;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.type.Role;
-import org.aspectj.util.Reflection;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -93,7 +92,7 @@ public class NoticeCommandServiceTest {
         void success() {
             // given
             ReflectionTestUtils.setField(notice, "authorId", 1L);
-            when(noticeService.readByIdJoinUser(2L)).thenReturn(Optional.of(notice));
+            when(noticeService.readById(2L)).thenReturn(Optional.of(notice));
             
             // when
             noticeCommandService.updateNotice(2L, 1L, dto);
@@ -107,7 +106,7 @@ public class NoticeCommandServiceTest {
         @DisplayName("실패 - 존재하지 않는 공지사항")
         void failIfNoticeNotFound() {
             // given
-            when(noticeService.readByIdJoinUser(anyLong())).thenReturn(Optional.empty());
+            when(noticeService.readById(anyLong())).thenReturn(Optional.empty());
             
             // when
             CustomException exception = assertThrows(CustomException.class, ()
@@ -122,7 +121,7 @@ public class NoticeCommandServiceTest {
         void failUnauthorizedAuthor() {
             // given
             ReflectionTestUtils.setField(notice, "authorId", 1L);
-            when(noticeService.readByIdJoinUser(anyLong())).thenReturn(Optional.of(notice));
+            when(noticeService.readById(anyLong())).thenReturn(Optional.of(notice));
             
             // when
             CustomException exception = assertThrows(CustomException.class, ()

--- a/src/test/java/kr/co/yeogiga/application/notice/service/NoticeCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/notice/service/NoticeCommandServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
@@ -90,6 +91,7 @@ public class NoticeCommandServiceTest {
         @DisplayName("성공")
         void success() {
             // given
+            ReflectionTestUtils.setField(notice, "authorId", 1L);
             when(noticeService.readByIdJoinUser(2L)).thenReturn(Optional.of(notice));
             
             // when

--- a/src/test/java/kr/co/yeogiga/presentation/notice/controller/NoticeControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/notice/controller/NoticeControllerTest.java
@@ -4,10 +4,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.notice.dto.NoticeReq;
 import kr.co.yeogiga.application.notice.service.NoticeCommandService;
 import kr.co.yeogiga.application.notice.service.NoticeQueryService;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.common.response.error.type.CommonErrorType;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
 import kr.co.yeogiga.domain.notice.dto.NoticeDto;
+import kr.co.yeogiga.domain.notice.exception.NoticeErrorType;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.type.Role;
 import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
@@ -35,13 +39,16 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -178,6 +185,104 @@ public class NoticeControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.content[0].id").value(noticeDetail.id()))
                     .andExpect(jsonPath("$.data.content.length()").value(1));
+        }
+    }
+    
+    @Nested
+    @DisplayName("공지사항 수정")
+    class UpdateNotice {
+        
+        private NoticeReq.Creation request = NoticeReq.Creation.builder()
+                .title("new title")
+                .description("new description")
+                .build();
+        
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            doNothing().when(noticeCommandService).updateNotice(eq(1L), eq(1L), any(NoticeReq.Creation.class));
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    put("/api/v1/trip/{tripId}/notices/{noticeId}", 2L, 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
+        
+        @Test
+        @DisplayName("실패 - 작성자가 아닌 경우")
+        void failUnauthorizedAuthor() throws Exception {
+            // given
+            doThrow(new CustomException(NoticeErrorType.UNAUTHORIZED_AUTHOR))
+                    .when(noticeCommandService).updateNotice(eq(1L), eq(1L), any(NoticeReq.Creation.class));
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    put("/api/v1/trip/{tripId}/notices/{noticeId}", 2L, 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.message").value(NoticeErrorType.UNAUTHORIZED_AUTHOR.getMessage()));
+        }
+        
+        @Test
+        @DisplayName("실패 - 공지사항이 존재하지 않는 경우")
+        void failIfNoticeNotFound() throws Exception {
+            // given
+            doThrow(new CustomException(NoticeErrorType.NOT_FOUND))
+                    .when(noticeCommandService).updateNotice(eq(1L), eq(1L), any(NoticeReq.Creation.class));
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    put("/api/v1/trip/{tripId}/notices/{noticeId}", 2L, 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(NoticeErrorType.NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.message").value(NoticeErrorType.NOT_FOUND.getMessage()));
+        }
+        
+        @Test
+        @DisplayName("실패 - 유효성 검증 실패")
+        void failValidation() throws Exception {
+            // given
+            NoticeReq.Creation request = NoticeReq.Creation.builder()
+                    .title(" ")
+                    .description(" ")
+                    .build();
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    put("/api/v1/trip/{tripId}/notices/{noticeId}", 2L, 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(CommonErrorType.VALIDATION_ERROR.getCode()))
+                    .andExpect(jsonPath("$.errors.title").exists())
+                    .andExpect(jsonPath("$.errors.description").exists());
         }
     }
 }


### PR DESCRIPTION
## 배경
- 공지사항 수정 기능 필요

## 작업 사항
- 공지사항 조회 도메인 로직 구현 | (210b8b93848147f7dc1579027b32814f1456c98b)
	- 지연 로딩 방지를 위한 join을 통한 조회
<br/>

- 공지사항 수정 로직 구현 | (40a1485a25376f3a1162edecf31e0bb15b380fab)

## 추가 논의
- 공지사항 수정 api 엔드포인트에서 tripId가 사용되지는 않지만 REST API에 정리한 양식에 따르는게 맞는 것 같아 일관된 주소로 작성하였습니다.