### PR TITLE
Feature(IL-254): 전체 여행 조회 기능 로직 변경

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
@@ -134,13 +134,7 @@ public class TripQueryService {
      * @return              사용자가 속한 여행 목록
      */
     @Transactional(readOnly = true)
-    public List<TripDto.Summary> getAllTrip(Long userId, String status) {
-        TripStatus tripStatus = TripStatus.resolveStatus(status);
-        
-        if (Objects.isNull(tripStatus)) {
-            throw new CustomException(TripErrorType.NOT_SUPPORTED_TRIP_STATUS);
-        }
-        
+    public List<TripDto.Summary> getAllTrip(Long userId, TripStatus tripStatus) {
         if (tripStatus == TripStatus.ALL) {
             return tripMemberService.readAllTripSummaryByUserId(userId);
         } else {

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.application.trip.service;
 
 import kr.co.yeogiga.application.trip.dto.TripRes;
+import kr.co.yeogiga.application.trip.type.TripStatus;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.dto.TripDto;
@@ -20,6 +21,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -132,8 +134,19 @@ public class TripQueryService {
      * @return              사용자가 속한 여행 목록
      */
     @Transactional(readOnly = true)
-    public List<TripDto.Summary> getAllTrip(Long userId) {
-        return tripMemberService.readAllTripSummaryByUserId(userId);
+    public List<TripDto.Summary> getAllTrip(Long userId, String status) {
+        TripStatus tripStatus = TripStatus.resolveStatus(status);
+        
+        if (Objects.isNull(tripStatus)) {
+            throw new CustomException(TripErrorType.NOT_SUPPORTED_TRIP_STATUS);
+        }
+        
+        if (tripStatus == TripStatus.ALL) {
+            return tripMemberService.readAllTripSummaryByUserId(userId);
+        } else {
+            TravelStatus travelStatus = TravelStatus.valueOf(tripStatus.name());
+            return tripMemberService.readAllTripSummaryByUserId(userId, travelStatus);
+        }
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/application/trip/type/TripStatus.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/type/TripStatus.java
@@ -1,0 +1,26 @@
+package kr.co.yeogiga.application.trip.type;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum TripStatus {
+    SETTING,
+    PLANNED,
+    IN_PROGRESS,
+    COMPLETED,
+    ALL;
+    
+    public static TripStatus resolveStatus(String value) {
+        if (value == null) {
+            return ALL;
+        }
+        
+        for (TripStatus status : TripStatus.values()) {
+            if (status.name().equalsIgnoreCase(value)) {
+                return status;
+            }
+        }
+        
+        return null;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/trip/type/TripStatus.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/type/TripStatus.java
@@ -8,19 +8,5 @@ public enum TripStatus {
     PLANNED,
     IN_PROGRESS,
     COMPLETED,
-    ALL;
-    
-    public static TripStatus resolveStatus(String value) {
-        if (value == null) {
-            return ALL;
-        }
-        
-        for (TripStatus status : TripStatus.values()) {
-            if (status.name().equalsIgnoreCase(value)) {
-                return status;
-            }
-        }
-        
-        return null;
-    }
+    ALL
 }

--- a/src/main/java/kr/co/yeogiga/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/yeogiga/common/exception/GlobalExceptionHandler.java
@@ -9,6 +9,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
@@ -52,8 +54,15 @@ public class GlobalExceptionHandler {
     /* Path Variable 예외 처리 */
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     protected ResponseEntity<?> handleValidationException(final MethodArgumentTypeMismatchException e) {
+        BaseErrorType error = CommonErrorType.INTERNAL_SERVER_ERROR;;
+        
+        if (e.getParameter().hasParameterAnnotation(PathVariable.class)) {
+            error = CommonErrorType.PATH_VARIABLE_VALIDATION_ERROR;
+        } else if (e.getParameter().hasParameterAnnotation(RequestParam.class)) {
+            error = CommonErrorType.QUERY_STRING_VALIDATION_ERROR;
+        }
+        
         log.error("[Error Occurred] {}", e.getMessage());
-        BaseErrorType error = CommonErrorType.PATH_VARIABLE_VALIDATION_ERROR;
         return ResponseEntity.status(error.getHttpStatus()).body(ErrorResponse.from(error));
     }
 

--- a/src/main/java/kr/co/yeogiga/common/response/error/type/CommonErrorType.java
+++ b/src/main/java/kr/co/yeogiga/common/response/error/type/CommonErrorType.java
@@ -11,7 +11,8 @@ public enum CommonErrorType implements BaseErrorType {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G001", "서버 내부 에러입니다."),
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "G002", "유효성 검증에 실패하였습니다."),
     PATH_VARIABLE_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "G003", "지원하지 않는 Path Variable 값입니다."),
-    TIME_SHOULD_NOT_BEFORE_NOW(HttpStatus.BAD_REQUEST, "G004", "요청 시각은 현재 시각 이전이 될 수 없습니다.");
+    TIME_SHOULD_NOT_BEFORE_NOW(HttpStatus.BAD_REQUEST, "G004", "요청 시각은 현재 시각 이전이 될 수 없습니다."),
+    QUERY_STRING_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "G005", "지원하지 않는 Query String 값입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
@@ -23,7 +23,12 @@ public enum TripErrorType implements BaseErrorType {
     CALENDAR_ALREADY_EXISTS(HttpStatus.CONFLICT, "T010", "이미 가능한 날짜 정보가 등록되어 있습니다."),
 
     SAME_TRIP_TITLE(HttpStatus.CONFLICT, "T011", "기존과 동일한 여행 제목입니다."),
-    TRIP_ALREADY_STARTED_OR_COMPLETED(HttpStatus.CONFLICT, "T012", "이미 시작되었거나 완료된 여행은 수정할 수 없습니다.");
+    TRIP_ALREADY_STARTED_OR_COMPLETED(HttpStatus.CONFLICT, "T012", "이미 시작되었거나 완료된 여행은 수정할 수 없습니다."),
+    
+    NOT_SUPPORTED_TRIP_STATUS(HttpStatus.BAD_REQUEST, "T013", "지원하지 않는 여행 타입입니다.");
+    
+    
+    
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepository.java
@@ -1,11 +1,12 @@
 package kr.co.yeogiga.domain.trip.repository;
 
 import kr.co.yeogiga.domain.trip.dto.TripDto;
+import kr.co.yeogiga.domain.trip.type.TravelStatus;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface CustomTripMemberRepository {
     Optional<TripDto.Summary> findTripSummaryByTripId(Long tripId);
-    List<TripDto.Summary> findAllTripSummaryByUserId(Long userId);
+    List<TripDto.Summary> findAllTripSummaryByUserId(Long userId, TravelStatus travelStatus);
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepositoryImpl.java
@@ -2,11 +2,13 @@ package kr.co.yeogiga.domain.trip.repository;
 
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.co.yeogiga.domain.trip.dto.TripDto;
 import kr.co.yeogiga.domain.trip.entity.QTrip;
 import kr.co.yeogiga.domain.trip.entity.QTripMember;
 import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.type.TravelStatus;
 import kr.co.yeogiga.domain.user.entity.QUser;
 import lombok.RequiredArgsConstructor;
 
@@ -55,12 +57,15 @@ public class CustomTripMemberRepositoryImpl implements CustomTripMemberRepositor
     }
     
     @Override
-    public List<TripDto.Summary> findAllTripSummaryByUserId(Long userId) {
+    public List<TripDto.Summary> findAllTripSummaryByUserId(Long userId, TravelStatus status) {
         List<Trip> tripList = jpaQueryFactory
                 .select(trip)
                 .from(tripMember)
                 .join(tripMember.trip, trip)
-                .where(tripMember.user.id.eq(userId))
+                .where(
+                        tripMember.user.id.eq(userId),
+                        eqTravelStatus(status)
+                )
                 .fetch();
         
         if (tripList.isEmpty()) {
@@ -102,5 +107,15 @@ public class CustomTripMemberRepositoryImpl implements CustomTripMemberRepositor
                         trip,
                         memberInfoMap.getOrDefault(trip.getId(), List.of()))
                 ).toList();
+    }
+    
+    /**
+     * 여행 상태(TravelStatus) 일치 여부 조건 BooleanExpression 반환 메서드
+     *
+     * @param travelStatus  여행 상태
+     * @return              여행 상태 일치 여부 조건문
+     */
+    private BooleanExpression eqTravelStatus(TravelStatus travelStatus) {
+        return travelStatus == null ? null : trip.travelStatus.eq(travelStatus);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
@@ -4,6 +4,7 @@ import kr.co.yeogiga.domain.trip.dto.TripDto;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.entity.TripMember;
 import kr.co.yeogiga.domain.trip.repository.TripMemberRepository;
+import kr.co.yeogiga.domain.trip.type.TravelStatus;
 import kr.co.yeogiga.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,7 +30,11 @@ public class TripMemberService {
     }
     
     public List<TripDto.Summary> readAllTripSummaryByUserId(Long userId) {
-        return tripMemberRepository.findAllTripSummaryByUserId(userId);
+        return tripMemberRepository.findAllTripSummaryByUserId(userId, null);
+    }
+    
+    public List<TripDto.Summary> readAllTripSummaryByUserId(Long userId, TravelStatus status) {
+        return tripMemberRepository.findAllTripSummaryByUserId(userId, status);
     }
 
     public List<Trip> readAllSettingTripByUserId(Long userId) {

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @ApiGroup(value = "[여행 API]")
 @Tag(name = "[여행 API]", description = "여행 관련 API")
@@ -162,7 +163,7 @@ public interface TripApi {
             @PathVariable Long tripId);
 
     @TrackApi(description = "사용자가 속한 여행 조회")
-    @Operation(summary = "사용자가 속한 여행 조회", description = "사용자가 속한 여행 조회 API")
+    @Operation(summary = "사용자가 속한 여행 조회", description = "사용자가 속한 여행 조회 API | 여행 상태(All, SETTING, PLANNED, IN_PROGRESS, COMPLETED)에 따른 여행 요약 정보 리스트 반환")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "사용자가 속한 여행 조회 성공",
                     content = @Content(mediaType = "application/json", examples = {
@@ -260,9 +261,29 @@ public interface TripApi {
                                                  "data": []
                                              }
                                     """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "여행 조회 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "여행 상태 바인딩 실패", value = """
+                                             {
+                                                  "code": "T013",
+                                                  "message": "지원하지 않는 여행 타입입니다."
+                                              }
+                                    """)
                     }))
     })
-    ResponseEntity<?> getAllTrip(@AuthenticationPrincipal CustomUserDetailsImpl userDetails);
+    ResponseEntity<?> getAllTrip(
+            @Parameter(description = "여행 상태", examples = {
+                    @ExampleObject(name = "null", value = "null", description = "null 값 시 ALL로 간주"),
+                    @ExampleObject(name = "ALL", value = "ALL"),
+                    @ExampleObject(name = "SETTING", value = "SETTING"),
+                    @ExampleObject(name = "PLANNED", value = "PLANNED"),
+                    @ExampleObject(name = "IN_PROGRESS", value = "IN_PROGRESS"),
+                    @ExampleObject(name = "COMPLETED", value = "COMPLETED"),
+            })
+            @RequestParam(name = "status") String status,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails
+    );
 
     @TrackApi(description = "준비 중 여행 조회")
     @Operation(summary = "준비 중 여행 조회", description = "준비 중 여행 조회 API")

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.co.yeogiga.application.trip.dto.TripReq;
+import kr.co.yeogiga.application.trip.type.TripStatus;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -272,16 +273,9 @@ public interface TripApi {
                                     """)
                     }))
     })
-    ResponseEntity<?> getAllTrip(
-            @Parameter(description = "여행 상태", examples = {
-                    @ExampleObject(name = "null", value = "null", description = "null 값 시 ALL로 간주"),
-                    @ExampleObject(name = "ALL", value = "ALL"),
-                    @ExampleObject(name = "SETTING", value = "SETTING"),
-                    @ExampleObject(name = "PLANNED", value = "PLANNED"),
-                    @ExampleObject(name = "IN_PROGRESS", value = "IN_PROGRESS"),
-                    @ExampleObject(name = "COMPLETED", value = "COMPLETED"),
-            })
-            @RequestParam(name = "status") String status,
+    public ResponseEntity<?> getAllTrip(
+            @Parameter(description = "여행 상태")
+            @RequestParam(name = "status", required = false) TripStatus status,
             @AuthenticationPrincipal CustomUserDetailsImpl userDetails
     );
 

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -50,9 +51,12 @@ public class TripController implements TripApi {
 
     @Override
     @GetMapping
-    public ResponseEntity<?> getAllTrip(@AuthenticationPrincipal CustomUserDetailsImpl userDetails) {
-        List<TripDto.Summary> tripList = tripQueryService.getAllTrip(userDetails.getUserId());
-        return ResponseEntity.ok().body(SuccessResponse.from(tripList));
+    public ResponseEntity<?> getAllTrip(
+            @RequestParam(name = "status", required = false) String status,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails
+    ) {
+        List<TripDto.Summary> result = tripQueryService.getAllTrip(userDetails.getUserId(), status);
+        return ResponseEntity.ok().body(SuccessResponse.from(result));
     }
 
     @Override

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
@@ -5,6 +5,7 @@ import kr.co.yeogiga.application.trip.dto.TripReq;
 import kr.co.yeogiga.application.trip.dto.TripRes;
 import kr.co.yeogiga.application.trip.service.TripCommandService;
 import kr.co.yeogiga.application.trip.service.TripQueryService;
+import kr.co.yeogiga.application.trip.type.TripStatus;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.domain.trip.dto.TripDto;
@@ -52,7 +53,7 @@ public class TripController implements TripApi {
     @Override
     @GetMapping
     public ResponseEntity<?> getAllTrip(
-            @RequestParam(name = "status", required = false) String status,
+            @RequestParam(name = "status", required = false) TripStatus status,
             @AuthenticationPrincipal CustomUserDetailsImpl userDetails
     ) {
         List<TripDto.Summary> result = tripQueryService.getAllTrip(userDetails.getUserId(), status);

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
@@ -206,36 +206,126 @@ public class TripQueryServiceTest {
     @DisplayName("전체 여행 목록 조회")
     class GetAllTrip {
         private final Long userId = 1L;
-
-        private TripDto.MemberInfo member = TripDto.MemberInfo.builder()
-                .userId(userId)
-                .nickname("nickname")
-                .imageUrl("https://image.com")
-                .build();
         
-        private List<TripDto.MemberInfo> members = List.of(member);
+        public TripDto.Summary generateTripSummary(TravelStatus travelStatus) {
+            TripDto.MemberInfo member = TripDto.MemberInfo.builder()
+                    .userId(userId)
+                    .nickname("nickname")
+                    .imageUrl("https://image.com")
+                    .build();
+            
+            List<TripDto.MemberInfo> members = List.of(member);
+            
+            return TripDto.Summary.builder()
+                    .tripId(1L)
+                    .title("졸업여행")
+                    .city("대구")
+                    .leaderId(userId)
+                    .startedAt(LocalDateTime.now())
+                    .endedAt(LocalDateTime.now().plusDays(7))
+                    .status(travelStatus)
+                    .members(members)
+                    .build();
+        }
         
-        private TripDto.Summary tripSummary = TripDto.Summary.builder()
-                .tripId(1L)
-                .title("졸업여행")
-                .city("대구")
-                .leaderId(userId)
-                .startedAt(LocalDateTime.of(2025, 7, 20, 12, 0))
-                .endedAt(LocalDateTime.of(2025, 7, 30, 12, 0))
-                .status(TravelStatus.PLANNED)
-                .members(members)
-                .build();
-
-
         @Test
-        @DisplayName("성공")
-        void success() {
+        @DisplayName("성공 - status가 null인 경우 전체 조회")
+        void successGetAllTripWhenStatusIsNull() {
             // given
-            when(tripMemberService.readAllTripSummaryByUserId(anyLong())).thenReturn(List.of(tripSummary));
+            TripDto.Summary trip1 = generateTripSummary(TravelStatus.SETTING);
+            TripDto.Summary trip2 = generateTripSummary(TravelStatus.PLANNED);
+            TripDto.Summary trip3 = generateTripSummary(TravelStatus.IN_PROGRESS);
+            TripDto.Summary trip4 = generateTripSummary(TravelStatus.COMPLETED);
+            
+            when(tripMemberService.readAllTripSummaryByUserId(userId))
+                    .thenReturn(List.of(trip1, trip2, trip3, trip4));
 
             // when
-            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId);
+            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, null);
 
+            // then
+            assertThat(result).hasSize(4);
+        }
+        
+        @Test
+        @DisplayName("성공 - status가 ALL인 경우 전체 조회")
+        void successGetAllTripWhenStatusIsALL() {
+            // given
+            TripDto.Summary trip1 = generateTripSummary(TravelStatus.SETTING);
+            TripDto.Summary trip2 = generateTripSummary(TravelStatus.PLANNED);
+            TripDto.Summary trip3 = generateTripSummary(TravelStatus.IN_PROGRESS);
+            TripDto.Summary trip4 = generateTripSummary(TravelStatus.COMPLETED);
+            
+            when(tripMemberService.readAllTripSummaryByUserId(userId))
+                    .thenReturn(List.of(trip1, trip2, trip3, trip4));
+            
+            // when
+            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, "all");
+            
+            // then
+            assertThat(result).hasSize(4);
+        }
+        
+        @Test
+        @DisplayName("성공 - status가 Setting인 경우 전체 조회")
+        void successGetAllTripWhenStatusIsSetting() {
+            // given
+            TripDto.Summary trip1 = generateTripSummary(TravelStatus.SETTING);
+            
+            when(tripMemberService.readAllTripSummaryByUserId(userId, TravelStatus.SETTING))
+                    .thenReturn(List.of(trip1));
+            
+            // when
+            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, "setting");
+            
+            // then
+            assertThat(result).hasSize(1);
+        }
+        
+        @Test
+        @DisplayName("성공 - status가 Planned인 경우 전체 조회")
+        void successGetAllTripWhenStatusIsPlanned() {
+            // give
+            TripDto.Summary trip1 = generateTripSummary(TravelStatus.PLANNED);
+            
+            when(tripMemberService.readAllTripSummaryByUserId(userId, TravelStatus.PLANNED))
+                    .thenReturn(List.of(trip1));
+            
+            // when
+            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, "planned");
+            
+            // then
+            assertThat(result).hasSize(1);
+        }
+        
+        @Test
+        @DisplayName("성공 - status가 In_Progress인 경우 전체 조회")
+        void successGetAllTripWhenStatusISInProgress() {
+            // give
+            TripDto.Summary trip1 = generateTripSummary(TravelStatus.IN_PROGRESS);
+            
+            when(tripMemberService.readAllTripSummaryByUserId(userId, TravelStatus.IN_PROGRESS))
+                    .thenReturn(List.of(trip1));
+            
+            // when
+            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, "in_progress");
+            
+            // then
+            assertThat(result).hasSize(1);
+        }
+        
+        @Test
+        @DisplayName("성공 - status가 COMPLETED인 경우 전체 조회")
+        void successGetAllTripWhenStatusISInCOMPLETED() {
+            // give
+            TripDto.Summary trip1 = generateTripSummary(TravelStatus.COMPLETED);
+            
+            when(tripMemberService.readAllTripSummaryByUserId(userId, TravelStatus.COMPLETED))
+                    .thenReturn(List.of(trip1));
+            
+            // when
+            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, "completed");
+            
             // then
             assertThat(result).hasSize(1);
         }
@@ -247,10 +337,21 @@ public class TripQueryServiceTest {
             when(tripMemberService.readAllTripSummaryByUserId(userId)).thenReturn(List.of());
 
             // when
-            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId);
+            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, null);
 
             // then
             assertThat(result).hasSize(0);
+        }
+        
+        @Test
+        @DisplayName("실패 - tripStatus 값 바인딩 불가")
+        void failIfTripStatusCanNotBinding() {
+            // given & when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> tripQueryService.getAllTrip(userId, "fakeValue"));
+            
+            // then
+            assertEquals(TripErrorType.NOT_SUPPORTED_TRIP_STATUS, exception.getErrorType());
         }
     }
 

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.application.trip.service;
 
 import kr.co.yeogiga.application.trip.dto.TripRes;
+import kr.co.yeogiga.application.trip.type.TripStatus;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.dto.TripDto;
 import kr.co.yeogiga.domain.trip.entity.Trip;
@@ -229,25 +230,6 @@ public class TripQueryServiceTest {
         }
         
         @Test
-        @DisplayName("성공 - status가 null인 경우 전체 조회")
-        void successGetAllTripWhenStatusIsNull() {
-            // given
-            TripDto.Summary trip1 = generateTripSummary(TravelStatus.SETTING);
-            TripDto.Summary trip2 = generateTripSummary(TravelStatus.PLANNED);
-            TripDto.Summary trip3 = generateTripSummary(TravelStatus.IN_PROGRESS);
-            TripDto.Summary trip4 = generateTripSummary(TravelStatus.COMPLETED);
-            
-            when(tripMemberService.readAllTripSummaryByUserId(userId))
-                    .thenReturn(List.of(trip1, trip2, trip3, trip4));
-
-            // when
-            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, null);
-
-            // then
-            assertThat(result).hasSize(4);
-        }
-        
-        @Test
         @DisplayName("성공 - status가 ALL인 경우 전체 조회")
         void successGetAllTripWhenStatusIsALL() {
             // given
@@ -260,7 +242,7 @@ public class TripQueryServiceTest {
                     .thenReturn(List.of(trip1, trip2, trip3, trip4));
             
             // when
-            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, "all");
+            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, TripStatus.ALL);
             
             // then
             assertThat(result).hasSize(4);
@@ -276,7 +258,7 @@ public class TripQueryServiceTest {
                     .thenReturn(List.of(trip1));
             
             // when
-            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, "setting");
+            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, TripStatus.SETTING);
             
             // then
             assertThat(result).hasSize(1);
@@ -292,7 +274,7 @@ public class TripQueryServiceTest {
                     .thenReturn(List.of(trip1));
             
             // when
-            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, "planned");
+            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, TripStatus.PLANNED);
             
             // then
             assertThat(result).hasSize(1);
@@ -308,14 +290,14 @@ public class TripQueryServiceTest {
                     .thenReturn(List.of(trip1));
             
             // when
-            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, "in_progress");
+            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, TripStatus.IN_PROGRESS);
             
             // then
             assertThat(result).hasSize(1);
         }
         
         @Test
-        @DisplayName("성공 - status가 COMPLETED인 경우 전체 조회")
+        @DisplayName("성공 - status가 Completed인 경우 전체 조회")
         void successGetAllTripWhenStatusISInCOMPLETED() {
             // give
             TripDto.Summary trip1 = generateTripSummary(TravelStatus.COMPLETED);
@@ -324,7 +306,7 @@ public class TripQueryServiceTest {
                     .thenReturn(List.of(trip1));
             
             // when
-            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, "completed");
+            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, TripStatus.COMPLETED);
             
             // then
             assertThat(result).hasSize(1);
@@ -337,21 +319,10 @@ public class TripQueryServiceTest {
             when(tripMemberService.readAllTripSummaryByUserId(userId)).thenReturn(List.of());
 
             // when
-            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, null);
+            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, TripStatus.ALL);
 
             // then
             assertThat(result).hasSize(0);
