### PR TITLE
Feature(IL-251): 탈퇴 사용자 로그인 시 에러 처리 및 계정 복구 기능 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/auth/dto/RestoreDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/RestoreDto.java
@@ -1,10 +1,13 @@
 package kr.co.yeogiga.application.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 public class RestoreDto {
     
+    @Schema(name = "RestoreDto.Request", description = "계정 복구 요청 DTO")
     public record Request(
+            @Schema(description = "사용자 ID", example = "1")
             @NotNull(message = "사용자 ID는 필수 입력값입니다.")
             Long userId
     ) { }

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/RestoreDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/RestoreDto.java
@@ -1,0 +1,11 @@
+package kr.co.yeogiga.application.auth.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public class RestoreDto {
+    
+    public record Request(
+            @NotNull(message = "사용자 ID는 필수 입력값입니다.")
+            Long userId
+    ) { }
+}

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
@@ -4,6 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 public class SignInDto {
 
     @Builder
@@ -49,6 +52,19 @@ public class SignInDto {
                             .accessToken(this.token.accessToken())
                             .build())
                     .shouldSignup(this.shouldSignup)
+                    .build();
+        }
+    }
+    
+    @Builder
+    public record WithdrawnUserInfo(
+            Long userId,
+            LocalDate deletionExpiration
+    ) {
+        public static WithdrawnUserInfo of(Long userId, LocalDateTime deletedAt) {
+            return WithdrawnUserInfo.builder()
+                    .userId(userId)
+                    .deletionExpiration(deletedAt.toLocalDate().plusDays(7))
                     .build();
         }
     }

--- a/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
@@ -130,4 +130,23 @@ public class AuthService {
             throw new CustomException(AuthErrorType.ALREADY_USED_NICKNAME);
         }
     }
