### PR TITLE
Feature(IL-222): 공지사항 삭제 기능 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/notice/service/NoticeCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/notice/service/NoticeCommandService.java
@@ -53,4 +53,24 @@ public class NoticeCommandService {
         
         notice.update(dto.title(), dto.description());
     }
+    
+    /**
+     * 여행 공지사항을 삭제하는 메서드
+     *
+     * @param noticeId  공지사항 ID
+     * @param userId    사용자 ID
+     *
+     * @throws CustomException  NoticeErrorType.UNAUTHORIZED_AUTHOR - 공지사항 작성자가 아닌 경우
+     */
+    @Transactional
+    public void deleteNotice(Long noticeId, Long userId) {
+        Long authorId = noticeService.readAuthorIdById(noticeId)
+                .orElseThrow(() -> new CustomException(NoticeErrorType.NOT_FOUND));
+        
+        if (!authorId.equals(userId)) {
+            throw new CustomException(NoticeErrorType.UNAUTHORIZED_AUTHOR);
+        }
+        
+        noticeService.deleteById(noticeId);
+    }
 }

--- a/src/main/java/kr/co/yeogiga/application/notice/service/NoticeCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/notice/service/NoticeCommandService.java
@@ -64,13 +64,13 @@ public class NoticeCommandService {
      */
     @Transactional
     public void deleteNotice(Long noticeId, Long userId) {
-        Long authorId = noticeService.readAuthorIdById(noticeId)
+        Notice notice = noticeService.readById(noticeId)
                 .orElseThrow(() -> new CustomException(NoticeErrorType.NOT_FOUND));
         
-        if (!authorId.equals(userId)) {
+        if (!notice.isAuthor(userId)) {
             throw new CustomException(NoticeErrorType.UNAUTHORIZED_AUTHOR);
         }
         
-        noticeService.deleteById(noticeId);
+        noticeService.delete(notice);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/notice/entity/Notice.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/entity/Notice.java
@@ -18,7 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Entity
+@Entity(name = "notice")
 @Table(
         name = "notice",
         indexes = {

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepository.java
@@ -4,6 +4,9 @@ import kr.co.yeogiga.domain.notice.dto.NoticeDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Optional;
+
 public interface CustomNoticeRepository {
+    Optional<Long> findAuthorIdById(Long id);
     Page<NoticeDto.Detail> findAllNoticeDetailByTripId(Long tripId, Pageable pageable);
 }

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepositoryImpl.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class CustomNoticeRepositoryImpl implements CustomNoticeRepository {
@@ -23,6 +24,17 @@ public class CustomNoticeRepositoryImpl implements CustomNoticeRepository {
     
     private final QNotice notice = QNotice.notice;
     private final QUser user = QUser.user;
+    
+    @Override
+    public Optional<Long> findAuthorIdById(Long id) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .select(notice.authorId)
+                        .from(notice)
+                        .where(notice.id.eq(id))
+                        .fetchFirst()
+        );
+    }
     
     @Override
     public Page<NoticeDto.Detail> findAllNoticeDetailByTripId(Long tripId, Pageable pageable) {

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/NoticeRepository.java
@@ -3,5 +3,8 @@ package kr.co.yeogiga.domain.notice.repository;
 import kr.co.yeogiga.domain.notice.entity.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface NoticeRepository extends JpaRepository<Notice, Long>, CustomNoticeRepository {
+    Optional<Long> findAuthorIdById(Long id);
 }

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/NoticeRepository.java
@@ -2,6 +2,12 @@ package kr.co.yeogiga.domain.notice.repository;
 
 import kr.co.yeogiga.domain.notice.entity.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long>, CustomNoticeRepository {
+    
+    @Modifying
+    @Query("DELETE FROM notice n WHERE n.id = :id")
+    void deleteById(Long id);
 }

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/NoticeRepository.java
@@ -3,8 +3,5 @@ package kr.co.yeogiga.domain.notice.repository;
 import kr.co.yeogiga.domain.notice.entity.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface NoticeRepository extends JpaRepository<Notice, Long>, CustomNoticeRepository {
-    Optional<Long> findAuthorIdById(Long id);
 }

--- a/src/main/java/kr/co/yeogiga/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/service/NoticeService.java
@@ -34,4 +34,8 @@ public class NoticeService {
     public void deleteById(Long id) {
         noticeRepository.deleteById(id);
     }
+    
+    public void delete(Notice notice) {
+        noticeRepository.delete(notice);
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/service/NoticeService.java
@@ -23,7 +23,15 @@ public class NoticeService {
         return noticeRepository.findById(id);
     }
     
+    public Optional<Long> readAuthorIdById(Long id) {
+        return noticeRepository.findAuthorIdById(id);
+    }
+    
     public Page<NoticeDto.Detail> readAllNoticeDetailByTripId(Long tripId, Pageable pageable) {
         return noticeRepository.findAllNoticeDetailByTripId(tripId, pageable);
+    }
+    
+    public void deleteById(Long id) {
+        noticeRepository.deleteById(id);
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/notice/api/NoticeApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/notice/api/NoticeApi.java
@@ -165,4 +165,40 @@ public interface NoticeApi {
             @PathVariable(name = "noticeId") Long noticeId,
             @Valid @RequestBody NoticeReq.Creation request
     );
+    
+    @TrackApi(description = "공지사항 삭제")
+    @Operation(summary = "공지사항 삭제", description = "공지사항 삭제 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "공지사항 삭제 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                             {
+                                                  "code": 200,
+                                                  "message": "요청이 성공하였습니다."
+                                              }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "공지사항 삭제 실패 - 공지사항의 작성자가 아닌 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "공지사항 작성자가 아닌 경우", value = """
+                                             {
+                                                    "code": "N001",
+                                                    "message": "공지사항의 작성자가 아닙니다."
+                                                }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "공지사항 삭제 실패 - 존재하지 않는 공지사항",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "공지사항이 존재하지 않는 경우", value = """
+                                             {
+                                                     "code": "N000",
+                                                     "message": "존재하지 않는 공지사항입니다."
+                                                 }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> deleteNotice(
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            @PathVariable(name = "noticeId") Long noticeId
+    );
 }

--- a/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
@@ -62,6 +62,7 @@ public class NoticeController implements NoticeApi {
         return ResponseEntity.ok(SuccessResponse.ok());
     }
     
+    @Override
     @DeleteMapping("/{tripId}/notices/{noticeId}")
     public ResponseEntity<?> deleteNotice(
             @AuthenticationPrincipal CustomUserDetailsImpl userDetails,

--- a/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
@@ -13,6 +13,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -58,6 +59,15 @@ public class NoticeController implements NoticeApi {
             @Valid @RequestBody NoticeReq.Creation request
     ) {
         noticeCommandService.updateNotice(noticeId, userDetails.getUserId(), request);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+    
+    @DeleteMapping("/{tripId}/notices/{noticeId}")
+    public ResponseEntity<?> deleteNotice(
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            @PathVariable(name = "noticeId") Long noticeId
+    ) {
+        noticeCommandService.deleteNotice(noticeId, userDetails.getUserId());
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 }

--- a/src/test/java/kr/co/yeogiga/application/notice/service/NoticeCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/notice/service/NoticeCommandServiceTest.java
@@ -7,6 +7,7 @@ import kr.co.yeogiga.domain.notice.exception.NoticeErrorType;
 import kr.co.yeogiga.domain.notice.service.NoticeService;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.type.Role;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -137,26 +138,41 @@ public class NoticeCommandServiceTest {
     @DisplayName("공지사항 삭제")
     class DeleteNotice {
         private final Long noticeId = 1L;
-        private final Long authorId = 2L;
+        
+        private User user = User.builder()
+                .id(2L)
+                .nickname("nickname")
+                .build();
+        
+        private Notice notice = Notice.builder()
+                .title("title")
+                .description("description")
+                .author(user)
+                .build();
+        
+        @BeforeEach
+        void setUp() {
+            ReflectionTestUtils.setField(notice, "authorId", 2L);
+        }
         
         @Test
         @DisplayName("성공")
         void success() {
             // given
-            when(noticeService.readAuthorIdById(noticeId)).thenReturn(Optional.of(authorId));
+            when(noticeService.readById(noticeId)).thenReturn(Optional.of(notice));
             
             // when
             noticeCommandService.deleteNotice(1L, 2L);
             
             // then
-            verify(noticeService, times(1)).deleteById(eq(noticeId));
+            verify(noticeService, times(1)).delete(eq(notice));
         }
         
         @Test
         @DisplayName("실패 - 존재하지 않는 공지사항")
         void failIfNoticeNotFound() {
             // given
-            when(noticeService.readAuthorIdById(noticeId)).thenReturn(Optional.empty());
+            when(noticeService.readById(noticeId)).thenReturn(Optional.empty());
             
             // when
             CustomException exception = assertThrows(CustomException.class, ()
@@ -170,7 +186,7 @@ public class NoticeCommandServiceTest {
         @DisplayName("실패 - 작성자가 아닌 경우")
         void failIfUnauthorizedAuthor() {
             // given
-            when(noticeService.readAuthorIdById(noticeId)).thenReturn(Optional.of(authorId));
+            when(noticeService.readById(noticeId)).thenReturn(Optional.of(notice));
             
             // when
             CustomException exception = assertThrows(CustomException.class, ()

--- a/src/test/java/kr/co/yeogiga/application/notice/service/NoticeCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/notice/service/NoticeCommandServiceTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.assertArg;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -126,6 +127,54 @@ public class NoticeCommandServiceTest {
             // when
             CustomException exception = assertThrows(CustomException.class, ()
                     -> noticeCommandService.updateNotice(2L, 3L, dto));
+            
+            // then
+            assertEquals(NoticeErrorType.UNAUTHORIZED_AUTHOR, exception.getErrorType());
+        }
+    }
+    
+    @Nested
+    @DisplayName("공지사항 삭제")
+    class DeleteNotice {
+        private final Long noticeId = 1L;
+        private final Long authorId = 2L;
+        
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            when(noticeService.readAuthorIdById(noticeId)).thenReturn(Optional.of(authorId));
+            
+            // when
+            noticeCommandService.deleteNotice(1L, 2L);
+            
+            // then
+            verify(noticeService, times(1)).deleteById(eq(noticeId));
+        }
+        
+        @Test
+        @DisplayName("실패 - 존재하지 않는 공지사항")
+        void failIfNoticeNotFound() {
+            // given
+            when(noticeService.readAuthorIdById(noticeId)).thenReturn(Optional.empty());
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> noticeCommandService.deleteNotice(1L, 2L));
+            
+            // then
+            assertEquals(NoticeErrorType.NOT_FOUND, exception.getErrorType());
+        }
+        
+        @Test
+        @DisplayName("실패 - 작성자가 아닌 경우")
+        void failIfUnauthorizedAuthor() {
+            // given
+            when(noticeService.readAuthorIdById(noticeId)).thenReturn(Optional.of(authorId));
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> noticeCommandService.deleteNotice(1L, 3L));
             
             // then
             assertEquals(NoticeErrorType.UNAUTHORIZED_AUTHOR, exception.getErrorType());

--- a/src/test/java/kr/co/yeogiga/presentation/notice/controller/NoticeControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/notice/controller/NoticeControllerTest.java
@@ -49,6 +49,7 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -283,6 +284,71 @@ public class NoticeControllerTest {
                     .andExpect(jsonPath("$.code").value(CommonErrorType.VALIDATION_ERROR.getCode()))
                     .andExpect(jsonPath("$.errors.title").exists())
                     .andExpect(jsonPath("$.errors.description").exists());
+        }
+    }
+    
+    @Nested
+    @DisplayName("공지사항 삭제")
+    class DeleteNotice {
+        private final Long noticeId = 1L;
+        
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            doNothing().when(noticeCommandService).deleteNotice(noticeId, userDetails.getUserId());
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    delete("/api/v1/trip/{tripId}/notices/{noticeId}", 1L, noticeId)
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
+        
+        @Test
+        @DisplayName("실패 - 존재하지 않는 공지사항")
+        void failIfNoticeNotFound() throws Exception {
+            // given
+            doThrow(new CustomException(NoticeErrorType.NOT_FOUND)).when(noticeCommandService)
+                    .deleteNotice(noticeId, userDetails.getUserId());
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    delete("/api/v1/trip/{tripId}/notices/{noticeId}", 1L, noticeId)
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(NoticeErrorType.NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.message").value(NoticeErrorType.NOT_FOUND.getMessage()));
+        }
+        
+        @Test
+        @DisplayName("실패 - 공지사항 작성자가 아닌 경우")
+        void failIfUnauthorizedAuthor() throws Exception {
+            // given
+            doThrow(new CustomException(NoticeErrorType.UNAUTHORIZED_AUTHOR)).when(noticeCommandService)
+                    .deleteNotice(noticeId, userDetails.getUserId());
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    delete("/api/v1/trip/{tripId}/notices/{noticeId}", 1L, noticeId)
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value(NoticeErrorType.UNAUTHORIZED_AUTHOR.getCode()))
+                    .andExpect(jsonPath("$.message").value(NoticeErrorType.UNAUTHORIZED_AUTHOR.getMessage()));
+            
         }
     }
 }


### PR DESCRIPTION
## 배경
- 여행 내 공지사항 삭제 기능 필요

## 작업 사항
- 공지사항 삭제 로직 구현 | (b5949df33ca69491f53d52aed53619e563a382b3) (4946155494458f2bc5a7293269b071f8326dfa35)
	- #97 에서 `Notice.isAuthor() 편의 메서드를 재사용하는 방법도 생각했었지만, 삭제 시에는 id 필드만 필요하다고 생각하여 해당 id에 맞는 공지사항의 작성자 id(authorId)만 들고오도록 조회 쿼리를 설계하였습니다.
	- 해당 조회 쿼리는 QueryDsl로 작성하였습니다 | (319b387c1a18db17d474d3191e0ad5a5cffd78ff)