-        }
-        
-        @Test
-        @DisplayName("실패 - tripStatus 값 바인딩 불가")
-        void failIfTripStatusCanNotBinding() {
-            // given & when
-            CustomException exception = assertThrows(CustomException.class, ()
-                    -> tripQueryService.getAllTrip(userId, "fakeValue"));
-            
-            // then
-            assertEquals(TripErrorType.NOT_SUPPORTED_TRIP_STATUS, exception.getErrorType());
         }
     }
 

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
@@ -5,8 +5,10 @@ import kr.co.yeogiga.application.trip.dto.TripReq;
 import kr.co.yeogiga.application.trip.dto.TripRes;
 import kr.co.yeogiga.application.trip.service.TripCommandService;
 import kr.co.yeogiga.application.trip.service.TripQueryService;
+import kr.co.yeogiga.application.trip.type.TripStatus;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
 import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.common.response.error.type.CommonErrorType;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
@@ -377,12 +379,12 @@ public class TripControllerTest {
                                     .build()))
                     .build();
 
-            when(tripQueryService.getAllTrip(anyLong(), anyString())).thenReturn(List.of(tripSummary));
+            when(tripQueryService.getAllTrip(anyLong(), any(TripStatus.class))).thenReturn(List.of(tripSummary));
 
             // when
             ResultActions resultActions = mockMvc.perform(
                     get("/api/v1/trip")
-                            .queryParam("status", "all")
+                            .queryParam("status", "ALL")
                             .with(user(userDetails))
             );
 