+    
+    /**
+     * 탈퇴(soft delete)된 사용자의 계정을 복구하는 메서드
+     *
+     * @param userId    사용자 ID
+     *
+     * @ throws CustomException AuthErrorType.NOT_WITHDRAWN - 탈퇴하지 않은 사용자인 경우
+     */
+    @Transactional
+    public void restoreUser(Long userId) {
+        User user = userService.readIncludeDeletedUserById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
+        
+        if (!user.isDeleted()) {
+            throw new CustomException(AuthErrorType.NOT_WITHDRAWN);
+        }
+        
+        user.revertWithdrawal();
+    }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
@@ -14,8 +14,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Objects;
-
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -67,7 +65,10 @@ public class AuthService {
                 .orElseThrow(() -> new CustomException(AuthErrorType.AUTHENTICATION_FAIL));
 
         if (user.isDeleted()) {
-            throw new CustomException(UserErrorType.ALREADY_WITHDRAW);
+            throw new CustomException(
+                    UserErrorType.ALREADY_WITHDRAW,
+                    SignInDto.WithdrawnUserInfo.of(user.getId(), user.getDeletedAt())
+            );
         }
 
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {

--- a/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
@@ -56,14 +56,18 @@ public class AuthService {
      * @param request               로그인 요청 dto(username, password)
      * @throws CustomException      AuthErrorType.AUTHENTICATION_FAIL 아이디 및 비밀번호 불일치
      * @return                      토큰(accessToken, refreshToken)
+     *
+     * @throws CustomException      UserErrorType.ALREADY_WITHDRAW - 이미 탈퇴한 사용자
+     *                              AuthErrorType.AUTHENTICATION_FAIL - 아이디 미존재
+     *                              AuthErrorType.AUTHENTICATION_FAIL - 비밀번호 불일치
      */
     @Transactional
     public TokenDto signIn(SignInDto.Request request) {
         User user = userService.readIncludeDeletedUserByUsername(request.username())
                 .orElseThrow(() -> new CustomException(AuthErrorType.AUTHENTICATION_FAIL));
 
-        if (Objects.nonNull(user.getDeletedAt())) {
-            user.revertWithdrawal();
+        if (user.isDeleted()) {
+            throw new CustomException(UserErrorType.ALREADY_WITHDRAW);
         }
 
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -94,12 +94,14 @@ public class OAuthManagementService {
      * @param platform      OAuth 로그인 플랫폼
      * @param userInfo      OAuth 리소스 서버 제공 사용자 정보
      * @return              User, 추가 정보 입력 필요 여부
+     *
+     * @throws CustomException UserErrorType.ALREADY_WITHDRAW - 이미 탈퇴한 사용자
      */
     private UserStatusDto getUserStatus(OAuthPlatform platform, UserInfoDto userInfo) {
         return userService.readIncludeDeletedUserByPlatformAndPlatformId(platform, userInfo.platformId())
                 .map(user -> {
-                    if (!Objects.isNull(user.getDeletedAt())) {
-                        user.revertWithdrawal();
+                    if (user.isDeleted()) {
+                        throw new CustomException(UserErrorType.ALREADY_WITHDRAW);
                     }
 
                     return user.isSignedUp()

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -102,7 +102,10 @@ public class OAuthManagementService {
         return userService.readIncludeDeletedUserByPlatformAndPlatformId(platform, userInfo.platformId())
                 .map(user -> {
                     if (user.isDeleted()) {
-                        throw new CustomException(UserErrorType.ALREADY_WITHDRAW);
+                        throw new CustomException(
+                                UserErrorType.ALREADY_WITHDRAW,
+                                SignInDto.WithdrawnUserInfo.of(user.getId(), user.getDeletedAt())
+                        );
                     }
 
                     return user.isSignedUp()

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -20,8 +20,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Objects;
-
 @Service
 @RequiredArgsConstructor
 public class OAuthManagementService {
@@ -66,12 +64,15 @@ public class OAuthManagementService {
         
         return getSignInResponse(userStatus);
     }
-
+    
     /**
      * GUEST 사용자의 권한 승격을 위한 회원 등록 메서드
      *
      * @param userId        사용자 ID
-     * @param request       회원 등록 요청 dto (nickname)
+     * @param request       회원 등록 요청 DTO (nickname)
+     * @return              JWT 토큰
+     *
+     * @throws CustomException AuthErrorType.ALREADY_USED_NICKNAME - 이미 사용 중인 닉네임일 경우
      */
     @Transactional
     public TokenDto register(Long userId, SignUpDto.Register request) {

--- a/src/main/java/kr/co/yeogiga/common/exception/CustomException.java
+++ b/src/main/java/kr/co/yeogiga/common/exception/CustomException.java
@@ -2,10 +2,19 @@ package kr.co.yeogiga.common.exception;
 
 import kr.co.yeogiga.common.response.error.type.BaseErrorType;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class CustomException extends RuntimeException {
     private final BaseErrorType errorType;
+    private final Object data;
+    
+    public CustomException(BaseErrorType errorType) {
+        this.errorType = errorType;
+        this.data = null;
+    }
+    
+    public CustomException(BaseErrorType errorType, Object data) {
+        this.errorType = errorType;
+        this.data = data;
+    }
 }

--- a/src/main/java/kr/co/yeogiga/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/yeogiga/common/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 @Slf4j
 @RestControllerAdvice
@@ -24,6 +25,13 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<?> handleCustomException(final CustomException e) {
         BaseErrorType error = e.getErrorType();
         log.error("[Error Occurred] {}", error.getMessage());
+        
+        Object data = e.getData();
+        
+        if (Objects.nonNull(data)) {
+            return ResponseEntity.status(error.getHttpStatus()).body(ErrorResponse.from(error, data));
+        }
+        
         return ResponseEntity.status(error.getHttpStatus()).body(ErrorResponse.from(error));
     }
 

--- a/src/main/java/kr/co/yeogiga/common/response/error/ErrorResponse.java
+++ b/src/main/java/kr/co/yeogiga/common/response/error/ErrorResponse.java
@@ -8,15 +8,24 @@ import java.util.Map;
 
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record ErrorResponse(
+public record ErrorResponse (
         String code,
         String message,
-        Map<String, String> errors
+        Map<String, String> errors,
+        Object data
 ) {
     public static ErrorResponse from(BaseErrorType error) {
         return ErrorResponse.builder()
                 .code(error.getCode())
                 .message(error.getMessage())
+                .build();
+    }
+    
+    public static ErrorResponse from(BaseErrorType error, Object data) {
+        return ErrorResponse.builder()
+                .code(error.getCode())
+                .message(error.getMessage())
+                .data(data)
                 .build();
     }
 }

--- a/src/main/java/kr/co/yeogiga/common/response/error/ErrorResponse.java
+++ b/src/main/java/kr/co/yeogiga/common/response/error/ErrorResponse.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record ErrorResponse (
+public record ErrorResponse(
         String code,
         String message,
         Map<String, String> errors,

--- a/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
@@ -28,7 +28,9 @@ public enum AuthErrorType implements BaseErrorType {
     
     EMAIL_VERIFICATION_TIMEOUT(HttpStatus.BAD_REQUEST, "A014", "이메일 인증 시간을 초과하였습니다."),
     EMAIL_VERIFICATION_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "A015", "이메일 인증 번호가 일치하지 않습니다."),
-    EMAIL_VERIFICATION_TIME_LIMIT(HttpStatus.BAD_REQUEST, "A016", "이메일 인증 시도 횟수를 초과하였습니다. 잠시 후 시도해주세요.");
+    EMAIL_VERIFICATION_TIME_LIMIT(HttpStatus.BAD_REQUEST, "A016", "이메일 인증 시도 횟수를 초과하였습니다. 잠시 후 시도해주세요."),
+    
+    NOT_WITHDRAWN(HttpStatus.BAD_REQUEST, "A017", "탈퇴한 사용자가 아닙니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/entity/User.java
@@ -19,6 +19,7 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -100,5 +101,9 @@ public class User extends BaseTimeEntity {
     
     public boolean isSameNickname(String nickname) {
         return this.nickname.equals(nickname);
+    }
+    
+    public boolean isDeleted() {
+        return Objects.nonNull(this.deletedAt);
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import kr.co.yeogiga.application.auth.dto.RestoreDto;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
 import kr.co.yeogiga.application.auth.dto.SignUpDto;
 import kr.co.yeogiga.application.auth.type.Device;
@@ -253,4 +254,51 @@ public interface AuthApi {
                     }))
     })
     ResponseEntity<?> checkDuplicatedNickname(@RequestParam(name = "value") String nickname);
+    
+    @TrackApi(description = "계정 복구")
+    @Operation(summary = "계정 복구", description = "탈퇴(soft delete)된 사용자가 계정을 복구하는 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "계정 복구 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "계정 복구 성공", value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "계정 복구 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "유효성 검증 실패", value = """
+                                        {
+                                            "code": "G002",
+                                            "errors": {
+                                                "userId": "사용자 ID는 필수 입력값입니다."
+                                            }
+                                        }
+                                    """),
+                            @ExampleObject(name = "탈퇴하지 않은 사용자", value = """
+                                        {
+                                             "code": "A017",
+                                             "message": "탈퇴한 사용자가 아닙니다."
+                                         }
+                                    """),
+                            @ExampleObject(name = "존재하지 않는 사용자", value = """
+                                        {
+                                              "code": "U000",
+                                              "message": "존재하지 않는 사용자입니다."
+                                          }
+                                    """),
+                    })),
+            @ApiResponse(responseCode = "404", description = "계정 복구 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "존재하지 않는 사용자", value = """
+                                        {
+                                              "code": "U000",
+                                              "message": "존재하지 않는 사용자입니다."
+                                          }
+                                    """),
+                    }))
+    })
+    ResponseEntity<?> restoreUser(@Valid @RequestBody RestoreDto.Request request);
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
@@ -110,9 +110,13 @@ public interface AuthApi {
                                     """),
                             @ExampleObject(name = "이미 탈퇴된 사용자", description = "탈퇴(Soft Delete)된 사용자에 대한 응답", value = """
                                         {
-                                             "code": "U003",
-                                             "message": "이미 회원탈퇴한 사용자입니다."
-                                         }
+                                              "code": "U003",
+                                              "message": "이미 회원탈퇴한 사용자입니다.",
+                                              "data": {
+                                                  "userId": 1,
+                                                  "deletionExpiration": "2025-08-13"
+                                              }
+                                          }
                                     """),
                             @ExampleObject(name = "인증 실패", description = "아이디 또는 비밀번호 불일치", value = """
                                         {

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
@@ -97,7 +97,7 @@ public interface AuthApi {
                                         }
                                     """)
                     })),
-            @ApiResponse(responseCode = "400", description = "유효성 검증 실패",
+            @ApiResponse(responseCode = "400", description = "로그인 실패",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(name = "유효성 검증 실패", value = """
                                         {
@@ -107,6 +107,18 @@ public interface AuthApi {
                                                  "username": "아이디는 필수 입력값입니다."
                                              }
                                         }
+                                    """),
+                            @ExampleObject(name = "이미 탈퇴된 사용자", description = "탈퇴(Soft Delete)된 사용자에 대한 응답", value = """
+                                        {
+                                             "code": "U003",
+                                             "message": "이미 회원탈퇴한 사용자입니다."
+                                         }
+                                    """),
+                            @ExampleObject(name = "인증 실패", description = "아이디 또는 비밀번호 불일치", value = """
+                                        {
+                                              "code": "A010",
+                                              "message": "로그인에 실패하였습니다. 아이디 또는 비밀번호를 확인해주세요."
+                                          }
                                     """)
                     }))
     })

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
@@ -55,7 +55,7 @@ public interface OAuthApi {
                                          }
                                     """)
                     })),
-            @ApiResponse(responseCode = "400", description = "유효성 검사 실패",
+            @ApiResponse(responseCode = "400", description = "로그인 실패",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(name = "인증 코드 유효성 검사 실패", value = """
                                         {
@@ -70,6 +70,12 @@ public interface OAuthApi {
                                             "code": "G003",
                                             "message": "지원하지 않는 Path Variable 값입니다."
                                         }
+                                    """),
+                            @ExampleObject(name = "이미 탈퇴한 사용자", description = "탈퇴(Soft Delete)된 사용자에 대한 응답", value = """
+                                        {
+                                             "code": "U003",
+                                             "message": "이미 회원탈퇴한 사용자입니다."
+                                         }
                                     """)
                     }))
     })
@@ -127,6 +133,12 @@ public interface OAuthApi {
                                             "code": "G003",
                                             "message": "지원하지 않는 Path Variable 값입니다."
                                         }
+                                    """),
+                            @ExampleObject(name = "이미 탈퇴한 사용자", description = "탈퇴(Soft Delete)된 사용자에 대한 응답", value = """
+                                        {
+                                             "code": "U003",
+                                             "message": "이미 회원탈퇴한 사용자입니다."
+                                         }
                                     """)
                     }))
     })

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
@@ -73,9 +73,13 @@ public interface OAuthApi {
                                     """),
                             @ExampleObject(name = "이미 탈퇴한 사용자", description = "탈퇴(Soft Delete)된 사용자에 대한 응답", value = """
                                         {
-                                             "code": "U003",
-                                             "message": "이미 회원탈퇴한 사용자입니다."
-                                         }
+                                              "code": "U003",
+                                              "message": "이미 회원탈퇴한 사용자입니다.",
+                                              "data": {
+                                                  "userId": 1,
+                                                  "deletionExpiration": "2025-08-13"
+                                              }
+                                          }
                                     """)
                     }))
     })
@@ -136,9 +140,13 @@ public interface OAuthApi {
                                     """),
                             @ExampleObject(name = "이미 탈퇴한 사용자", description = "탈퇴(Soft Delete)된 사용자에 대한 응답", value = """
                                         {
-                                             "code": "U003",
-                                             "message": "이미 회원탈퇴한 사용자입니다."
-                                         }
+                                              "code": "U003",
+                                              "message": "이미 회원탈퇴한 사용자입니다.",
+                                              "data": {
+                                                  "userId": 1,
+                                                  "deletionExpiration": "2025-08-13"
+                                              }
+                                          }
                                     """)
                     }))
     })

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.presentation.auth.controller;
 
 import jakarta.validation.Valid;
