### PR TITLE
Feature(IL-262): 여행 전체 조회 로직 페이지네이션 추가

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
@@ -12,6 +12,8 @@ import kr.co.yeogiga.domain.trip.type.TravelStatus;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,7 +23,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -134,12 +135,12 @@ public class TripQueryService {
      * @return              사용자가 속한 여행 목록
      */
     @Transactional(readOnly = true)
-    public List<TripDto.Summary> getAllTrip(Long userId, TripStatus tripStatus) {
+    public Page<TripDto.Summary> getAllTrip(Long userId, TripStatus tripStatus, Pageable pageable) {
         if (tripStatus == TripStatus.ALL) {
-            return tripMemberService.readAllTripSummaryByUserId(userId);
+            return tripMemberService.readAllTripSummaryByUserId(userId, pageable);
         } else {
             TravelStatus travelStatus = TravelStatus.valueOf(tripStatus.name());
-            return tripMemberService.readAllTripSummaryByUserId(userId, travelStatus);
+            return tripMemberService.readAllTripSummaryByUserId(userId, travelStatus, pageable);
         }
     }
 

--- a/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/trip/service/TripQueryService.java
@@ -136,7 +136,8 @@ public class TripQueryService {
      */
     @Transactional(readOnly = true)
     public Page<TripDto.Summary> getAllTrip(Long userId, TripStatus tripStatus, Pageable pageable) {
-        if (tripStatus == TripStatus.ALL) {
+        // TODO: 기존 프론트엔드 API 호환성을 위한 null 값 처리 유지. 차후 프론트 API 호출 로직 변경 시 null값 처리 삭제 예정
+        if (tripStatus == TripStatus.ALL || tripStatus == null) {
             return tripMemberService.readAllTripSummaryByUserId(userId, pageable);
         } else {
             TravelStatus travelStatus = TravelStatus.valueOf(tripStatus.name());

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepository.java
@@ -2,11 +2,12 @@ package kr.co.yeogiga.domain.trip.repository;
 
 import kr.co.yeogiga.domain.trip.dto.TripDto;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface CustomTripMemberRepository {
     Optional<TripDto.Summary> findTripSummaryByTripId(Long tripId);
-    List<TripDto.Summary> findAllTripSummaryByUserId(Long userId, TravelStatus travelStatus);
+    Page<TripDto.Summary> findAllTripSummaryByUserId(Long userId, TravelStatus travelStatus, Pageable pageable);
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/CustomTripMemberRepositoryImpl.java
@@ -1,8 +1,13 @@
 package kr.co.yeogiga.domain.trip.repository;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.co.yeogiga.domain.trip.dto.TripDto;
 import kr.co.yeogiga.domain.trip.entity.QTrip;
@@ -11,8 +16,10 @@ import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
 import kr.co.yeogiga.domain.user.entity.QUser;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -57,7 +64,7 @@ public class CustomTripMemberRepositoryImpl implements CustomTripMemberRepositor
     }
     
     @Override
-    public List<TripDto.Summary> findAllTripSummaryByUserId(Long userId, TravelStatus status) {
+    public Page<TripDto.Summary> findAllTripSummaryByUserId(Long userId, TravelStatus status, Pageable pageable) {
         List<Trip> tripList = jpaQueryFactory
                 .select(trip)
                 .from(tripMember)
@@ -66,10 +73,13 @@ public class CustomTripMemberRepositoryImpl implements CustomTripMemberRepositor
                         tripMember.user.id.eq(userId),
                         eqTravelStatus(status)
                 )
+                .orderBy(getOrderSpecifiers(status))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
         
         if (tripList.isEmpty()) {
-            return Collections.emptyList();
+            return Page.empty();
         }
         
         List<Long> tripIds = tripList.stream()
@@ -102,11 +112,22 @@ public class CustomTripMemberRepositoryImpl implements CustomTripMemberRepositor
                         )
                 ));
         
-        return tripList.stream()
+        List<TripDto.Summary> tripSummaries = tripList.stream()
                 .map(trip -> TripDto.Summary.from(
                         trip,
                         memberInfoMap.getOrDefault(trip.getId(), List.of()))
                 ).toList();
+        
+        JPAQuery<Long> count = jpaQueryFactory
+                .select(trip.count())
+                .from(tripMember)
+                .join(tripMember.trip, trip)
+                .where(
+                        tripMember.user.id.eq(userId),
+                        eqTravelStatus(status)
+                );
+        
+        return PageableExecutionUtils.getPage(tripSummaries, pageable, count::fetchOne);
     }
     
     /**
@@ -117,5 +138,29 @@ public class CustomTripMemberRepositoryImpl implements CustomTripMemberRepositor
      */
     private BooleanExpression eqTravelStatus(TravelStatus travelStatus) {
         return travelStatus == null ? null : trip.travelStatus.eq(travelStatus);
+    }
+    
+    /**
+     * 여행 상태를 바탕으로 정렬 기준을 제공하는 메서드
+     * - 전체: 시작 일자 내림차순, null 값 우선 배치
+     * - SETTING, PLANNED, IN_PROGRESS: 시작 일자 오름차순, null 값 후순위 배치
+     * - COMPLETED: 종료 일자 내림차순, null 값 후순위 배치
+     *
+     * @param travelStatus  여행 상태
+     * @return              상태별 정렬 기준을 담은 OrderSpecifier 객체
+     */
+    private OrderSpecifier getOrderSpecifiers(TravelStatus travelStatus) {
+        Path<Object> target = Expressions.path(Object.class, trip.startedAt.getMetadata().getName());
+        
+        if (travelStatus == null) {
+            return new OrderSpecifier(Order.DESC, target, OrderSpecifier.NullHandling.NullsFirst);
+        } else if (travelStatus == TravelStatus.SETTING || travelStatus == TravelStatus.PLANNED || travelStatus== TravelStatus.IN_PROGRESS) {
+            return new OrderSpecifier(Order.ASC, target, OrderSpecifier.NullHandling.NullsLast);
+        } else if (travelStatus == TravelStatus.COMPLETED) {
+            target = Expressions.path(Object.class, trip, trip.endedAt.getMetadata().getName());
+            return new OrderSpecifier(Order.DESC, target, OrderSpecifier.NullHandling.NullsLast);
+        } else {
+            return null;
+        }
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
@@ -7,6 +7,8 @@ import kr.co.yeogiga.domain.trip.repository.TripMemberRepository;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
 import kr.co.yeogiga.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -29,12 +31,12 @@ public class TripMemberService {
         return tripMemberRepository.findTripSummaryByTripId(tripId);
     }
     
-    public List<TripDto.Summary> readAllTripSummaryByUserId(Long userId) {
-        return tripMemberRepository.findAllTripSummaryByUserId(userId, null);
+    public Page<TripDto.Summary> readAllTripSummaryByUserId(Long userId, Pageable pageable) {
+        return tripMemberRepository.findAllTripSummaryByUserId(userId, null, pageable);
     }
     
-    public List<TripDto.Summary> readAllTripSummaryByUserId(Long userId, TravelStatus status) {
-        return tripMemberRepository.findAllTripSummaryByUserId(userId, status);
+    public Page<TripDto.Summary> readAllTripSummaryByUserId(Long userId, TravelStatus status, Pageable pageable) {
+        return tripMemberRepository.findAllTripSummaryByUserId(userId, status, pageable);
     }
 
     public List<Trip> readAllSettingTripByUserId(Long userId) {

--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripApi.java
@@ -13,6 +13,8 @@ import jakarta.validation.Valid;
 import kr.co.yeogiga.application.trip.dto.TripReq;
 import kr.co.yeogiga.application.trip.type.TripStatus;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -168,99 +170,302 @@ public interface TripApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "사용자가 속한 여행 조회 성공",
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(name = "조회 성공", value = """
+                            @ExampleObject(name = "조회 성공 - 전체", value = """
                                              {
-                                                   "code": 200,
-                                                   "message": "요청이 성공하였습니다.",
-                                                   "data": [
-                                                       {
-                                                           "tripId": 1,
-                                                           "title": "새로운 여행1",
-                                                           "city": "경주시",
-                                                           "leaderId": 2,
-                                                           "startedAt": "2025-05-01T12:00:00",
-                                                           "endedAt": "2025-05-02T12:01:00",
-                                                           "status": "COMPLETED",
-                                                           "members": [
+                                                    "code": 200,
+                                                    "message": "요청이 성공하였습니다.",
+                                                    "data": {
+                                                        "content": [
+                                                            {
+                                                                "tripId": 1,
+                                                                "title": "여행1",
+                                                                "city": null,
+                                                                "leaderId": 15,
+                                                                "startedAt": null,
+                                                                "endedAt": null,
+                                                                "status": "SETTING",
+                                                                "members": [
+                                                                    {
+                                                                        "userId": 15,
+                                                                        "nickname": "nick15",
+                                                                        "imageUrl": "https://image.com/image"
+                                                                    },
+                                                                    {
+                                                                        "userId": 14,
+                                                                        "nickname": "nick14",
+                                                                        "imageUrl": null
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "tripId": 3,
+                                                                "title": "여행3",
+                                                                "city": null,
+                                                                "leaderId": 15,
+                                                                "startedAt": null,
+                                                                "endedAt": null,
+                                                                "status": "COMPLETED",
+                                                                "members": [
+                                                                    {
+                                                                        "userId": 15,
+                                                                        "nickname": "nick15",
+                                                                        "imageUrl": "https://image.com/image"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "tripId": 7,
+                                                                "title": "여행6",
+                                                                "city": null,
+                                                                "leaderId": 15,
+                                                                "startedAt": "2025-09-14T12:51:36",
+                                                                "endedAt": "2025-09-18T12:51:40",
+                                                                "status": "PLANNED",
+                                                                "members": [
+                                                                    {
+                                                                        "userId": 15,
+                                                                        "nickname": "nick15",
+                                                                        "imageUrl": "https://image.com/image"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "tripId": 2,
+                                                                "title": "여행2",
+                                                                "city": null,
+                                                                "leaderId": 15,
+                                                                "startedAt": "2025-08-17T12:52:26",
+                                                                "endedAt": "2025-08-23T12:52:40",
+                                                                "status": "SETTING",
+                                                                "members": [
+                                                                    {
+                                                                        "userId": 15,
+                                                                        "nickname": "nick15",
+                                                                        "imageUrl": "https://image.com/image"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "tripId": 6,
+                                                                "title": "여행6",
+                                                                "city": null,
+                                                                "leaderId": 15,
+                                                                "startedAt": "2025-08-16T12:51:14",
+                                                                "endedAt": "2025-08-20T12:51:21",
+                                                                "status": "PLANNED",
+                                                                "members": [
+                                                                    {
+                                                                        "userId": 15,
+                                                                        "nickname": "nick15",
+                                                                        "imageUrl": "https://image.com/image"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ],
+                                                        "page": {
+                                                            "size": 5,
+                                                            "number": 0,
+                                                            "totalElements": 7,
+                                                            "totalPages": 2
+                                                        }
+                                                    }
+                                                }
+                                    """),
+                            @ExampleObject(name = "조회 성공 - SETTING", value = """
+                                             {
+                                                     "code": 200,
+                                                     "message": "요청이 성공하였습니다.",
+                                                     "data": {
+                                                         "content": [
+                                                             {
+                                                                 "tripId": 2,
+                                                                 "title": "여행2",
+                                                                 "city": null,
+                                                                 "leaderId": 15,
+                                                                 "startedAt": "2025-08-17T12:52:26",
+                                                                 "endedAt": "2025-08-23T12:52:40",
+                                                                 "status": "SETTING",
+                                                                 "members": [
+                                                                     {
+                                                                         "userId": 15,
+                                                                         "nickname": "nick15",
+                                                                         "imageUrl": "https://image.com/image"
+                                                                     }
+                                                                 ]
+                                                             },
+                                                             {
+                                                                 "tripId": 1,
+                                                                 "title": "여행1",
+                                                                 "city": null,
+                                                                 "leaderId": 15,
+                                                                 "startedAt": null,
+                                                                 "endedAt": null,
+                                                                 "status": "SETTING",
+                                                                 "members": [
+                                                                     {
+                                                                         "userId": 15,
+                                                                         "nickname": "nick15",
+                                                                         "imageUrl": "https://image.com/image"
+                                                                     },
+                                                                     {
+                                                                         "userId": 14,
+                                                                         "nickname": "nick14",
+                                                                         "imageUrl": null
+                                                                     }
+                                                                 ]
+                                                             }
+                                                         ],
+                                                         "page": {
+                                                             "size": 5,
+                                                             "number": 0,
+                                                             "totalElements": 2,
+                                                             "totalPages": 1
+                                                         }
+                                                     }
+                                                 }
+                                    """),
+                            @ExampleObject(name = "조회 성공 - PLANNED", value = """
+                                             {
+                                                      "code": 200,
+                                                      "message": "요청이 성공하였습니다.",
+                                                      "data": {
+                                                          "content": [
+                                                              {
+                                                                  "tripId": 6,
+                                                                  "title": "여행6",
+                                                                  "city": null,
+                                                                  "leaderId": 15,
+                                                                  "startedAt": "2025-08-16T12:51:14",
+                                                                  "endedAt": "2025-08-20T12:51:21",
+                                                                  "status": "PLANNED",
+                                                                  "members": [
+                                                                      {
+                                                                          "userId": 15,
+                                                                          "nickname": "nick15",
+                                                                          "imageUrl": "https://image.com/image"
+                                                                      }
+                                                                  ]
+                                                              },
+                                                              {
+                                                                  "tripId": 7,
+                                                                  "title": "여행6",
+                                                                  "city": null,
+                                                                  "leaderId": 15,
+                                                                  "startedAt": "2025-09-14T12:51:36",
+                                                                  "endedAt": "2025-09-18T12:51:40",
+                                                                  "status": "PLANNED",
+                                                                  "members": [
+                                                                      {
+                                                                          "userId": 15,
+                                                                          "nickname": "nick15",
+                                                                          "imageUrl": "https://image.com/image"
+                                                                      }
+                                                                  ]
+                                                              }
+                                                          ],
+                                                          "page": {
+                                                              "size": 5,
+                                                              "number": 0,
+                                                              "totalElements": 2,
+                                                              "totalPages": 1
+                                                          }
+                                                      }
+                                                  }
+                                    """),
+                            @ExampleObject(name = "조회 성공 - IN_PROGRESS", value = """
+                                             {
+                                                       "code": 200,
+                                                       "message": "요청이 성공하였습니다.",
+                                                       "data": {
+                                                           "content": [
                                                                {
-                                                                   "userId": 1,
-                                                                   "nickname": "nick3",
-                                                                   "imageUrl": null
-                                                               },
-                                                               {
-                                                                   "userId": 2,
-                                                                   "nickname": "nick",
-                                                                   "imageUrl": null
-                                                               },
-                                                               {
-                                                                   "userId": 3,
-                                                                   "nickname": "nick2",
-                                                                   "imageUrl": null
-                                                               },
-                                                               {
-                                                                   "userId": 4,
-                                                                   "nickname": "testNick",
-                                                                   "imageUrl": null
+                                                                   "tripId": 4,
+                                                                   "title": "여행4",
+                                                                   "city": null,
+                                                                   "leaderId": 15,
+                                                                   "startedAt": "2025-08-13T12:30:54",
+                                                                   "endedAt": "2025-08-20T12:31:08",
+                                                                   "status": "IN_PROGRESS",
+                                                                   "members": [
+                                                                       {
+                                                                           "userId": 15,
+                                                                           "nickname": "nick15",
+                                                                           "imageUrl": "https://image.com/image"
+                                                                       }
+                                                                   ]
                                                                }
-                                                           ]
-                                                       },
-                                                       {
-                                                           "tripId": 2,
-                                                           "title": "여행2",
-                                                           "city": "대구광역시",
-                                                           "leaderId": 2,
-                                                           "startedAt": "2025-05-01T12:00:00",
-                                                           "endedAt": "2025-05-02T12:01:00",
-                                                           "status": "COMPLETED",
-                                                           "members": [
-                                                               {
-                                                                   "userId": 2,
-                                                                   "nickname": "nick",
-                                                                   "imageUrl": null
-                                                               }
-                                                           ]
-                                                       },
-                                                       {
-                                                           "tripId": 3,
-                                                           "title": "여행3",
-                                                           "city": "부산광역시",
-                                                           "leaderId": 2,
-                                                           "startedAt": "2025-05-01T12:00:00",
-                                                           "endedAt": "2025-05-02T12:01:00",
-                                                           "status": "COMPLETED",
-                                                           "members": [
-                                                               {
-                                                                   "userId": 2,
-                                                                   "nickname": "nick",
-                                                                   "imageUrl": null
-                                                               }
-                                                           ]
-                                                       },
-                                                       {
-                                                           "tripId": 4,
-                                                           "title": "여행4",
-                                                           "city": "가평",
-                                                           "leaderId": 2,
-                                                           "startedAt": "2025-05-17T12:00:00",
-                                                           "endedAt": "2025-05-25T12:01:00",
-                                                           "status": "IN_PROGRESS",
-                                                           "members": [
-                                                               {
-                                                                   "userId": 2,
-                                                                   "nickname": "nick",
-                                                                   "imageUrl": null
-                                                               }
-                                                           ]
+                                                           ],
+                                                           "page": {
+                                                               "size": 5,
+                                                               "number": 0,
+                                                               "totalElements": 1,
+                                                               "totalPages": 1
+                                                           }
                                                        }
-                                                   ]
-                                               }
+                                                   }
+                                    """),
+                            @ExampleObject(name = "조회 성공 - COMPLETED", value = """
+                                             {
+                                                        "code": 200,
+                                                        "message": "요청이 성공하였습니다.",
+                                                        "data": {
+                                                            "content": [
+                                                                {
+                                                                    "tripId": 5,
+                                                                    "title": "여행5",
+                                                                    "city": null,
+                                                                    "leaderId": 15,
+                                                                    "startedAt": "2025-08-10T12:32:27",
+                                                                    "endedAt": "2025-08-12T12:32:13",
+                                                                    "status": "COMPLETED",
+                                                                    "members": [
+                                                                        {
+                                                                            "userId": 15,
+                                                                            "nickname": "nick15",
+                                                                            "imageUrl": "https://image.com/image"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "tripId": 3,
+                                                                    "title": "여행3",
+                                                                    "city": null,
+                                                                    "leaderId": 15,
+                                                                    "startedAt": null,
+                                                                    "endedAt": null,
+                                                                    "status": "COMPLETED",
+                                                                    "members": [
+                                                                        {
+                                                                            "userId": 15,
+                                                                            "nickname": "nick15",
+                                                                            "imageUrl": "https://image.com/image"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "page": {
+                                                                "size": 5,
+                                                                "number": 0,
+                                                                "totalElements": 2,
+                                                                "totalPages": 1
+                                                            }
+                                                        }
+                                                    }
                                     """),
                             @ExampleObject(name = "조회 성공 - 속한 여행 없는 경우 빈 배열 반환", value = """
                                              {
-                                                 "code": 200,
-                                                 "message": "요청이 성공하였습니다.",
-                                                 "data": []
-                                             }
+                                                  "code": 200,
+                                                  "message": "요청이 성공하였습니다.",
+                                                  "data": {
+                                                      "content": [],
+                                                      "page": {
+                                                          "size": 0,
+                                                          "number": 0,
+                                                          "totalElements": 0,
+                                                          "totalPages": 1
+                                                      }
+                                                  }
+                                              }
                                     """)
                     })),
             @ApiResponse(responseCode = "400", description = "여행 조회 실패",
@@ -276,6 +481,10 @@ public interface TripApi {
     public ResponseEntity<?> getAllTrip(
             @Parameter(description = "여행 상태")
             @RequestParam(name = "status", required = false) TripStatus status,
+            
+            @Parameter(example = "page=0&size=10&sort=createdAt,desc", hidden = true)
+            @PageableDefault(size = 5) Pageable pageable,
+            
             @AuthenticationPrincipal CustomUserDetailsImpl userDetails
     );
 

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripController.java
@@ -11,6 +11,9 @@ import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.domain.trip.dto.TripDto;
 import kr.co.yeogiga.presentation.trip.api.TripApi;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -54,9 +57,10 @@ public class TripController implements TripApi {
     @GetMapping
     public ResponseEntity<?> getAllTrip(
             @RequestParam(name = "status", required = false) TripStatus status,
+            @PageableDefault(size = 5) Pageable pageable,
             @AuthenticationPrincipal CustomUserDetailsImpl userDetails
     ) {
-        List<TripDto.Summary> result = tripQueryService.getAllTrip(userDetails.getUserId(), status);
+        Page<TripDto.Summary> result = tripQueryService.getAllTrip(userDetails.getUserId(), status, pageable);
         return ResponseEntity.ok().body(SuccessResponse.from(result));
     }
 

--- a/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/trip/service/TripQueryServiceTest.java
@@ -22,19 +22,23 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -229,6 +233,8 @@ public class TripQueryServiceTest {
                     .build();
         }
         
+        private Pageable pageable = PageRequest.of(0, 5);
+        
         @Test
         @DisplayName("성공 - status가 ALL인 경우 전체 조회")
         void successGetAllTripWhenStatusIsALL() {
@@ -238,14 +244,14 @@ public class TripQueryServiceTest {
             TripDto.Summary trip3 = generateTripSummary(TravelStatus.IN_PROGRESS);
             TripDto.Summary trip4 = generateTripSummary(TravelStatus.COMPLETED);
             
-            when(tripMemberService.readAllTripSummaryByUserId(userId))
-                    .thenReturn(List.of(trip1, trip2, trip3, trip4));
+            when(tripMemberService.readAllTripSummaryByUserId(userId, pageable))
+                    .thenReturn(new PageImpl<>(List.of(trip1, trip2, trip3, trip4)));
             
             // when
-            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, TripStatus.ALL);
+            Page<TripDto.Summary> result = tripQueryService.getAllTrip(userId, TripStatus.ALL, pageable);
             
             // then
-            assertThat(result).hasSize(4);
+            assertThat(result.getContent()).hasSize(4);
         }
         
         @Test
@@ -254,14 +260,14 @@ public class TripQueryServiceTest {
             // given
             TripDto.Summary trip1 = generateTripSummary(TravelStatus.SETTING);
             
-            when(tripMemberService.readAllTripSummaryByUserId(userId, TravelStatus.SETTING))
-                    .thenReturn(List.of(trip1));
+            when(tripMemberService.readAllTripSummaryByUserId(userId, TravelStatus.SETTING, pageable))
+                    .thenReturn(new PageImpl<>(List.of(trip1)));
             
             // when
-            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, TripStatus.SETTING);
+            Page<TripDto.Summary> result = tripQueryService.getAllTrip(userId, TripStatus.SETTING, pageable);
             
             // then
-            assertThat(result).hasSize(1);
+            assertThat(result.getContent()).hasSize(1);
         }
         
         @Test
@@ -270,11 +276,11 @@ public class TripQueryServiceTest {
             // give
             TripDto.Summary trip1 = generateTripSummary(TravelStatus.PLANNED);
             
-            when(tripMemberService.readAllTripSummaryByUserId(userId, TravelStatus.PLANNED))
-                    .thenReturn(List.of(trip1));
+            when(tripMemberService.readAllTripSummaryByUserId(userId, TravelStatus.PLANNED, pageable))
+                    .thenReturn(new PageImpl<>(List.of(trip1)));
             
             // when
-            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, TripStatus.PLANNED);
+            Page<TripDto.Summary> result = tripQueryService.getAllTrip(userId, TripStatus.PLANNED, pageable);
             
             // then
             assertThat(result).hasSize(1);
@@ -286,11 +292,11 @@ public class TripQueryServiceTest {
             // give
             TripDto.Summary trip1 = generateTripSummary(TravelStatus.IN_PROGRESS);
             
-            when(tripMemberService.readAllTripSummaryByUserId(userId, TravelStatus.IN_PROGRESS))
-                    .thenReturn(List.of(trip1));
+            when(tripMemberService.readAllTripSummaryByUserId(userId, TravelStatus.IN_PROGRESS, pageable))
+                    .thenReturn(new PageImpl<>(List.of(trip1)));
             
             // when
-            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, TripStatus.IN_PROGRESS);
+            Page<TripDto.Summary> result = tripQueryService.getAllTrip(userId, TripStatus.IN_PROGRESS, pageable);
             
             // then
             assertThat(result).hasSize(1);
@@ -302,11 +308,11 @@ public class TripQueryServiceTest {
             // give
             TripDto.Summary trip1 = generateTripSummary(TravelStatus.COMPLETED);
             
-            when(tripMemberService.readAllTripSummaryByUserId(userId, TravelStatus.COMPLETED))
-                    .thenReturn(List.of(trip1));
+            when(tripMemberService.readAllTripSummaryByUserId(userId, TravelStatus.COMPLETED, pageable))
+                    .thenReturn(new PageImpl<>(List.of(trip1)));
             
             // when
-            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, TripStatus.COMPLETED);
+            Page<TripDto.Summary> result = tripQueryService.getAllTrip(userId, TripStatus.COMPLETED, pageable);
             
             // then
             assertThat(result).hasSize(1);
@@ -316,13 +322,13 @@ public class TripQueryServiceTest {
         @DisplayName("성공 - 빈 배열 반환")
         void successEmptyList() {
             // given
-            when(tripMemberService.readAllTripSummaryByUserId(userId)).thenReturn(List.of());
+            when(tripMemberService.readAllTripSummaryByUserId(userId, pageable)).thenReturn(Page.empty());
 
             // when
-            List<TripDto.Summary> result = tripQueryService.getAllTrip(userId, TripStatus.ALL);
+            Page<TripDto.Summary> result = tripQueryService.getAllTrip(userId, TripStatus.ALL, pageable);
 
             // then
-            assertThat(result).hasSize(0);
+            assertThat(result.getContent()).hasSize(0);
         }
     }
 

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
@@ -394,8 +394,8 @@ public class TripControllerTest {
             resultActions
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()))
-                    .andExpect(jsonPath("$.data").isArray())
-                    .andExpect(jsonPath("$.data[0].members").isArray());
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.content[0].members").isArray());
         }
         
         @Test

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripControllerTest.java
@@ -31,6 +31,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
@@ -379,7 +381,7 @@ public class TripControllerTest {
                                     .build()))
                     .build();
 
-            when(tripQueryService.getAllTrip(anyLong(), any(TripStatus.class))).thenReturn(List.of(tripSummary));
+            when(tripQueryService.getAllTrip(anyLong(), any(TripStatus.class), any(Pageable.class))).thenReturn(new PageImpl<>(List.of(tripSummary)));
 
             // when
             ResultActions resultActions = mockMvc.perform(


### PR DESCRIPTION
## 배경
- 여행 전체 조회 로직 내 페이지네이션 추가 필요

## 작업 사항
- 여행 전체 조회 로직 내 페이지네이션 및 정렬 기준 추가 | (246a0bc4c30c473e811351170c6e5101ba801e48)
	- 전체: 시작 일자 내림차순, null 값 우선 배치
     - SETTING, PLANNED, IN_PROGRESS: 시작 일자 오름차순, null 값 후순위 배치
     - COMPLETED: 종료 일자 내림차순, null 값 후순위 배치
     	- SETTING을 제외하고 나머지 값에 null 값은 존재하지 않긴 하지만 통일성을 위해 넣어두었습니다.
 		- 정렬 기준 관련해서 여행 상태 별 적용되어야할 정렬 기준이 다르기도 하고, 컨트롤러에서 `@PageableDefault`로 엔티티의 필드명을 직접 알아야하는 것이 결합도가 높아진다는 생각이 들어 `@PageableDefault` 내에는 size만 적용해두었습니다.
<br/>

- 여행 전체 조회 로직 변경 | (284aad821c8fab9c0f085b92985676711835083d)
	- 파라미터 및 호출 메서드
<br/>

- 여행 전체 조회 api 변경 | (3e536d15320dea22ed3973c73708afb5200984ae)