@@ -395,13 +397,9 @@ public class TripControllerTest {
         }
         
         @Test
-        @DisplayName("실패 - TripStatus 바인딩 불가")
+        @DisplayName("실패 - 미지원 TripStatus 입력")
         void failTripStatusCanNotBinding() throws Exception {
-            // given
-            doThrow(new CustomException(TripErrorType.NOT_SUPPORTED_TRIP_STATUS))
-                    .when(tripQueryService).getAllTrip(anyLong(), anyString());
-            
-            // when
+            // given & when
             ResultActions resultActions = mockMvc.perform(
                     get("/api/v1/trip")
                             .queryParam("status", "fakeValue")
@@ -411,8 +409,8 @@ public class TripControllerTest {
             // then
             resultActions
                     .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.code").value(TripErrorType.NOT_SUPPORTED_TRIP_STATUS.getCode()))
-                    .andExpect(jsonPath("$.message").value(TripErrorType.NOT_SUPPORTED_TRIP_STATUS.getMessage()));
+                    .andExpect(jsonPath("$.code").value(CommonErrorType.QUERY_STRING_VALIDATION_ERROR.getCode()))
+                    .andExpect(jsonPath("$.message").value(CommonErrorType.QUERY_STRING_VALIDATION_ERROR.getMessage()));
         }
     }
 

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
@@ -40,6 +40,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
@@ -375,11 +377,12 @@ public class TripControllerTest {
                                     .build()))
                     .build();
 