+import kr.co.yeogiga.application.auth.dto.RestoreDto;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
 import kr.co.yeogiga.application.auth.dto.SignUpDto;
 import kr.co.yeogiga.application.auth.dto.TokenDto;
@@ -19,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -104,5 +106,11 @@ public class AuthController implements AuthApi {
                 .code(HttpStatus.OK.value())
                 .message("사용 가능한 닉네임입니다.")
                 .build());
+    }
+    
+    @PutMapping("/restore")
+    public ResponseEntity<?> restoreUser(@Valid @RequestBody RestoreDto.Request request) {
+        authService.restoreUser(request.userId());
+        return ResponseEntity.ok(SuccessResponse.ok());
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
@@ -108,6 +108,7 @@ public class AuthController implements AuthApi {
                 .build());
     }
     
+    @Override
     @PutMapping("/restore")
     public ResponseEntity<?> restoreUser(@Valid @RequestBody RestoreDto.Request request) {
         authService.restoreUser(request.userId());

--- a/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
@@ -19,7 +19,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -261,6 +263,29 @@ public class AuthServiceTest {
 
             // then
             assertEquals(exception.getErrorType(), AuthErrorType.AUTHENTICATION_FAIL);
+        }
+        
+        @Test
+        @DisplayName("실패 - 이미 탈퇴(소프트 딜리트)한 사용자")
+        void failWhenDeletedUserSignIn() {
+            // given
+            User user = User.builder()
+                    .username("testid")
+                    .email("test@test.com")
+                    .nickname("testnick")
+                    .password("testpw")
+                    .build();
+            
+            ReflectionTestUtils.setField(user, "deletedAt", LocalDateTime.now());
+            
+            when(userService.readIncludeDeletedUserByUsername(request.username())).thenReturn(Optional.of(user));
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> authService.signIn(request));
+            
+            // then
+            assertEquals(UserErrorType.ALREADY_WITHDRAW, exception.getErrorType());
         }
     }
 

