### PR TITLE
Feature(IL-248): 키워드를 통한 장소 검색 기능 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/place/application/PlaceSearchService.java
+++ b/src/main/java/kr/co/yeogiga/application/place/application/PlaceSearchService.java
@@ -1,0 +1,30 @@
+package kr.co.yeogiga.application.place.application;
+
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.place.exception.PlaceErrorType;
+import kr.co.yeogiga.infrastructure.place.PlaceSearchClient;
+import kr.co.yeogiga.infrastructure.place.dto.PlaceInfoDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceSearchService {
+    private final PlaceSearchClient placeSearchClient;
+    
+    /**
+     * 특정 키워드를 통해 연관된 장소를 검색하는 메서드
+     *
+     * @param place     장소 키워드
+     * @return          키워드와 연관된 장소 목록
+     */
+    public List<PlaceInfoDto> searchPlace(String place) {
+        if (place.isBlank()) {
+            throw new CustomException(PlaceErrorType.NOT_VALID_PLACE_QUERY);
+        }
+        
+        return placeSearchClient.fetchPlaces(place);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/place/exception/PlaceErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/place/exception/PlaceErrorType.java
@@ -1,0 +1,32 @@
+package kr.co.yeogiga.domain.place.exception;
+
+import kr.co.yeogiga.common.response.error.type.BaseErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Place ErrorCode: Pxxx
+ */
+@RequiredArgsConstructor
+public enum PlaceErrorType implements BaseErrorType {
+    NOT_VALID_PLACE_QUERY(HttpStatus.BAD_REQUEST, "P000", "장소는 필수 입력값입니다.");
+    
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+    
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+    
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+    
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
@@ -12,6 +12,7 @@ public final class EndpointConstants {
     public static final String[] USER_ENDPOINTS = {
             "/api/v1/trip/**",
             "/api/v1/users/**",
+            "/api/v1/places/**"
     };
 
     public static final String[] GUEST_ENDPOINTS = {

--- a/src/main/java/kr/co/yeogiga/infrastructure/place/NaverPlaceSearchClient.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/place/NaverPlaceSearchClient.java
@@ -1,0 +1,96 @@
+package kr.co.yeogiga.infrastructure.place;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.common.response.error.type.CommonErrorType;
+import kr.co.yeogiga.infrastructure.place.dto.NaverPlaceInfoDto;
+import kr.co.yeogiga.infrastructure.place.dto.PlaceInfoDto;
+import kr.co.yeogiga.infrastructure.properties.OAuthProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+public class NaverPlaceSearchClient implements PlaceSearchClient {
+    private final String clientId;
+    private final String clientSecret;
+    private final ObjectMapper objectMapper;
+    
+    private final String CLIENT_ID_HEADER = "X-Naver-Client-Id";
+    private final String CLIENT_SECRET_HEADER = "X-Naver-Client-Secret";
+    
+    private final String NAVER_OPEN_API_URI = "https://openapi.naver.com/";
+    private final String PLACE_SEARCH_PATH = "v1/search/local.json";
+    
+    @Autowired
+    public NaverPlaceSearchClient(OAuthProperties oAuthProperties, ObjectMapper objectMapper) {
+        OAuthProperties.Platform naverProperties = oAuthProperties.getNaver();
+        
+        this.clientId = naverProperties.getClientId();
+        this.clientSecret = naverProperties.getClientSecret();
+        this.objectMapper = objectMapper;
+    }
+    
+    /**
+     * 특정 장소 키워드를 통한 연관된 장소 검색 메서드
+     * - 네이버 지역 검색 API 사용
+     *
+     * @param place     검색할 장소 키워드
+     * @return          해당 키워드와 연관된 장소 목록
+     */
+    @Override
+    public List<PlaceInfoDto> fetchPlaces(String place) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(CLIENT_ID_HEADER, clientId);
+        headers.add(CLIENT_SECRET_HEADER, clientSecret);
+        
+        HttpEntity<String> request = new HttpEntity<>(headers);
+        
+        URI uri = UriComponentsBuilder.fromUriString(NAVER_OPEN_API_URI)
+                .path(PLACE_SEARCH_PATH)
+                .queryParam("query", place)
+                .queryParam("display", 5)
+                .queryParam("start", 1)
+                .queryParam("sort", "random")
+                .encode(StandardCharsets.UTF_8)
+                .build()
+                .toUri();
+        
+        RestTemplate restTemplate = new RestTemplate();
+        
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(
+                    uri,
+                    HttpMethod.GET,
+                    request,
+                    String.class
+            );
+            
+            JsonNode rootNode = objectMapper.readTree(response.getBody());
+            JsonNode items = rootNode.get("items");
+            
+            List<NaverPlaceInfoDto> naverPlaceInfoList = objectMapper.readValue(items.traverse(), new TypeReference<List<NaverPlaceInfoDto>>() {
+            });
+            
+            return new ArrayList<>(naverPlaceInfoList);
+            
+        } catch (Exception e) {
+            log.error("[ERROR] Could not fetch place from NAVER place search api - {}", e.getMessage());
+            throw new CustomException(CommonErrorType.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/place/NaverPlaceSearchClient.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/place/NaverPlaceSearchClient.java
@@ -7,9 +7,9 @@ import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.response.error.type.CommonErrorType;
 import kr.co.yeogiga.infrastructure.place.dto.NaverPlaceInfoDto;
 import kr.co.yeogiga.infrastructure.place.dto.PlaceInfoDto;
-import kr.co.yeogiga.infrastructure.properties.OAuthProperties;
+import kr.co.yeogiga.infrastructure.properties.NaverMapProperties;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -25,25 +25,14 @@ import java.util.List;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class NaverPlaceSearchClient implements PlaceSearchClient {
-    private final String clientId;
-    private final String clientSecret;
     private final ObjectMapper objectMapper;
+    private final NaverMapProperties naverMapProperties;
     
     private final String CLIENT_ID_HEADER = "X-Naver-Client-Id";
     private final String CLIENT_SECRET_HEADER = "X-Naver-Client-Secret";
-    
-    private final String NAVER_OPEN_API_URI = "https://openapi.naver.com/";
     private final String PLACE_SEARCH_PATH = "v1/search/local.json";
-    
-    @Autowired
-    public NaverPlaceSearchClient(OAuthProperties oAuthProperties, ObjectMapper objectMapper) {
-        OAuthProperties.Platform naverProperties = oAuthProperties.getNaver();
-        
-        this.clientId = naverProperties.getClientId();
-        this.clientSecret = naverProperties.getClientSecret();
-        this.objectMapper = objectMapper;
-    }
     
     /**
      * 특정 장소 키워드를 통한 연관된 장소 검색 메서드
@@ -55,12 +44,12 @@ public class NaverPlaceSearchClient implements PlaceSearchClient {
     @Override
     public List<PlaceInfoDto> fetchPlaces(String place) {
         HttpHeaders headers = new HttpHeaders();
-        headers.add(CLIENT_ID_HEADER, clientId);
-        headers.add(CLIENT_SECRET_HEADER, clientSecret);
+        headers.add(CLIENT_ID_HEADER, naverMapProperties.getClientId());
+        headers.add(CLIENT_SECRET_HEADER, naverMapProperties.getClientSecret());
         
         HttpEntity<String> request = new HttpEntity<>(headers);
         
-        URI uri = UriComponentsBuilder.fromUriString(NAVER_OPEN_API_URI)
+        URI uri = UriComponentsBuilder.fromUriString(naverMapProperties.getUri())
                 .path(PLACE_SEARCH_PATH)
                 .queryParam("query", place)
                 .queryParam("display", 5)

--- a/src/main/java/kr/co/yeogiga/infrastructure/place/PlaceSearchClient.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/place/PlaceSearchClient.java
@@ -1,0 +1,16 @@
+package kr.co.yeogiga.infrastructure.place;
+
+import kr.co.yeogiga.infrastructure.place.dto.PlaceInfoDto;
+
+import java.util.List;
+
+public interface PlaceSearchClient {
+    
+    /**
+     * 특정 장소 키워드를 통한 연관된 장소 검색 메서드
+     *
+     * @param place     검색할 장소 키워드
+     * @return          해당 키워드와 연관된 장소 목록
+     */
+    List<PlaceInfoDto> fetchPlaces(String place);
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/place/dto/NaverPlaceInfoDto.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/place/dto/NaverPlaceInfoDto.java
@@ -1,0 +1,29 @@
+package kr.co.yeogiga.infrastructure.place.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class NaverPlaceInfoDto extends PlaceInfoDto {
+    @JsonCreator
+    public NaverPlaceInfoDto(
+            String title,
+            String link,
+            String description,
+            String telephone,
+            String address,
+            String roadAddress,
+            @JsonProperty(value = "mapx") String mapX,
+            @JsonProperty(value = "mapy") String mapY
+    ) {
+        this.title = title.replaceAll("<.*?>", "");
+        this.link = link;
+        this.description = description;
+        this.telephone = telephone;
+        this.address = address;
+        this.roadAddress = roadAddress;
+        this.longitude = Double.parseDouble(mapX.substring(0,3) + "." + mapX.substring(3));
+        this.latitude = Double.parseDouble(mapY.substring(0,2) + "." + mapY.substring(2));
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/place/dto/PlaceInfoDto.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/place/dto/PlaceInfoDto.java
@@ -1,0 +1,15 @@
+package kr.co.yeogiga.infrastructure.place.dto;
+
+import lombok.Getter;
+
+@Getter
+public abstract class PlaceInfoDto {
+    protected String title;
+    protected String link;
+    protected String description;
+    protected String telephone;
+    protected String address;
+    protected String roadAddress;
+    protected double longitude;
+    protected double latitude;
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/properties/NaverMapProperties.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/properties/NaverMapProperties.java
@@ -1,0 +1,16 @@
+package kr.co.yeogiga.infrastructure.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "map.naver")
+public class NaverMapProperties {
+    private String uri;
+    private String clientId;
+    private String clientSecret;
+}

--- a/src/main/java/kr/co/yeogiga/presentation/place/api/PlaceApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/place/api/PlaceApi.java
@@ -1,0 +1,98 @@
+package kr.co.yeogiga.presentation.place.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@ApiGroup(value = "[장소 검색 API]")
+@Tag(name = "[장소 검색 API]", description = "장소 검색 관련 API")
+public interface PlaceApi {
+    
+    @TrackApi(description = "장소 검색")
+    @Operation(summary = "장소 검색", description = "키워드를 통해 장소를 검색하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "장소 검색 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(description = "네이버 지역 검색 api 제한으로 인해 최대 5개까지 출력 가능", value = """
+                                        {
+                                             "code": 200,
+                                             "message": "요청이 성공하였습니다.",
+                                             "data": [
+                                                 {
+                                                     "title": "경복궁",
+                                                     "link": "https://royal.khs.go.kr/gbg",
+                                                     "description": "",
+                                                     "telephone": "",
+                                                     "address": "서울특별시 종로구 세종로 1-1 경복궁",
+                                                     "roadAddress": "서울특별시 종로구 사직로 161 경복궁",
+                                                     "longitude": 126.9770162,
+                                                     "latitude": 37.5788408
+                                                 },
+                                                 {
+                                                     "title": "경복궁 한옥마을점",
+                                                     "link": "http://www.entas.co.kr/",
+                                                     "description": "",
+                                                     "telephone": "",
+                                                     "address": "인천광역시 연수구 송도동 24-17",
+                                                     "roadAddress": "인천광역시 연수구 테크노파크로 180",
+                                                     "longitude": 126.6388695,
+                                                     "latitude": 37.3907929
+                                                 },
+                                                 {
+                                                     "title": "경복궁 판교점",
+                                                     "link": "http://www.entas.co.kr/",
+                                                     "description": "",
+                                                     "telephone": "",
+                                                     "address": "경기도 성남시 분당구 삼평동 741 2층",
+                                                     "roadAddress": "경기도 성남시 분당구 대왕판교로606번길 58 2층",
+                                                     "longitude": 127.1132503,
+                                                     "latitude": 37.395166
+                                                 },
+                                                 {
+                                                     "title": "경복궁 방이점",
+                                                     "link": "http://www.entas.co.kr/",
+                                                     "description": "",
+                                                     "telephone": "",
+                                                     "address": "서울특별시 송파구 방이동 35",
+                                                     "roadAddress": "서울특별시 송파구 올림픽로 348",
+                                                     "longitude": 127.1090835,
+                                                     "latitude": 37.5159841
+                                                 },
+                                                 {
+                                                     "title": "경복궁 대구점",
+                                                     "link": "http://www.entas.co.kr/",
+                                                     "description": "",
+                                                     "telephone": "",
+                                                     "address": "대구광역시 수성구 두산동 793",
+                                                     "roadAddress": "대구광역시 수성구 용학로 134",
+                                                     "longitude": 128.6233411,
+                                                     "latitude": 35.8234245
+                                                 }
+                                             ]
+                                         }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "장소 검색 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(description = "장소 키워드 유효성 검증 실패", value = """
+                                        {
+                                              "code": "P000",
+                                              "message": "장소는 필수 입력값입니다."
+                                          }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> searchPlace(
+            @Parameter(description = "장소 키워드", example = "경복궁")
+            @RequestParam(name = "place") String place
+    );
+    
+}

--- a/src/main/java/kr/co/yeogiga/presentation/place/controller/PlaceController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/place/controller/PlaceController.java
@@ -1,0 +1,23 @@
+package kr.co.yeogiga.presentation.place.controller;
+
+import kr.co.yeogiga.application.place.application.PlaceSearchService;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/places")
+public class PlaceController {
+    private final PlaceSearchService placeSearchService;
+    
+    @GetMapping("/search")
+    public ResponseEntity<?> searchPlace(@RequestParam(name = "place") String place) {
+        return ResponseEntity
+                .ok(SuccessResponse.from(placeSearchService.searchPlace(place)));
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/place/controller/PlaceController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/place/controller/PlaceController.java
@@ -2,6 +2,7 @@ package kr.co.yeogiga.presentation.place.controller;
 
 import kr.co.yeogiga.application.place.application.PlaceSearchService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.presentation.place.api.PlaceApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,9 +13,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/places")
-public class PlaceController {
+public class PlaceController implements PlaceApi {
     private final PlaceSearchService placeSearchService;
     
+    @Override
     @GetMapping("/search")
     public ResponseEntity<?> searchPlace(@RequestParam(name = "place") String place) {
         return ResponseEntity

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,3 +68,10 @@ spring:
         auth: true
         starttls:
           enable: true
+
+--- # map
+map:
+  naver:
+    uri: ${NAVER_API_URI}
+    client-id: ${NAVER_CLIENT_ID}
+    client-secret: ${NAVER_CLIENT_SECRET}

--- a/src/test/java/kr/co/yeogiga/application/place/PlaceSearchServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/place/PlaceSearchServiceTest.java
@@ -1,0 +1,80 @@
+package kr.co.yeogiga.application.place;
+
+import kr.co.yeogiga.application.place.application.PlaceSearchService;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.place.exception.PlaceErrorType;
+import kr.co.yeogiga.infrastructure.place.PlaceSearchClient;
+import kr.co.yeogiga.infrastructure.place.dto.NaverPlaceInfoDto;
+import kr.co.yeogiga.infrastructure.place.dto.PlaceInfoDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class PlaceSearchServiceTest {
+    
+    @Mock
+    private PlaceSearchClient placeSearchClient;
+    
+    @InjectMocks
+    private PlaceSearchService placeSearchService;
+    
+    @Nested
+    @DisplayName("키워드를 통한 장소 검색")
+    class SearchPlace {
+        private final String keyword = "경복궁";
+        
+        private NaverPlaceInfoDto dto = new NaverPlaceInfoDto(
+                "경복궁",
+                "https://mock.com",
+                "경복궁입니다.",
+                "02-000-0000",
+                "서울특별시 종로구 세종로 1-1 경복궁",
+                "서울특별시 종로구 사직로 161 경복궁",
+                "1269770162",
+                "375788408"
+        );
+        
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            when(placeSearchClient.fetchPlaces(keyword)).thenReturn(List.of(dto));
+            
+            // when
+            List<PlaceInfoDto> result = placeSearchService.searchPlace(keyword);
+            
+            // then
+            assertThat(result).hasSize(1);
+            
+            PlaceInfoDto place = result.get(0);
+            assertEquals(dto.getTitle(), place.getTitle());
+            assertEquals(37.5788408, place.getLatitude());
+            assertEquals(126.9770162, place.getLongitude());
+        }
+        
+        @Test
+        @DisplayName("실패 - 장소 키워드 누락")
+        void failKeyworldNotValid() {
+            // given & when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> placeSearchService.searchPlace(" "));
+            
+            // then
+            assertEquals(PlaceErrorType.NOT_VALID_PLACE_QUERY, exception.getErrorType());
+        }
+    }
+    
+    
+}

--- a/src/test/java/kr/co/yeogiga/presentation/place/controller/PlaceControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/place/controller/PlaceControllerTest.java
@@ -1,0 +1,127 @@
+package kr.co.yeogiga.presentation.place.controller;
+
+import kr.co.yeogiga.application.place.application.PlaceSearchService;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
+import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.domain.place.exception.PlaceErrorType;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.type.Role;
+import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
+import kr.co.yeogiga.infrastructure.place.dto.NaverPlaceInfoDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.List;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = PlaceController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthenticationFilter.class})
+        }
+)
+public class PlaceControllerTest {
+    
+    private MockMvc mockMvc;
+        
+    private CustomUserDetails userDetails;
+    
+    @MockBean
+    private PlaceSearchService placeSearchService;
+    
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .alwaysDo(print())
+                .build();
+        
+        User user = User.builder()
+                .username("username")
+                .password("password")
+                .nickname("nickname")
+                .email("email")
+                .role(Role.USER)
+                .build();
+        
+        ReflectionTestUtils.setField(user, "id", 1L);
+        
+        userDetails = new CustomUserDetailsImpl(user);
+    }
+    
+    @Nested
+    @DisplayName("장소 검색")
+    class SearchPlace {
+        private final String keyword = "경복궁";
+        
+        private NaverPlaceInfoDto dto = new NaverPlaceInfoDto(
+                "경복궁",
+                "https://mock.com",
+                "경복궁입니다.",
+                "02-000-0000",
+                "서울특별시 종로구 세종로 1-1 경복궁",
+                "서울특별시 종로구 사직로 161 경복궁",
+                "1269770162",
+                "375788408"
+        );
+        
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            when(placeSearchService.searchPlace(keyword)).thenReturn(List.of(dto));
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/places/search")
+                            .queryParam("place", keyword)
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data[0].title").value(dto.getTitle()))
+                    .andExpect(jsonPath("$.data[0].latitude").value(37.5788408))
+                    .andExpect(jsonPath("$.data[0].longitude").value(126.9770162));
+        }
+        
+        @Test
+        @DisplayName("실패 - 키워드 유효성 검증 실패")
+        void failKeywordNotValid() throws Exception {
+            // given
+            doThrow(new CustomException(PlaceErrorType.NOT_VALID_PLACE_QUERY)).when(placeSearchService).searchPlace(keyword);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/places/search")
+                            .queryParam("place", keyword)
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(PlaceErrorType.NOT_VALID_PLACE_QUERY.getCode()))
+                    .andExpect(jsonPath("$.message").value(PlaceErrorType.NOT_VALID_PLACE_QUERY.getMessage()));
+        }
+    }
+}


### PR DESCRIPTION
## 배경
- 키워드를 통한 장소 검색 기능 구현 요구
	- 프론트엔드 상에서 네이버 지역 검색 api 호출 시 CORS 문제 발생으로 인한 백엔드 상 api 호출 요구 
	(해당 부분도 찾아보니 프론트엔드 상에 프록시 서버를 구성하면 가능하다고는 합니다.)

## 작업 사항
- [네이버 지역 검색 api](https://developers.naver.com/docs/serviceapi/search/local/local.md#%EA%B2%80%EC%83%89-_-%EC%A7%80%EC%97%AD) 연결 | (0164172fd84ad64e942f3a2a0c8c9cf92b537aa2)
	- 네이버 지역 검색 api 제한 상, 하루에 최대 25,000건 호출 가능 & 한 번에 최대 5건까지 조회 가능
	- 정확도 순 or 리뷰 순으로 조회 가능하나, 현재 정확도 순 `sort=random`으로 정렬
<br/>

**📗 기존 네이버 응답값**
```json
{
    "lastBuildDate": "Mon, 04 Aug 2025 15:25:13 +0900",
    "total": 5,
    "start": 1,
    "display": 5,
    "items": [
        {
            "title": "<b>경복궁</b>",
            "link": "https://royal.khs.go.kr/gbg",
            "category": "여행,명소>궁궐",
            "description": "",
            "telephone": "",
            "address": "서울특별시 종로구 세종로 1-1 경복궁",
            "roadAddress": "서울특별시 종로구 사직로 161 경복궁",
            "mapx": "1269770162",
            "mapy": "375788408"
        }, ...
    ]
}
```

**📗 데이터 처리 후 서버 응답값**
```
{
    "code": 200,
    "message": "요청이 성공하였습니다.",
    "data": [
        {
            "title": "경복궁",
            "link": "https://royal.khs.go.kr/gbg",
            "description": "",
            "telephone": "",
            "address": "서울특별시 종로구 세종로 1-1 경복궁",
            "roadAddress": "서울특별시 종로구 사직로 161 경복궁",
            "longitude": 126.9770162,
            "latitude": 37.5788408
        }, ...
	]
}
```



- 키워드를 통한 장소 검색 로직 구현 | (7ed371db082adc49b192676281eaa5c326f53b49)
	- 장소 검색 외에 추가적인 로직은 추가하지 않았고, 빈 값의 키워드로 api 호출 시 오류가 발생해 해당 부분만 처리 해놓았습니다.
	- `[카톡으로 연락드린 내용입니다]` 네이버 지역 검색 api에서 제공하는 응답값 내 카테고리 목록이 따로 없어 해당 값을 서비스 내에 사용하는 카테고리로 매핑하는데 문제가 있어 카테고리를 제외한 장소 정보값들만 반환하도록 설계하였습니다.


## 추가 논의
- 네이버 지역 검색 api(0164172fd84ad64e942f3a2a0c8c9cf92b537aa2) 사용 시에 OAuth 소셜 로그인과 같이 `Client-Id`, `Client-Secret`을 사용합니다. 현재는 두 값 모두 `OAuthProperties` 내에 정의되어 있어서 우선은 해당 값을 그대로 주입받아 사용하였습니다. 따라서, 별도의 NaverProperties 클래스를 정의해야할지 고민하였지만 일관성 문제와 변경이 클 것 같아 우선은 그대로 사용하였습니다. 
	- 또한, 네이버 오픈 api의 경로또한 `NaverPlaceSearchClient` 내에 직접 정의한 상태입니다. 해당 부분 때문에도 별로도 NaverProperties 프로퍼티 클래스를 정의할까 고민하였지만 위와 같은 이유로 아직 그대로 두었습니다.