-            when(tripQueryService.getAllTrip(any())).thenReturn(List.of(tripSummary));
+            when(tripQueryService.getAllTrip(anyLong(), anyString())).thenReturn(List.of(tripSummary));
 
             // when
             ResultActions resultActions = mockMvc.perform(
                     get("/api/v1/trip")
+                            .queryParam("status", "all")
                             .with(user(userDetails))
             );
 
@@ -389,6 +392,27 @@ public class TripControllerTest {
                     .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()))
                     .andExpect(jsonPath("$.data").isArray())
                     .andExpect(jsonPath("$.data[0].members").isArray());
+        }
+        
+        @Test
+        @DisplayName("실패 - TripStatus 바인딩 불가")
+        void failTripStatusCanNotBinding() throws Exception {
+            // given
+            doThrow(new CustomException(TripErrorType.NOT_SUPPORTED_TRIP_STATUS))
+                    .when(tripQueryService).getAllTrip(anyLong(), anyString());
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip")
+                            .queryParam("status", "fakeValue")
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(TripErrorType.NOT_SUPPORTED_TRIP_STATUS.getCode()))
+                    .andExpect(jsonPath("$.message").value(TripErrorType.NOT_SUPPORTED_TRIP_STATUS.getMessage()));
         }
     }
 