--- a/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
@@ -25,6 +25,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -349,6 +350,60 @@ public class AuthServiceTest {
 
             // then
             assertEquals(AuthErrorType.ALREADY_USED_NICKNAME, exception.getErrorType());
+        }
+    }
+    
+    @Nested
+    @DisplayName("계정 복구")
+    class RestoreUser {
+        private final Long userId = 1L;
+        private User user = User.builder()
+                .id(userId)
+                .username("username")
+                .nickname("nickname")
+                .password("password")
+                .build();
+        
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            ReflectionTestUtils.setField(user, "deletedAt", LocalDateTime.now());
+            when(userService.readIncludeDeletedUserById(userId)).thenReturn(Optional.of(user));
+            
+            // when
+            authService.restoreUser(userId);
+            
+            // then
+            assertThat(user.getDeletedAt()).isNull();
+        }
+        
+        @Test
+        @DisplayName("실패 - 존재하지 않는 유저")
+        void failIfUserNotFound() {
+            // given
+            when(userService.readIncludeDeletedUserById(userId)).thenReturn(Optional.empty());
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> authService.restoreUser(userId));
+            
+            // then
+            assertEquals(UserErrorType.NOT_FOUND, exception.getErrorType());
+        }
+        
+        @Test
+        @DisplayName("실패 - 탈퇴하지 않은 사용자")
+        void failIfNotWithdrawnUser() {
+            // given
+            when(userService.readIncludeDeletedUserById(userId)).thenReturn(Optional.of(user));
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> authService.restoreUser(userId));
+            
+            // then
+            assertEquals(AuthErrorType.NOT_WITHDRAWN, exception.getErrorType());
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
@@ -21,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -270,6 +271,7 @@ public class AuthServiceTest {
         void failWhenDeletedUserSignIn() {
             // given
             User user = User.builder()
+                    .id(1L)
                     .username("testid")
                     .email("test@test.com")
                     .nickname("testnick")
@@ -286,6 +288,9 @@ public class AuthServiceTest {
             
             // then
             assertEquals(UserErrorType.ALREADY_WITHDRAW, exception.getErrorType());
+            SignInDto.WithdrawnUserInfo withdrawnUserInfo = (SignInDto.WithdrawnUserInfo) exception.getData();
+            assertEquals(1L, withdrawnUserInfo.userId());
+            assertEquals(LocalDate.now().plusDays(7), withdrawnUserInfo.deletionExpiration());
         }
     }
 

--- a/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
@@ -13,6 +13,7 @@ import kr.co.yeogiga.common.response.error.type.CommonErrorType;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
 import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
+import kr.co.yeogiga.domain.user.exception.UserErrorType;
 import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -29,6 +30,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -461,6 +465,37 @@ public class AuthControllerTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value(AuthErrorType.AUTHENTICATION_FAIL.getCode()))
                     .andExpect(jsonPath("$.message").value(AuthErrorType.AUTHENTICATION_FAIL.getMessage()));;
