### PR TITLE
Feature(IL-230): 게스트 사용자 회원가입(닉네임 설정) api 응답값 변경

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -74,7 +74,7 @@ public class OAuthManagementService {
      * @param request       회원 등록 요청 dto (nickname)
      */
     @Transactional
-    public void register(Long userId, SignUpDto.Register request) {
+    public TokenDto register(Long userId, SignUpDto.Register request) {
         User user = userService.readById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
 
@@ -84,6 +84,8 @@ public class OAuthManagementService {
 
         user.updateNickname(request.nickname());
         user.upgradeRoleToUser();
+        
+        return jwtService.generateToken(user.getNickname(), user.getId(), LoginType.SOCIAL);
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/user/service/UserManagementService.java
@@ -98,7 +98,7 @@ public class UserManagementService {
         User user = userService.readById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
 
-        if (user.getNickname().equals(nickname)) {
+        if (user.isSameNickname(nickname)) {
             throw new CustomException(UserErrorType.SAME_NICKNAME);
         }
 

--- a/src/main/java/kr/co/yeogiga/common/util/TokenResponseUtil.java
+++ b/src/main/java/kr/co/yeogiga/common/util/TokenResponseUtil.java
@@ -1,0 +1,36 @@
+package kr.co.yeogiga.common.util;
+
+import com.google.common.net.HttpHeaders;
+import kr.co.yeogiga.application.auth.dto.TokenDto;
+import kr.co.yeogiga.application.auth.type.Device;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static kr.co.yeogiga.application.auth.constant.AuthConstants.REFRESH_TOKEN_PREFIX;
+
+public class TokenResponseUtil {
+    
+    /**
+     * 사용자 접속 디바이스 별 HTTP 응답 객체 생성 유틸 메서드
+     *
+     * @param device    사용자 디바이스 종류(WEB, MOBILE)
+     * @param token     토큰(accessToken, refreshToken)
+     * @return          MOBILE  -> accessToken(body), refreshToken(body)
+     *                  WEB     -> accessToken(body), refreshToken(Cookie)
+     */
+    public static ResponseEntity<?> createTokenResponse(Device device, TokenDto token) {
+        return switch(device) {
+            case MOBILE -> ResponseEntity.ok(SuccessResponse.from(token));
+            case WEB -> ResponseEntity.ok()
+                    .header(HttpHeaders.SET_COOKIE, CookieUtil.createCookie(
+                            REFRESH_TOKEN_PREFIX,
+                            token.refreshToken(),
+                            Duration.ofDays(7).toSeconds()).toString()
+                    )
+                    .body(SuccessResponse.from(Map.of("accessToken", token.accessToken())));
+        };
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -97,4 +97,8 @@ public class User extends BaseTimeEntity {
     public void updateProfileImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
     }
+    
+    public boolean isSameNickname(String nickname) {
+        return this.nickname.equals(nickname);
+    }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
@@ -142,12 +142,27 @@ public interface OAuthApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "회원 등록 성공",
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name = "회원 등록 성공", value = """
+                            @ExampleObject(name = "웹 장치 이용자", description = "웹은 리프레시 토큰이 쿠키(refreshToken)으로 전달", value = """
                                         {
                                              "code": 200,
-                                             "message": "요청이 성공하였습니다."
+                                             "message": "요청이 성공하였습니다.",
+                                             "data": {
+                                                 "token": {
+                                                     "accessToken": "xxxxx.xxxxx.xxxxx"
+                                                 }
+                                             }
                                          }
                                     """),
+                            @ExampleObject(name = "모바일 장치 이용자", value = """
+                                        {
+                                              "code": 200,
+                                              "message": "요청이 성공하였습니다.",
+                                              "data": {
+                                                  "accessToken": "xxx.xxx.xxx",
+                                                  "refreshToken": "xxx.xxx.xxx"
+                                              }
+                                          }
+                                    """)
                     })),
             @ApiResponse(responseCode = "400", description = "유효성 검증 실패",
                     content = @Content(mediaType = "application/json", examples = {

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
@@ -19,6 +19,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @ApiGroup(value = "[OAuth2 인증 API]")
 @Tag(name = "[OAuth2 인증 API]", description = "OAuth2 인증 관련 API")
@@ -179,5 +180,11 @@ public interface OAuthApi {
                     }))
 
     })
-    ResponseEntity<?> register(@AuthenticationPrincipal CustomUserDetailsImpl userDetails, @RequestBody SignUpDto.Register request);
+    ResponseEntity<?> register(
+            @Parameter(description = "클라이언트 장치", example = "MOBILE, WEB")
+            @RequestHeader(name = "device") Device device,
+            
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            
+            @RequestBody SignUpDto.Register request);
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
@@ -9,6 +9,7 @@ import kr.co.yeogiga.application.auth.type.Device;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.util.CookieUtil;
+import kr.co.yeogiga.common.util.TokenResponseUtil;
 import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
 import kr.co.yeogiga.presentation.auth.api.AuthApi;
 import lombok.RequiredArgsConstructor;
@@ -23,9 +24,6 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.time.Duration;
-import java.util.Map;
 
 import static kr.co.yeogiga.application.auth.constant.AuthConstants.REFRESH_TOKEN_PREFIX;
 
@@ -49,7 +47,7 @@ public class AuthController implements AuthApi {
             @Valid @RequestBody SignInDto.Request request
     ) {
         TokenDto token = authService.signIn(request);
-        return createTokenResponse(device, token);
+        return TokenResponseUtil.createTokenResponse(device, token);
     }
 
     @Override
@@ -65,8 +63,8 @@ public class AuthController implements AuthApi {
         }
 
         return switch (device) {
-            case MOBILE -> createTokenResponse(device, authService.reissueToken(refreshTokenInHeader));
-            case WEB -> createTokenResponse(device, authService.reissueToken(refreshTokenInCookie));
+            case MOBILE -> TokenResponseUtil.createTokenResponse(device, authService.reissueToken(refreshTokenInHeader));
+            case WEB -> TokenResponseUtil.createTokenResponse(device, authService.reissueToken(refreshTokenInCookie));
         };
     }
 
@@ -106,25 +104,5 @@ public class AuthController implements AuthApi {
                 .code(HttpStatus.OK.value())
                 .message("사용 가능한 닉네임입니다.")
                 .build());
-    }
-
-    /**
-     * 토큰 응답 생성 메서드
-     *
-     * @param device            사용자 장치(WEB, MOBILE)
-     * @param token             토큰(accessToken, refreshToken)
-     * @return                  MOBILE -> accessToken(body), refreshToken(body)
-     *                          WEB    -> accessToken(body), refreshToken(cookie)
-     */
-    private ResponseEntity<?> createTokenResponse(Device device, TokenDto token) {
-        return switch (device) {
-            case MOBILE -> ResponseEntity.ok(SuccessResponse.from(token));
-            case WEB -> ResponseEntity.ok()
-                    .header(HttpHeaders.SET_COOKIE, CookieUtil.createCookie(
-                            REFRESH_TOKEN_PREFIX,
-                            token.refreshToken(),
-                            Duration.ofDays(7).toSeconds()).toString()
-                    ).body(SuccessResponse.from(Map.of("accessToken", token.accessToken())));
-        };
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/OAuthController.java
@@ -3,10 +3,13 @@ package kr.co.yeogiga.presentation.auth.controller;
 import jakarta.validation.Valid;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
 import kr.co.yeogiga.application.auth.dto.SignUpDto;
+import kr.co.yeogiga.application.auth.dto.TokenDto;
 import kr.co.yeogiga.application.auth.service.OAuthManagementService;
+import kr.co.yeogiga.application.auth.type.Device;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.common.util.CookieUtil;
+import kr.co.yeogiga.common.util.TokenResponseUtil;
 import kr.co.yeogiga.domain.oauth.type.OAuthPlatform;
 import kr.co.yeogiga.presentation.auth.api.OAuthApi;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +20,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -60,10 +64,12 @@ public class OAuthController implements OAuthApi {
     @Override
     @PutMapping("/register")
     public ResponseEntity<?> register(
+            @RequestHeader(name = "device") Device device,
             @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @Valid @RequestBody SignUpDto.Register request) {
-        oAuthManagementService.register(userDetails.getUserId(), request);
-        return ResponseEntity.ok(SuccessResponse.ok());
+        TokenDto token = oAuthManagementService.register(userDetails.getUserId(), request);
+        
+        return TokenResponseUtil.createTokenResponse(device, token);
     }
 }
 

--- a/src/test/java/kr/co/yeogiga/application/user/service/UserManagementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/user/service/UserManagementServiceTest.java
@@ -229,8 +229,10 @@ public class UserManagementServiceTest {
     class UpdateUserInfo {
         private final Long userId = 1L;
 
-        @Mock
-        private User user;
+        private User user = User.builder()
+            .id(userId)
+            .nickname("nickname")
+            .build();
 
         private UserInfoUpdateReq userInfoUpdateReq = UserInfoUpdateReq.builder()
                 .nickname("newNickname")
@@ -240,15 +242,14 @@ public class UserManagementServiceTest {
         @DisplayName("성공")
         void success() {
             // given
-            when(user.getNickname()).thenReturn("nickname");
-            when(userService.existsIncludeDeletedByNickname(eq("newNickname"))).thenReturn(false);
             when(userService.readById(eq(userId))).thenReturn(Optional.of(user));
+            when(userService.existsIncludeDeletedByNickname(eq("newNickname"))).thenReturn(false);
 
             // when
             userManagementService.updateUserInfo(userId, userInfoUpdateReq);
 
             // then
-            verify(user).updateNickname("newNickname");
+            assertEquals(userInfoUpdateReq.nickname(), user.getNickname());
 
         }
 
@@ -256,7 +257,6 @@ public class UserManagementServiceTest {
         @DisplayName("실패 - 이미 사용 중인 닉네임")
         void failAlreadyUsedNickname() {
             // given
-            when(user.getNickname()).thenReturn("nickname");
             when(userService.readById(userId)).thenReturn(Optional.of(user));
             when(userService.existsIncludeDeletedByNickname("newNickname")).thenReturn(true);
 
@@ -272,12 +272,15 @@ public class UserManagementServiceTest {
         @DisplayName("실패 - 기존과 동일한 닉네임")
         void failSameNickname() {
             // given
-            when(user.getNickname()).thenReturn("newNickname");
+            UserInfoUpdateReq sameUserInfoUpdateReq = UserInfoUpdateReq.builder()
+                    .nickname("nickname")
+                    .build();
+            
             when(userService.readById(eq(userId))).thenReturn(Optional.of(user));
 
             // when
             CustomException exception = assertThrows(CustomException.class,
-                    () -> userManagementService.updateUserInfo(userId, userInfoUpdateReq));
+                    () -> userManagementService.updateUserInfo(userId, sameUserInfoUpdateReq));
 
             // then
             assertEquals(UserErrorType.SAME_NICKNAME, exception.getErrorType());

--- a/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthSecurityControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthSecurityControllerTest.java
@@ -2,8 +2,8 @@ package kr.co.yeogiga.presentation.oauth.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.auth.dto.SignUpDto;
+import kr.co.yeogiga.application.auth.dto.TokenDto;
 import kr.co.yeogiga.application.auth.service.OAuthManagementService;
-import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
@@ -30,11 +30,13 @@ import org.springframework.web.context.WebApplicationContext;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -79,6 +81,11 @@ public class OAuthSecurityControllerTest {
                 .build();
 
         private CustomUserDetails userDetails;
+        
+        private TokenDto token = TokenDto.builder()
+                .accessToken("accessToken.xxx.xxx")
+                .refreshToken("refreshToken.xxx.xxx")
+                .build();
 
         @BeforeEach
         void setUp() {
@@ -88,13 +95,15 @@ public class OAuthSecurityControllerTest {
         }
 
         @Test
-        @DisplayName("성공")
-        void success() throws Exception {
+        @DisplayName("성공 - 웹")
+        void successWeb() throws Exception {
             // given
             SignUpDto.Register request = new SignUpDto.Register("newNick");
+            when(oAuthManagementService.register(userDetails.getUserId(), request)).thenReturn(token);
 
             // when
             ResultActions resultActions = mockMvc.perform(put("/api/v1/oauth/register")
+                    .header("device", "WEB")
                     .with(user(userDetails))
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsBytes(request))
@@ -103,8 +112,37 @@ public class OAuthSecurityControllerTest {
             // then
             resultActions
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+                    .andExpect(cookie().value("refreshToken", token.refreshToken()))
+                    .andExpect(jsonPath("$.data.accessToken").value(token.accessToken()))
+                    .andExpect(jsonPath("$.data.refreshToken").doesNotExist());
+                    
 
+            verify(oAuthManagementService, times(1)).register(any(), any());
+        }
+        
+        @Test
+        @DisplayName("성공 - 모바일")
+        void successMobile() throws Exception {
+            // given
+            SignUpDto.Register request = new SignUpDto.Register("newNick");
+            when(oAuthManagementService.register(userDetails.getUserId(), request)).thenReturn(token);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(put("/api/v1/oauth/register")
+                    .header("device", "MOBILE")
+                    .with(user(userDetails))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(request))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(cookie().doesNotExist("refreshToken"))
+                    .andExpect(jsonPath("$.data.accessToken").value(token.accessToken()))
+                    .andExpect(jsonPath("$.data.refreshToken").value(token.refreshToken()));
+            
+            
             verify(oAuthManagementService, times(1)).register(any(), any());
         }
 
@@ -117,6 +155,7 @@ public class OAuthSecurityControllerTest {
             // when
             ResultActions resultActions = mockMvc.perform(
                     put("/api/v1/oauth/register")
+                            .header("device", "WEB")
                             .with(user(userDetails))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsBytes(request))


### PR DESCRIPTION
## 배경
- OAuth 소셜 로그인 후 게스트 사용자 회원가입(닉네임 설정) 시 api 응답값 변경 요청: `단순 성공 응답` → `jwt 토큰`

## 작업 사항
- 게스트 사용자 회원가입(닉네임 설정) api 응답값 변경 | 로직 (b04e1b7b1bf354fb24bb4d83c98a1a686674f796) / api(7b7d897bd4c78a40f885897fc177be805f6370f4)
	- 사용자 디바이스 별 별도 리프레시 토큰 쿠키 포함 여부 차이에 따른 http 응답값 생성 메서드 중복 코드 발생 ⇒ 유틸 클래스 분리 | (7b7d897bd4c78a40f885897fc177be805f6370f4)
<br/>

- 사용자 엔티티 내 닉네임 일치 여부 확인 메서드 정의 및 적용 | (801fb41bc8c1ab816efc66d29becd0dcf304f137)
	- #97 에서 대영님께서 추천해주신 엔티티나 편의 메서드를 적용시키면 좋은 부분이 있다고 생각하여, 사용자 정보 업데이트(`UserManagementService.updateUserInfo()`) 로직 내 코드 변경하였습니다.


## 추가사항
- 병합 후 프론트엔드 인원에게 api 변동사항 확인 요청하도록 하겠습니다.