### PR TITLE
Feature(IL-231): 특정 공지사항 조회 기능 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/notice/service/NoticeQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/notice/service/NoticeQueryService.java
@@ -1,6 +1,8 @@
 package kr.co.yeogiga.application.notice.service;
 
+import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.notice.dto.NoticeDto;
+import kr.co.yeogiga.domain.notice.exception.NoticeErrorType;
 import kr.co.yeogiga.domain.notice.service.NoticeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -21,5 +23,17 @@ public class NoticeQueryService {
      */
     public Page<NoticeDto.Detail> getAllNotices(Long tripId, Pageable pageable) {
         return noticeService.readAllNoticeDetailByTripId(tripId, pageable);
+    }
+    
+    /**
+     * 특정 여행을 조회하는 메서드
+     *
+     * @param noticeId  공지사항 ID
+     * @return          공지사항 정보
+     */
+    public NoticeDto.Detail getNotice(Long noticeId) {
+        return noticeService.readJoinUserById(noticeId)
+                .map(NoticeDto.Detail::fromEntity)
+                .orElseThrow(() -> new CustomException(NoticeErrorType.NOT_FOUND));
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/notice/dto/NoticeDto.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/dto/NoticeDto.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.domain.notice.dto;
 
+import kr.co.yeogiga.domain.notice.entity.Notice;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -15,5 +16,17 @@ public class NoticeDto {
             Long authorId,
             String nickname,
             String imageUrl
-    ) { }
+    ) {
+        public static Detail fromEntity(Notice notice) {
+            return Detail.builder()
+                    .id(notice.getId())
+                    .title(notice.getTitle())
+                    .description(notice.getDescription())
+                    .createdAt(notice.getCreatedAt())
+                    .authorId(notice.getAuthorId())
+                    .nickname(notice.getAuthor().getNickname())
+                    .imageUrl(notice.getAuthor().getImageUrl())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 
 public interface CustomNoticeRepository {
     Optional<Long> findAuthorIdById(Long id);
-    Optional<Notice> findNoticeJoinUser(Long id);
+    Optional<Notice> findNoticeJoinUserById(Long id);
     Page<NoticeDto.Detail> findAllNoticeDetailByTripId(Long tripId, Pageable pageable);
 }

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepository.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.domain.notice.repository;
 
 import kr.co.yeogiga.domain.notice.dto.NoticeDto;
+import kr.co.yeogiga.domain.notice.entity.Notice;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -8,5 +9,6 @@ import java.util.Optional;
 
 public interface CustomNoticeRepository {
     Optional<Long> findAuthorIdById(Long id);
+    Optional<Notice> findNoticeJoinUser(Long id);
     Page<NoticeDto.Detail> findAllNoticeDetailByTripId(Long tripId, Pageable pageable);
 }

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepositoryImpl.java
@@ -38,7 +38,7 @@ public class CustomNoticeRepositoryImpl implements CustomNoticeRepository {
     }
     
     @Override
-    public Optional<Notice> findNoticeJoinUser(Long id) {
+    public Optional<Notice> findNoticeJoinUserById(Long id) {
         return Optional.ofNullable(
                 jpaQueryFactory
                         .selectFrom(notice)

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepositoryImpl.java
@@ -42,7 +42,7 @@ public class CustomNoticeRepositoryImpl implements CustomNoticeRepository {
         return Optional.ofNullable(
                 jpaQueryFactory
                         .selectFrom(notice)
-                        .join(notice.author, user)
+                        .join(notice.author, user).fetchJoin()
                         .where(notice.id.eq(id))
                         .fetchFirst()
         );

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepositoryImpl.java
@@ -8,6 +8,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.co.yeogiga.domain.notice.dto.NoticeDto;
+import kr.co.yeogiga.domain.notice.entity.Notice;
 import kr.co.yeogiga.domain.notice.entity.QNotice;
 import kr.co.yeogiga.domain.user.entity.QUser;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,17 @@ public class CustomNoticeRepositoryImpl implements CustomNoticeRepository {
                 jpaQueryFactory
                         .select(notice.authorId)
                         .from(notice)
+                        .where(notice.id.eq(id))
+                        .fetchFirst()
+        );
+    }
+    
+    @Override
+    public Optional<Notice> findNoticeJoinUser(Long id) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .selectFrom(notice)
+                        .join(notice.author, user)
                         .where(notice.id.eq(id))
                         .fetchFirst()
         );

--- a/src/main/java/kr/co/yeogiga/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/service/NoticeService.java
@@ -23,6 +23,10 @@ public class NoticeService {
         return noticeRepository.findById(id);
     }
     
+    public Optional<Notice> readJoinUserById(Long id) {
+        return noticeRepository.findNoticeJoinUser(id);
+    }
+    
     public Optional<Long> readAuthorIdById(Long id) {
         return noticeRepository.findAuthorIdById(id);
     }

--- a/src/main/java/kr/co/yeogiga/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/service/NoticeService.java
@@ -24,7 +24,7 @@ public class NoticeService {
     }
     
     public Optional<Notice> readJoinUserById(Long id) {
-        return noticeRepository.findNoticeJoinUser(id);
+        return noticeRepository.findNoticeJoinUserById(id);
     }
     
     public Optional<Long> readAuthorIdById(Long id) {

--- a/src/main/java/kr/co/yeogiga/presentation/notice/api/NoticeApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/notice/api/NoticeApi.java
@@ -117,6 +117,42 @@ public interface NoticeApi {
             @PageableDefault(size = 10) Pageable pageable
     );
     
+    @TrackApi(description = "특정 공지사항 조회")
+    @Operation(summary = "특정 공지사항 조회", description = "특정 공지사항 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "특정 공지사항 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                             {
+                                                   "code": 200,
+                                                   "message": "요청이 성공하였습니다.",
+                                                   "data": {
+                                                       "id": 22,
+                                                       "title": "중요 공지입니다.",
+                                                       "description": "설명입니다.",
+                                                       "createdAt": "2025-07-27T11:56:27.579067",
+                                                       "authorId": 13,
+                                                       "nickname": "nick",
+                                                       "imageUrl": "https://image.com/image"
+                                                   }
+                                               }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "공지사항 수정 실패 - 존재하지 않는 공지사항",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "공지사항이 존재하지 않는 경우", value = """
+                                             {
+                                                     "code": "N000",
+                                                     "message": "존재하지 않는 공지사항입니다."
+                                                 }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getNotice(
+            @Parameter(description = "여행 ID", example = "1")
+            @PathVariable(name = "noticeId") Long noticeId
+    );
+    
     @TrackApi(description = "공지사항 수정")
     @Operation(summary = "공지사항 수정", description = "공지사항 수정 API")
     @ApiResponses({

--- a/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
@@ -51,6 +51,7 @@ public class NoticeController implements NoticeApi {
                 .body(SuccessResponse.from(noticeQueryService.getAllNotices(tripId, pageable)));
     }
     
+    @Override
     @GetMapping("/{tripId}/notices/{noticeId}")
     public ResponseEntity<?> getNotice(
             @PathVariable(name = "noticeId") Long noticeId

--- a/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
@@ -51,6 +51,14 @@ public class NoticeController implements NoticeApi {
                 .body(SuccessResponse.from(noticeQueryService.getAllNotices(tripId, pageable)));
     }
     
+    @GetMapping("/{tripId}/notices/{noticeId}")
+    public ResponseEntity<?> getNotice(
+            @PathVariable(name = "noticeId") Long noticeId
+    ) {
+        return ResponseEntity
+                .ok(SuccessResponse.from(noticeQueryService.getNotice(noticeId)));
+    }
+    
     @Override
     @PutMapping("/{tripId}/notices/{noticeId}")
     public ResponseEntity<?> updateNotice(

--- a/src/test/java/kr/co/yeogiga/application/notice/service/NoticeQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/notice/service/NoticeQueryServiceTest.java
@@ -1,7 +1,12 @@
 package kr.co.yeogiga.application.notice.service;
 
+import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.notice.dto.NoticeDto;
+import kr.co.yeogiga.domain.notice.entity.Notice;
+import kr.co.yeogiga.domain.notice.exception.NoticeErrorType;
 import kr.co.yeogiga.domain.notice.service.NoticeService;
+import kr.co.yeogiga.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,11 +18,15 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -58,6 +67,62 @@ public class NoticeQueryServiceTest {
             // then
             assertThat(noticeDetails.getContent()).hasSize(1);
             assertThat(noticeDetails.getContent().get(0)).usingRecursiveComparison().isEqualTo(noticeDetail);
+        }
+    }
+    
+    @Nested
+    @DisplayName("특정 공지 조회")
+    class GetNotice {
+        private final Long noticeId = 1L;
+        
+        private User user = User.builder()
+                .nickname("nickname")
+                .build();
+        
+        private Notice notice;
+        
+        @BeforeEach
+        void setUp() {
+            notice = Notice.builder()
+                    .title("title")
+                    .description("description")
+                    .tripId(1L)
+                    .author(user)
+                    .build();
+            
+            ReflectionTestUtils.setField(user, "imageUrl", "https://image.com/image");
+            ReflectionTestUtils.setField(notice, "authorId", 1L);
+        }
+        
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            when(noticeService.readJoinUserById(noticeId)).thenReturn(Optional.of(notice));
+            
+            // when
+            NoticeDto.Detail result = noticeQueryService.getNotice(noticeId);
+            
+            // then
+            assertEquals(notice.getId(), result.id());
+            assertEquals(notice.getTitle(), result.title());
+            assertEquals(notice.getDescription(), result.description());
+            assertEquals(notice.getAuthorId(), result.authorId());
+            assertEquals(user.getNickname(), result.nickname());
+        }
+        
+        @Test
+        @DisplayName("실패 - 공지사항 미존재")
+        void failIfNoticeNotFound() {
+            // given
+            when(noticeService.readJoinUserById(noticeId)).thenReturn(Optional.empty());
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                     -> noticeQueryService.getNotice(noticeId));
+            
+            // then
+            assertEquals(NoticeErrorType.NOT_FOUND, exception.getErrorType());
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/notice/controller/NoticeControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/notice/controller/NoticeControllerTest.java
@@ -190,6 +190,60 @@ public class NoticeControllerTest {
     }
     
     @Nested
+    @DisplayName("특정 공지사항 조회")
+    class GetNotice {
+        private final Long noticeId = 1L;
+        
+        private NoticeDto.Detail dto = NoticeDto.Detail.builder()
+                .id(noticeId)
+                .title("title")
+                .description("description")
+                .authorId(1L)
+                .createdAt(LocalDateTime.now().minusDays(1))
+                .imageUrl("http://image.com/image")
+                .build();
+        
+        
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            when(noticeQueryService.getNotice(noticeId)).thenReturn(dto);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip/{tripId}/notices/{noticeId}", 1L, noticeId)
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.id").value(dto.id()))
+                    .andExpect(jsonPath("$.data.authorId").value(dto.authorId()));
+        }
+        
+        @Test
+        @DisplayName("실패 - 존재하지 않는 공지사항")
+        void failIfNoticeNotFound() throws Exception {
+            // given
+            doThrow(new CustomException(NoticeErrorType.NOT_FOUND)).when(noticeQueryService).getNotice(noticeId);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip/{tripId}/notices/{noticeId}", 1L, noticeId)
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(NoticeErrorType.NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.message").value(NoticeErrorType.NOT_FOUND.getMessage()));
+        }
+    }
+    
+    @Nested
     @DisplayName("공지사항 수정")
     class UpdateNotice {
         


### PR DESCRIPTION
## 배경
- 특정 공지사항 조회 기능 필요

## 작업 사항
- 공지사항 조회 도메인 로직 구현 | (0e0b5ea9b7ced75a5841ba1014e41348e23af56b) (08a810484eac964a2013e73f6866caa72e1c4cc5)
	- 공지사항 작성자 조회 시 지연로딩으로 인한 추가 쿼리 방지를 위해 쿼리문 fetch join 적용 | (08a810484eac964a2013e73f6866caa72e1c4cc5 | 위의 2번째 커밋과 동일)
<br/>

- 공지사항 조회 로직 구현 | (a72a95a1e0ed6bd096f93f7829ae166345a2b603)