+        }
+        
+        @Test
+        @DisplayName("실패 - 탈퇴한 사용자")
+        void failAlreadyWithdrawnUser() throws Exception {
+            // given
+            SignInDto.Request request = SignInDto.Request.builder()
+                    .username("testid")
+                    .password("testpw")
+                    .build();
+            
+            doThrow(new CustomException(
+                    UserErrorType.ALREADY_WITHDRAW,
+                    SignInDto.WithdrawnUserInfo.of(1L, LocalDateTime.now()))
+            ).when(authService).signIn(request);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/sign-in")
+                            .header("device", Device.WEB)
+                            .content(objectMapper.writeValueAsBytes(request))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(UserErrorType.ALREADY_WITHDRAW.getCode()))
+                    .andExpect(jsonPath("$.message").value(UserErrorType.ALREADY_WITHDRAW.getMessage()))
+                    .andExpect(jsonPath("$.data.userId").value(1L))
+                    .andExpect(jsonPath("$.data.deletionExpiration").value(LocalDate.now().plusDays(7).toString()));
         }
     }
 

--- a/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.presentation.auth.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
 import kr.co.yeogiga.application.auth.constant.AuthConstants;
+import kr.co.yeogiga.application.auth.dto.RestoreDto;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
 import kr.co.yeogiga.application.auth.dto.SignUpDto;
 import kr.co.yeogiga.application.auth.dto.TokenDto;