### PR DESCRIPTION
## 배경
- 여행 상태에 따른 여행 조회 기능 필요 (지난 여행 조회 등)
	⇒ 전체 여행 조회 api 변경: 쿼리 파라미터를 통한 여행 상태 전달 및 여행 상태에 따른 조회 데이터 변경

## 작업 사항
- 사용자가 속한 전체 여행 조회 도메인 로직 변경 | (48ada7ec4737e880fd4f9293db0d71b5a3d58c69)
	- QueryDsl의 동적 쿼리를 이용하여 `TravelStatus`에 따른 조회 쿼리 조건문 동적 생성

- 전체 여행 조회 로직 변경 | (641547d471032251780ef8568e0fa5df6b287b38)
	- 사용자가 쿼리 파라미터로 보낸 `TripStatus`에 따른 조회 메서드 분리
		- 대소문자 구분 X
		- `ALL` or `null` : 전체 여행 조회
		- `SETTING` : Setting 상태 여행 조회
		- `PLANNED` : Planned 상태 여행 조회
		- `IN_PROGRESS`: In_Progress 상태 여행 조회
		- `Completed`: Completed 상태 여행 조회

## 추가 논의
- 페이지네이션도 적용하려 하였으니 해당 PR 크기를 고려하여 다음 PR에서 작업하도록 하겠습니다.