@@ -40,6 +41,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -587,5 +589,72 @@ public class AuthControllerTest {
                     .andExpect(jsonPath("$.code").value(AuthErrorType.ALREADY_USED_NICKNAME.getCode()))
                     .andExpect(jsonPath("$.message").value(AuthErrorType.ALREADY_USED_NICKNAME.getMessage()));
         }
+    }
+    
+    @Nested
+    @DisplayName("계정 복구")
+    class RestoreUser {
+        private final Long userId = 1L;
+        private RestoreDto.Request request = new RestoreDto.Request(userId);
+        
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            doNothing().when(authService).restoreUser(userId);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    put("/api/v1/auth/restore")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(SuccessResponse.ok().code()))
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
+        
+        @Test
+        @DisplayName("실패 - 탈퇴하지 않은 사용자")
+        void failIfUserNotWithdrawn() throws Exception {
+            // gvien
+            doThrow(new CustomException(AuthErrorType.NOT_WITHDRAWN)).when(authService).restoreUser(userId);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    put("/api/v1/auth/restore")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(AuthErrorType.NOT_WITHDRAWN.getCode()))
+                    .andExpect(jsonPath("$.message").value(AuthErrorType.NOT_WITHDRAWN.getMessage()));
+        }
+        
+        @Test
+        @DisplayName("실패 - 유효성 검증 실패")
+        void failValidation() throws Exception {
+            // given
+            RestoreDto.Request request = new RestoreDto.Request(null);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    put("/api/v1/auth/restore")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors.userId").exists());
+        }
+        
     }
 }


### PR DESCRIPTION
## 배경
- 탈퇴(soft delete) 사용자 로그인 시 별도의 계정 복구 과정 없이 바로 로그인 되는 것에 대한 모호성 인식

## 작업 사항
- 탈퇴 사용자 로그인 시 에러 응답
	- 일반 로그인 | (ae82fc1b2305d52d6951f0abbdecd02e37b39584) (3a5fe6285c39e062182e2bc36e2dc55e7e0e19d2)
	- 소셜 로그인 | (60a2a6ef380aba8526a3e2d28c2caeb99ad35976) (3a5fe6285c39e062182e2bc36e2dc55e7e0e19d2)
		- 2번째 커밋은 카톡으로 연락드렸던, "계정 복구 시 사용자 식별 정보 필요" 이유로 인하여 `ErrorResponse` 내 `data` 필드를 추가한 커밋입니다.
<br/>

- 계정 복구 로직 구현 | (2d5688e36e2a80dd252ce91bb39b2a9ca1202036)
	- 계정 복구 시 바로 토큰 발급을 해야하는지 고민하였지만 토큰 내 LoginType (소셜 or 일반)을 구분하여 넣어야하는 로직이 있어 그냥 계정 복구 후 성공 여부만 응답하도록 처리하였습니다. 따라서, 나중에 프론트에서 바로 로그인 페이지로 리다이렉트 되로록 요청하겠습니다.