### PR TITLE
Feature(IL-270): 여행 일정 및 목적지 추가 로직 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceReq.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceReq.java
@@ -1,0 +1,57 @@
+package kr.co.yeogiga.application.tripplace.dto;
+
+import kr.co.yeogiga.domain.trip.entity.Place;
+import kr.co.yeogiga.domain.trip.entity.TripDay;
+import kr.co.yeogiga.domain.trip.type.PlaceCategory;
+import lombok.Builder;
+
+import java.util.List;
+import java.util.UUID;
+
+public class TripPlaceReq {
+
+    @Builder
+    public record Request(
+            String name,
+            double latitude,
+            double longitude,
+            PlaceCategory placeType
+    ) {
+        public Place toEntity(TripDay tripDay, int sortOrder) {
+            return Place.builder()
+                    .name(name)
+                    .latitude(latitude)
+                    .longitude(longitude)
+                    .sortOrder(sortOrder)
+                    .placeType(placeType)
+                    .tripDay(tripDay)
+                    .build();
+        }
+
+        public TripPlaceReq.StoredFormat toStoredFormat() {
+            return new TripPlaceReq.StoredFormat(
+                    UUID.randomUUID().toString(),
+                    name,
+                    latitude,
+                    longitude,
+                    placeType
+            );
+        }
+    }
+
+    public record StoredFormat(
+            String id,
+            String name,
+            double latitude,
+            double longitude,
+            PlaceCategory placeCategory
+    ) { }
+
+    public record CompleteRequest(
+            int lastDay
+    ) { }
+
+    public record ReorderRequest(
+            List<String> orderedPlaceIds
+    ) { }
+}

--- a/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceReqLegacy.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceReqLegacy.java
@@ -8,10 +8,10 @@ import lombok.Builder;
 import java.util.List;
 import java.util.UUID;
 
-public class TripPlaceReq {
+public class TripPlaceReqLegacy {
 
     @Builder
-    @Schema(name = "TripPlaceReq.Request", description = "여행 목적지 추가 DTO")
+    @Schema(name = "TripPlaceReqLegacy.Request", description = "여행 목적지 추가 DTO")
     public record Request(
             @Schema(description = "목적지 이름", example = "광화문")
             String name,
@@ -52,13 +52,13 @@ public class TripPlaceReq {
             PlaceCategory placeCategory
     ) { }
 
-    @Schema(name = "TripPlaceReq.CompleteRequest", description = "여행 목적지 선택 완료 요청 DTO")
+    @Schema(name = "TripPlaceReqLegacy.CompleteRequest", description = "여행 목적지 선택 완료 요청 DTO")
     public record CompleteRequest(
             @Schema(description = "편집 완료된 마지막 일차", example = "5")
             int lastDay
     ) { }
 
-    @Schema(name = "TripPlaceReq.ReorderRequest", description = "여행 목적지 순서 변경 요청 DTO")
+    @Schema(name = "TripPlaceReqLegacy.ReorderRequest", description = "여행 목적지 순서 변경 요청 DTO")
     public record ReorderRequest(
             @Schema(description = "정렬된 목적지 ID 리스트", example = "[\"place3-id\", \"place1-id\", \"place2-id\"]")
             List<String> orderedPlaceIds

--- a/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceRes.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceRes.java
@@ -58,7 +58,7 @@ public class TripPlaceRes {
             double longitude,
             String placeCategory
     ) {
-        public static TempPlaceInfo from(TripPlaceReq.StoredFormat place) {
+        public static TempPlaceInfo from(TripPlaceReqLegacy.StoredFormat place) {
             return new TempPlaceInfo(
                     place.id(), place.name(), place.latitude(),
                     place.longitude(), place.placeCategory().getLabel()

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandService.java
@@ -1,0 +1,51 @@
+package kr.co.yeogiga.application.tripplace.service;
+
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReqLegacy;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.entity.Place;
+import kr.co.yeogiga.domain.trip.entity.TripDay;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.trip.service.PlaceService;
+import kr.co.yeogiga.domain.trip.service.TripDayService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TripPlaceCommandService {
+    private final TripDayService tripDayService;
+    private final PlaceService placeService;
+
+    /**
+     * 여행 일차에 새로운 목적지를 삽입 메서드
+     * 삽입 위치는 현재 목적지 order 중 최대값을 기준으로 order를 계산하여 결정
+     *
+     * @param tripId        여행 ID
+     * @param day           여행 일차
+     * @param insertRequest 삽입할 장소 정보 및 위치 기준 정보
+     */
+    public void addNewPlace(Long tripId, int day, TripPlaceReq.Request insertRequest) {
+        TripDay tripDay = tripDayService.readByTripIdAndDay(tripId, day)
+                .orElseThrow(() -> new CustomException(TripErrorType.TRIP_DAY_NOT_FOUND));
+
+        int placeCount = placeService.countByTripDayId(tripDay.getId());
+
+        placeService.save(createPlace(tripDay, insertRequest, placeCount));
+    }
+
+    /**
+     * 목적지 객체를 만드는 메서드
+     * 현재 목적지 order 최대값 기반으로 새로운 order를 계산하여 새로운 Place 객체를 생성
+     * 1. maxPlaceOrder : 0 => 존재하는 목적지가 없는 상황
+     * 2. maxPlaceOrder : 0 x => 마지막 목적지 뒤에 추가하는 상화
+     *
+     * @param tripDay       여행 일차 객체
+     * @param request       사용자 요청 정보
+     * @param maxPlaceOrder 현재 목적지 order 중 최대값 (nullable)
+     * @return 생성된 Place 객체
+     */
+    private Place createPlace(TripDay tripDay, TripPlaceReq.Request request, int maxPlaceOrder) {
+        return request.toEntity(tripDay, maxPlaceOrder + 1);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandServiceLegacy.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandServiceLegacy.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.application.tripplace.service;
 
-import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReqLegacy;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-public class TripPlaceCommandService {
+public class TripPlaceCommandServiceLegacy {
     private final TripDayPlaceService tripDayPlaceService;
 
     /**
@@ -27,7 +27,7 @@ public class TripPlaceCommandService {
      * @param tripDayPlaceId 여행 일차(TripDayPlace)의 ID
      * @param insertRequest  삽입할 장소 정보 및 위치 기준 정보
      */
-    public void addNewPlace(String tripDayPlaceId, TripPlaceReq.Request insertRequest) {
+    public void addNewPlace(String tripDayPlaceId, TripPlaceReqLegacy.Request insertRequest) {
         Double maxPlaceOrder = tripDayPlaceService.readMaxOrderById(tripDayPlaceId);
 
         // TODO : 중복여행 못담기게
@@ -47,7 +47,7 @@ public class TripPlaceCommandService {
      * @param maxPlaceOrder 현재 목적지 order 중 최대값 (nullable)
      * @return 생성된 Place 객체
      */
-    private Place createPlace(TripPlaceReq.Request request, Double maxPlaceOrder) {
+    private Place createPlace(TripPlaceReqLegacy.Request request, Double maxPlaceOrder) {
         return request.toEntity(maxPlaceOrder + 10.0);
     }
 
@@ -58,7 +58,7 @@ public class TripPlaceCommandService {
      * @param tripDayPlaceId 여행 일차(TripDayPlace)의 ID
      * @param reorderRequest 재정렬할 목적지 ID 리스트
      */
-    public void reorderPlaces(String tripDayPlaceId, TripPlaceReq.ReorderRequest reorderRequest) {
+    public void reorderPlaces(String tripDayPlaceId, TripPlaceReqLegacy.ReorderRequest reorderRequest) {
         TripDayPlace tripDayPlace = tripDayPlaceService.readById(tripDayPlaceId)
                 .orElseThrow(() -> new CustomException(TripErrorType.TRIP_PLACE_NOT_FOUND));
 

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingService.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.application.tripplace.service;
 
-import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReqLegacy;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
@@ -32,10 +32,10 @@ public class TripPlaceEditingService {
      *
      * @param tripId : 여행 ID
      * @param day    : 여행 일차
-     * @param place  : 추가할 TripPlaceReq.Request 객체
+     * @param place  : 추가할 TripPlaceReqLegacy.Request 객체
      * @throws CustomException - ALREADY_ADDED_PLACE : 이미 목적지를 추가한 경우
      */
-    public void assignPlaceToDay(Long tripId, int day, TripPlaceReq.Request place) {
+    public void assignPlaceToDay(Long tripId, int day, TripPlaceReqLegacy.Request place) {
         String listKey = PlaceConstant.dayPlacesKey(tripId, day);
         String setKey = PlaceConstant.dayPlaceSetKey(tripId, day);
 
@@ -57,8 +57,8 @@ public class TripPlaceEditingService {
      */
     public List<TripPlaceRes.TempPlaceInfo> getAssignedPlaces(Long tripId, int day) {
         String dayPlacesKey = PlaceConstant.dayPlacesKey(tripId, day);
-        List<TripPlaceReq.StoredFormat> places =
-                redisRepository.getList(dayPlacesKey, TripPlaceReq.StoredFormat.class);
+        List<TripPlaceReqLegacy.StoredFormat> places =
+                redisRepository.getList(dayPlacesKey, TripPlaceReqLegacy.StoredFormat.class);
 
         return places.stream().map(TripPlaceRes.TempPlaceInfo::from).toList();
     }
@@ -76,7 +76,7 @@ public class TripPlaceEditingService {
         String dayPlacesKey = PlaceConstant.dayPlacesKey(tripId, day);
         String dayPlaceSetKey = PlaceConstant.dayPlaceSetKey(tripId, day);
 
-        TripPlaceReq.StoredFormat target = findPlaceInList(dayPlacesKey, placeId);
+        TripPlaceReqLegacy.StoredFormat target = findPlaceInList(dayPlacesKey, placeId);
         if (target == null) {
             return;
         }
@@ -94,8 +94,8 @@ public class TripPlaceEditingService {
      * @param placeId : 조회할 장소의 ID
      * @return : 일치하는 장소가 존재하면 해당 객체, 없으면 null 반환
      */
-    private TripPlaceReq.StoredFormat findPlaceInList(String listKey, String placeId) {
-        List<TripPlaceReq.StoredFormat> places = redisRepository.getList(listKey, TripPlaceReq.StoredFormat.class);
+    private TripPlaceReqLegacy.StoredFormat findPlaceInList(String listKey, String placeId) {
+        List<TripPlaceReqLegacy.StoredFormat> places = redisRepository.getList(listKey, TripPlaceReqLegacy.StoredFormat.class);
 
         return places.stream()
                 .filter(p -> placeId.equals(p.id()))
@@ -112,29 +112,29 @@ public class TripPlaceEditingService {
      * @param day            여행 일차
      * @param reorderRequest 재정렬할 목적지 ID 리스트
      */
-    public void reorderPlaces(Long tripId, int day, TripPlaceReq.ReorderRequest reorderRequest) {
+    public void reorderPlaces(Long tripId, int day, TripPlaceReqLegacy.ReorderRequest reorderRequest) {
         String dayPlacesKey = PlaceConstant.dayPlacesKey(tripId, day);
         String dayPlaceSetKey = PlaceConstant.dayPlaceSetKey(tripId, day);
 
-        List<TripPlaceReq.StoredFormat> storedPlaces =
-                redisRepository.getList(dayPlacesKey, TripPlaceReq.StoredFormat.class);
+        List<TripPlaceReqLegacy.StoredFormat> storedPlaces =
+                redisRepository.getList(dayPlacesKey, TripPlaceReqLegacy.StoredFormat.class);
 
         if (storedPlaces == null || storedPlaces.isEmpty()) {
             return;
         }
 
-        Map<String, TripPlaceReq.StoredFormat> placeMap = storedPlaces.stream()
-                .collect(Collectors.toMap(TripPlaceReq.StoredFormat::id, Function.identity()));
+        Map<String, TripPlaceReqLegacy.StoredFormat> placeMap = storedPlaces.stream()
+                .collect(Collectors.toMap(TripPlaceReqLegacy.StoredFormat::id, Function.identity()));
 
         // 요청한 정렬 순서에 맞게 목적지 재정렬
-        List<TripPlaceReq.StoredFormat> reordered =
+        List<TripPlaceReqLegacy.StoredFormat> reordered =
                 buildReorderedPlaces(reorderRequest.orderedPlaceIds(), placeMap);
 
         redisRepository.del(dayPlacesKey);
         redisRepository.del(dayPlaceSetKey);
 
         redisRepository.setListAll(dayPlacesKey, reordered);
-        for (TripPlaceReq.StoredFormat place : reordered) {
+        for (TripPlaceReqLegacy.StoredFormat place : reordered) {
             String placeUniqueKey = makeUniqueKey(place.name(), place.latitude(), place.longitude());
             redisRepository.addToSet(dayPlaceSetKey, placeUniqueKey);
         }
@@ -147,14 +147,14 @@ public class TripPlaceEditingService {
      * @param placeMap   ID 기준 Place 매핑 정보
      * @return 재정렬된 Place 리스트
      */
-    private List<TripPlaceReq.StoredFormat> buildReorderedPlaces(
+    private List<TripPlaceReqLegacy.StoredFormat> buildReorderedPlaces(
             List<String> orderedIds,
-            Map<String, TripPlaceReq.StoredFormat> placeMap
+            Map<String, TripPlaceReqLegacy.StoredFormat> placeMap
     ) {
-        List<TripPlaceReq.StoredFormat> reordered = new ArrayList<>();
+        List<TripPlaceReqLegacy.StoredFormat> reordered = new ArrayList<>();
 
         for (String placeId : orderedIds) {
-            TripPlaceReq.StoredFormat place = placeMap.get(placeId);
+            TripPlaceReqLegacy.StoredFormat place = placeMap.get(placeId);
             reordered.add(place);
         }
 

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingService.java
@@ -1,0 +1,102 @@
+package kr.co.yeogiga.application.tripplace.service;
+
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.entity.Place;
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.entity.TripDay;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.trip.service.PlaceService;
+import kr.co.yeogiga.domain.trip.service.TripDayService;
+import kr.co.yeogiga.domain.trip.service.TripService;
+import kr.co.yeogiga.domain.trip.type.TravelStatus;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import kr.co.yeogiga.infrastructure.redis.constant.PlaceConstant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TripPlaceSavingService {
+    private final TripService tripService;
+    private final TripDayService tripDayService;
+    private final PlaceService placeService;
+    private final RedisRepository redisRepository;
+
+    /**
+     * 여행 생성 완료 시, Redis에 임시 저장된 일차별 목적지들을 MongoDB에 저장하는 메서드
+     * - 1일차부터 lastDay까지 순회하며 TripDayPlace 생성
+     * - Redis에 임시 저장한 데이터 삭제 (list, set)
+     * - 생성된 TripDayPlace 리스트를 MongoDB에 일괄
+     * - 여행 생성 완료 시, 여행 상태 변경
+     *
+     * @param tripId  : 여행 ID
+     * @param lastDay : 여행 마지막 일차
+     */
+    @Transactional
+    public void completeTrip(Long tripId, int lastDay) {
+        Trip trip = tripService.readById(tripId)
+                .orElseThrow(() -> new CustomException(TripErrorType.TRIP_NOT_FOUND));
+
+        List<Place> places = new ArrayList<>();
+        for (int day = 1; day <= lastDay; day++) {
+            places.addAll(createTripDayPlace(trip, day));
+
+            // Redis에 임시 저장된 데이터 삭제
+            redisRepository.del(PlaceConstant.dayPlacesKey(tripId, day));
+            redisRepository.del(PlaceConstant.dayPlaceSetKey(tripId, day));
+        }
+
+        trip.updateStatus(TravelStatus.resolveStatus(trip.getStartedAt(), trip.getEndedAt()));
+
+        placeService.saveAll(places);
+    }
+
+    /**
+     * 특정 일자(day)에 해당하는 여행 일차(TripDay) 객체 생성 및 목적지(place) 리스트 반환
+     *
+     * @param trip : 여행 객체
+     * @param day  : 일차 (1일차, 2일차 ...)
+     */
+    private List<Place> createTripDayPlace(Trip trip, int day) {
+        String dayPlacesKey = PlaceConstant.dayPlacesKey(trip.getId(), day);
+        List<TripPlaceReq.StoredFormat> storedPlaces
+                = redisRepository.getList(dayPlacesKey, TripPlaceReq.StoredFormat.class);
+
+        TripDay tripDay = tripDayService.save(TripDay.builder()
+                .day(day)
+                .trip(trip)
+                .build());
+
+        List<Place> places = new ArrayList<>();
+        for (int index = 0; index < storedPlaces.size(); index++) {
+            TripPlaceReq.StoredFormat stored = storedPlaces.get(index);
+            places.add(convertToPlace(stored, tripDay, index));
+        }
+
+        return places;
+    }
+
+    /**
+     * StoredFormat -> Place 변환 (순서(order) 반영)
+     *
+     * @param stored  : 저장된 StoredFormat
+     * @param tripDay : 여행 일차 객체
+     * @param index   : 리스트 내 순서
+     * @return : Place 변환 객체
+     */
+    private Place convertToPlace(TripPlaceReq.StoredFormat stored, TripDay tripDay, int index) {
+        return Place.builder()
+                .name(stored.name())
+                .latitude(stored.latitude())
+                .longitude(stored.longitude())
+                .placeType(stored.placeCategory())
+                .sortOrder(index + 1)
+                .tripDay(tripDay)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingServiceLegacy.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingServiceLegacy.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.application.tripplace.service;
 
-import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReqLegacy;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
@@ -20,7 +20,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class TripPlaceSavingService {
+public class TripPlaceSavingServiceLegacy {
     private final TripDayPlaceService tripDayPlaceService;
     private final TripService tripService;
     private final RedisRepository redisRepository;
@@ -64,12 +64,12 @@ public class TripPlaceSavingService {
      */
     private TripDayPlace createTripDayPlace(Long tripId, int day) {
         String dayPlacesKey = PlaceConstant.dayPlacesKey(tripId, day);
-        List<TripPlaceReq.StoredFormat> storedPlaces
-                = redisRepository.getList(dayPlacesKey, TripPlaceReq.StoredFormat.class);
+        List<TripPlaceReqLegacy.StoredFormat> storedPlaces
+                = redisRepository.getList(dayPlacesKey, TripPlaceReqLegacy.StoredFormat.class);
 
         List<Place> places = new ArrayList<>();
         for (int i = 0; i < storedPlaces.size(); i++) {
-            TripPlaceReq.StoredFormat stored = storedPlaces.get(i);
+            TripPlaceReqLegacy.StoredFormat stored = storedPlaces.get(i);
             places.add(convertToPlace(stored, i));
         }
 
@@ -88,7 +88,7 @@ public class TripPlaceSavingService {
      * @param index  : 리스트 내 순서
      * @return : Place 변환 객체
      */
-    private Place convertToPlace(TripPlaceReq.StoredFormat stored, int index) {
+    private Place convertToPlace(TripPlaceReqLegacy.StoredFormat stored, int index) {
         return Place.builder()
                 .id(stored.id())
                 .name(stored.name())

--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortService.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortService.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.application.tripplace.service;
 
-import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReqLegacy;
 import kr.co.yeogiga.common.util.DistanceUtils;
 import kr.co.yeogiga.domain.trip.type.PlaceCategory;
 import kr.co.yeogiga.infrastructure.redis.RedisRepository;
@@ -31,23 +31,23 @@ public class TripPlaceSortService {
      */
     public void sortDayTripPlaces(Long tripId, int day) {
         String listKey = PlaceConstant.dayPlacesKey(tripId, day);
-        List<TripPlaceReq.StoredFormat> places =
-                redisRepository.getList(listKey, TripPlaceReq.StoredFormat.class);
+        List<TripPlaceReqLegacy.StoredFormat> places =
+                redisRepository.getList(listKey, TripPlaceReqLegacy.StoredFormat.class);
 
         if (places == null || places.isEmpty()) {
             return;
         }
 
         // 숙소 카테고리 & 나머지 카테고리 분리
-        List<TripPlaceReq.StoredFormat> lodgings = new ArrayList<>();
-        List<TripPlaceReq.StoredFormat> otherPlaces = new ArrayList<>();
+        List<TripPlaceReqLegacy.StoredFormat> lodgings = new ArrayList<>();
+        List<TripPlaceReqLegacy.StoredFormat> otherPlaces = new ArrayList<>();
         partitionPlaces(places, otherPlaces, lodgings);
 
         // 위도/경도 기준 목적지 정렬
         sortByDistance(otherPlaces);
 
         // 연속된 식당 카테고리 방지 (3번 이상 방지)
-        List<TripPlaceReq.StoredFormat> sorted = preventConsecutiveRestaurants(otherPlaces);
+        List<TripPlaceReqLegacy.StoredFormat> sorted = preventConsecutiveRestaurants(otherPlaces);
 
         // 마지막에 숙소 삽입
         sorted.addAll(lodgings);
@@ -64,11 +64,11 @@ public class TripPlaceSortService {
      * @param lodgings    숙소만 저장할 리스트
      */
     private void partitionPlaces(
-            List<TripPlaceReq.StoredFormat> places,
-            List<TripPlaceReq.StoredFormat> otherPlaces,
-            List<TripPlaceReq.StoredFormat> lodgings
+            List<TripPlaceReqLegacy.StoredFormat> places,
+            List<TripPlaceReqLegacy.StoredFormat> otherPlaces,
+            List<TripPlaceReqLegacy.StoredFormat> lodgings
     ) {
-        for (TripPlaceReq.StoredFormat place : places) {
+        for (TripPlaceReqLegacy.StoredFormat place : places) {
             if (PlaceCategory.LODGING == place.placeCategory()) {
                 lodgings.add(place);
             } else {
@@ -83,10 +83,10 @@ public class TripPlaceSortService {
      *
      * @param places 정렬할 장소 목록
      */
-    private void sortByDistance(List<TripPlaceReq.StoredFormat> places) {
+    private void sortByDistance(List<TripPlaceReqLegacy.StoredFormat> places) {
         if (places.isEmpty()) return;
 
-        TripPlaceReq.StoredFormat basePlace = places.get(0);
+        TripPlaceReqLegacy.StoredFormat basePlace = places.get(0);
         places.sort(Comparator.comparingDouble(p ->
                         DistanceUtils.calculateDistance(
                                 basePlace.latitude(), basePlace.longitude(), p.latitude(), p.longitude()
@@ -101,11 +101,11 @@ public class TripPlaceSortService {
      * @param input 정렬된 장소 목록
      * @return 재배치된 장소 목록
      */
-    private List<TripPlaceReq.StoredFormat> preventConsecutiveRestaurants(List<TripPlaceReq.StoredFormat> input) {
-        List<TripPlaceReq.StoredFormat> result = new ArrayList<>();
-        Queue<TripPlaceReq.StoredFormat> restaurants = new LinkedList<>();
+    private List<TripPlaceReqLegacy.StoredFormat> preventConsecutiveRestaurants(List<TripPlaceReqLegacy.StoredFormat> input) {
+        List<TripPlaceReqLegacy.StoredFormat> result = new ArrayList<>();
+        Queue<TripPlaceReqLegacy.StoredFormat> restaurants = new LinkedList<>();
 
-        for (TripPlaceReq.StoredFormat place : input) {
+        for (TripPlaceReqLegacy.StoredFormat place : input) {
             if (result.contains(place)) continue;
 
             if (isRestaurant(place)) {  // 식당 카테고리인 경우
@@ -116,7 +116,7 @@ public class TripPlaceSortService {
                 }
 
                 // 식당 3개 연속 방지 로직
-                TripPlaceReq.StoredFormat nonRestaurant = findNextNonRestaurant(input, result, restaurants);
+                TripPlaceReqLegacy.StoredFormat nonRestaurant = findNextNonRestaurant(input, result, restaurants);
                 if (nonRestaurant != null) {
                     result.add(restaurants.poll());    // 식당 1
                     result.add(nonRestaurant);         // 식당 이외의 카테고리
@@ -149,10 +149,10 @@ public class TripPlaceSortService {
      * @param restaurants 현재 연속된 식당 리스트
      * @return 조건에 맞는 식당 이외 장소, 없으면 null
      */
-    private TripPlaceReq.StoredFormat findNextNonRestaurant(
-            List<TripPlaceReq.StoredFormat> input,
-            List<TripPlaceReq.StoredFormat> result,
-            Queue<TripPlaceReq.StoredFormat> restaurants
+    private TripPlaceReqLegacy.StoredFormat findNextNonRestaurant(
+            List<TripPlaceReqLegacy.StoredFormat> input,
+            List<TripPlaceReqLegacy.StoredFormat> result,
+            Queue<TripPlaceReqLegacy.StoredFormat> restaurants
     ) {
         return input.stream()
                 .filter(p -> !isRestaurant(p) && !result.contains(p) && !restaurants.contains(p))
@@ -166,7 +166,7 @@ public class TripPlaceSortService {
      * @param place 장소 객체
      * @return true = 식당, false = 식당 아님
      */
-    private boolean isRestaurant(TripPlaceReq.StoredFormat place) {
+    private boolean isRestaurant(TripPlaceReqLegacy.StoredFormat place) {
         return PlaceCategory.RESTAURANT == place.placeCategory();
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/exception/TripErrorType.java
@@ -25,7 +25,9 @@ public enum TripErrorType implements BaseErrorType {
     SAME_TRIP_TITLE(HttpStatus.CONFLICT, "T011", "기존과 동일한 여행 제목입니다."),
     TRIP_ALREADY_STARTED_OR_COMPLETED(HttpStatus.CONFLICT, "T012", "이미 시작되었거나 완료된 여행은 수정할 수 없습니다."),
     
-    NOT_SUPPORTED_TRIP_STATUS(HttpStatus.BAD_REQUEST, "T013", "지원하지 않는 여행 타입입니다.");
+    NOT_SUPPORTED_TRIP_STATUS(HttpStatus.BAD_REQUEST, "T013", "지원하지 않는 여행 타입입니다."),
+
+    TRIP_DAY_NOT_FOUND(HttpStatus.NOT_FOUND, "T014", "해당 여행 일차가 존재하지 않습니다");
     
     
     

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/PlaceRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/PlaceRepository.java
@@ -1,7 +1,0 @@
-package kr.co.yeogiga.domain.trip.repository;
-
-import kr.co.yeogiga.domain.trip.entity.Place;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface PlaceRepository extends JpaRepository<Place, Long> {
-}

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/place/CustomPlaceRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/place/CustomPlaceRepository.java
@@ -1,0 +1,9 @@
+package kr.co.yeogiga.domain.trip.repository.place;
+
+import kr.co.yeogiga.domain.trip.entity.Place;
+
+import java.util.List;
+
+public interface CustomPlaceRepository {
+    void saveAllInBatch(List<Place> places);
+}

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/place/CustomPlaceRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/place/CustomPlaceRepositoryImpl.java
@@ -1,0 +1,37 @@
+package kr.co.yeogiga.domain.trip.repository.place;
+
+import kr.co.yeogiga.domain.trip.entity.Place;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.PreparedStatement;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomPlaceRepositoryImpl implements CustomPlaceRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    private final static int BATCH_SIZE = 100;
+
+    @Override
+    public void saveAllInBatch(List<Place> places) {
+        String sql = "INSERT INTO place ("
+                + "name, latitude, longitude, sort_order, is_visited, place_type, trip_day_id"
+                + ") VALUES (?, ?, ?, ?, ?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(
+                sql,
+                places,
+                BATCH_SIZE,
+                (PreparedStatement ps, Place place) -> {
+                    ps.setString(1, place.getName());
+                    ps.setDouble(2, place.getLatitude());
+                    ps.setDouble(3, place.getLongitude());
+                    ps.setInt(4, place.getSortOrder());
+                    ps.setBoolean(5, place.isVisited());
+                    ps.setString(6, place.getPlaceType().name());
+                    ps.setLong(7, place.getTripDay().getId());
+                }
+        );
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/place/PlaceRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/place/PlaceRepository.java
@@ -1,0 +1,8 @@
+package kr.co.yeogiga.domain.trip.repository.place;
+
+import kr.co.yeogiga.domain.trip.entity.Place;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceRepository extends JpaRepository<Place, Long>, CustomPlaceRepository {
+    int countByTripDay_Id(Long tripDayId);
+}

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/trip/CustomTripRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/trip/CustomTripRepository.java
@@ -1,4 +1,4 @@
-package kr.co.yeogiga.domain.trip.repository;
+package kr.co.yeogiga.domain.trip.repository.trip;
 
 import kr.co.yeogiga.domain.trip.dto.TripFcmTokenInfoDto;
 import kr.co.yeogiga.domain.trip.dto.TripFcmTokenQueryDto;

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/trip/CustomTripRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/trip/CustomTripRepositoryImpl.java
@@ -1,4 +1,4 @@
-package kr.co.yeogiga.domain.trip.repository;
+package kr.co.yeogiga.domain.trip.repository.trip;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/trip/TripRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/trip/TripRepository.java
@@ -1,4 +1,4 @@
-package kr.co.yeogiga.domain.trip.repository;
+package kr.co.yeogiga.domain.trip.repository.trip;
 
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/tripday/TripDayRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/tripday/TripDayRepository.java
@@ -1,7 +1,10 @@
-package kr.co.yeogiga.domain.trip.repository;
+package kr.co.yeogiga.domain.trip.repository.tripday;
 
 import kr.co.yeogiga.domain.trip.entity.TripDay;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TripDayRepository extends JpaRepository<TripDay, Long> {
+    Optional<TripDay> findByTrip_IdAndDay(Long tripId, int day);
 }

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/tripmember/CustomTripMemberRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/tripmember/CustomTripMemberRepository.java
@@ -1,4 +1,4 @@
-package kr.co.yeogiga.domain.trip.repository;
+package kr.co.yeogiga.domain.trip.repository.tripmember;
 
 import kr.co.yeogiga.domain.trip.dto.TripDto;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/tripmember/CustomTripMemberRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/tripmember/CustomTripMemberRepositoryImpl.java
@@ -1,4 +1,4 @@
-package kr.co.yeogiga.domain.trip.repository;
+package kr.co.yeogiga.domain.trip.repository.tripmember;
 
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Order;

--- a/src/main/java/kr/co/yeogiga/domain/trip/repository/tripmember/TripMemberRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/repository/tripmember/TripMemberRepository.java
@@ -1,4 +1,4 @@
-package kr.co.yeogiga.domain.trip.repository;
+package kr.co.yeogiga.domain.trip.repository.tripmember;
 
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.entity.TripMember;

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/PlaceService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/PlaceService.java
@@ -1,0 +1,26 @@
+package kr.co.yeogiga.domain.trip.service;
+
+import kr.co.yeogiga.domain.trip.entity.Place;
+import kr.co.yeogiga.domain.trip.repository.place.PlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceService {
+    private final PlaceRepository placeRepository;
+
+    public void save(Place place) {
+        placeRepository.save(place);
+    }
+
+    public void saveAll(List<Place> places) {
+        placeRepository.saveAllInBatch(places);
+    }
+
+    public int countByTripDayId(Long tripDayId) {
+        return placeRepository.countByTripDay_Id(tripDayId);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/TripDayService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/TripDayService.java
@@ -1,0 +1,22 @@
+package kr.co.yeogiga.domain.trip.service;
+
+import kr.co.yeogiga.domain.trip.entity.TripDay;
+import kr.co.yeogiga.domain.trip.repository.tripday.TripDayRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class TripDayService {
+    private final TripDayRepository tripDayRepository;
+
+    public TripDay save(TripDay tripDay) {
+        return tripDayRepository.save(tripDay);
+    }
+
+    public Optional<TripDay> readByTripIdAndDay(Long tripId, int day) {
+        return tripDayRepository.findByTrip_IdAndDay(tripId, day);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/TripMemberService.java
@@ -3,7 +3,7 @@ package kr.co.yeogiga.domain.trip.service;
 import kr.co.yeogiga.domain.trip.dto.TripDto;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.entity.TripMember;
-import kr.co.yeogiga.domain.trip.repository.TripMemberRepository;
+import kr.co.yeogiga.domain.trip.repository.tripmember.TripMemberRepository;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
 import kr.co.yeogiga.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/kr/co/yeogiga/domain/trip/service/TripService.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/service/TripService.java
@@ -3,7 +3,7 @@ package kr.co.yeogiga.domain.trip.service;
 import kr.co.yeogiga.domain.trip.dto.TripFcmTokenInfoDto;
 import kr.co.yeogiga.domain.trip.dto.TripFcmTokenQueryDto;
 import kr.co.yeogiga.domain.trip.entity.Trip;
-import kr.co.yeogiga.domain.trip.repository.TripRepository;
+import kr.co.yeogiga.domain.trip.repository.trip.TripRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/api/TripPlaceApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/api/TripPlaceApi.java
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReqLegacy;
 import kr.co.yeogiga.application.tripplace.dto.VisitedMarkReq;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -37,7 +37,7 @@ public interface TripPlaceApi {
             @PathVariable Long tripId,
 
             @Parameter(description = "여행의 마지막 일차 (3일 여행이라면 3)")
-            @RequestBody TripPlaceReq.CompleteRequest request
+            @RequestBody TripPlaceReqLegacy.CompleteRequest request
     );
 
     @TrackApi(description = "여행 목적지 추가 - 하나씩 (여행 목적지 지정 확정 후)")
@@ -61,7 +61,7 @@ public interface TripPlaceApi {
             @PathVariable String tripDayPlaceId,
 
             @Parameter(description = "추가할 목적지 정보")
-            @RequestBody TripPlaceReq.Request request
+            @RequestBody TripPlaceReqLegacy.Request request
     );
 
     @TrackApi(description = "여행 일정 정보 불러오기 (여행 목적지 지정 확정 후)")
@@ -251,7 +251,7 @@ public interface TripPlaceApi {
             @PathVariable String tripDayPlaceId,
 
             @Parameter(description = "목적지 순서 변경을 위한 정보")
-            @RequestBody TripPlaceReq.ReorderRequest reorderRequest
+            @RequestBody TripPlaceReqLegacy.ReorderRequest reorderRequest
     );
 
     @TrackApi(description = "여행 목적지 방문 여부 체크 (여행 목적지 지정 확정 후)")

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/api/TripPlaceEditingApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/api/TripPlaceEditingApi.java
@@ -9,12 +9,10 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReqLegacy;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
-
-import java.util.List;
 
 @ApiGroup(value = "[여행 생성 단계에서의 목적지 API]")
 @Tag(name = "[여행 생성 단계에서의 목적지 API]", description = "여행 목적지 관련 API")
@@ -49,7 +47,7 @@ public interface TripPlaceEditingApi {
             @Parameter(description = "배정하고자 하는 여행 일차")
             @PathVariable int day,
 
-            @RequestBody TripPlaceReq.Request place
+            @RequestBody TripPlaceReqLegacy.Request place
     );
 
     @TrackApi(description = "일차에 지정한 목적지 조회")
@@ -112,7 +110,7 @@ public interface TripPlaceEditingApi {
             @PathVariable int day,
 
             @Parameter(description = "변경된 순서로의 목적지 ID 리스트")
-            @RequestBody TripPlaceReq.ReorderRequest request
+            @RequestBody TripPlaceReqLegacy.ReorderRequest request
     );
 
     @TrackApi(description = "일차별 목적지의 순서 추천 알고리즘")

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceController.java
@@ -1,10 +1,10 @@
 package kr.co.yeogiga.presentation.tripplace.controller;
 
-import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReqLegacy;
 import kr.co.yeogiga.application.tripplace.dto.VisitedMarkReq;
-import kr.co.yeogiga.application.tripplace.service.TripPlaceCommandService;
+import kr.co.yeogiga.application.tripplace.service.TripPlaceCommandServiceLegacy;
 import kr.co.yeogiga.application.tripplace.service.TripPlaceQueryService;
-import kr.co.yeogiga.application.tripplace.service.TripPlaceSavingService;
+import kr.co.yeogiga.application.tripplace.service.TripPlaceSavingServiceLegacy;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.presentation.tripplace.api.TripPlaceApi;
 import lombok.RequiredArgsConstructor;
@@ -24,16 +24,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/trip")
 @RequiredArgsConstructor
 public class TripPlaceController implements TripPlaceApi {
-    private final TripPlaceSavingService tripPlaceSavingService;
-    private final TripPlaceCommandService tripPlaceCommandService;
+    private final TripPlaceSavingServiceLegacy tripPlaceSavingServiceLegacy;
+    private final TripPlaceCommandServiceLegacy tripPlaceCommandServiceLegacy;
     private final TripPlaceQueryService tripPlaceQueryService;
 
     @Override
     @PostMapping("/{tripId}/complete")
     public ResponseEntity<?> completeTrip(@PathVariable Long tripId,
-                                          @RequestBody TripPlaceReq.CompleteRequest request) {
+                                          @RequestBody TripPlaceReqLegacy.CompleteRequest request) {
 
-        tripPlaceSavingService.completeTrip(tripId, request.lastDay());
+        tripPlaceSavingServiceLegacy.completeTrip(tripId, request.lastDay());
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
     }
 
@@ -41,9 +41,9 @@ public class TripPlaceController implements TripPlaceApi {
     @PostMapping("/{tripId}/day-place/{tripDayPlaceId}/places")
     public ResponseEntity<?> addNewPlace(@PathVariable Long tripId,
                                          @PathVariable String tripDayPlaceId,
-                                         @RequestBody TripPlaceReq.Request request) {
+                                         @RequestBody TripPlaceReqLegacy.Request request) {
 
-        tripPlaceCommandService.addNewPlace(tripDayPlaceId, request);
+        tripPlaceCommandServiceLegacy.addNewPlace(tripDayPlaceId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
     }
 
@@ -77,8 +77,8 @@ public class TripPlaceController implements TripPlaceApi {
     @PutMapping("/{tripId}/day-place/{tripDayPlaceId}/places/order")
     public ResponseEntity<?> reorderPlaces(@PathVariable Long tripId,
                                            @PathVariable String tripDayPlaceId,
-                                           @RequestBody TripPlaceReq.ReorderRequest reorderRequest) {
-        tripPlaceCommandService.reorderPlaces(tripDayPlaceId, reorderRequest);
+                                           @RequestBody TripPlaceReqLegacy.ReorderRequest reorderRequest) {
+        tripPlaceCommandServiceLegacy.reorderPlaces(tripDayPlaceId, reorderRequest);
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 
@@ -88,7 +88,7 @@ public class TripPlaceController implements TripPlaceApi {
                                                 @PathVariable String tripDayPlaceId,
                                                 @PathVariable String placeId,
                                                 @RequestBody VisitedMarkReq visitedMarkReq) {
-        tripPlaceCommandService.markPlaceAsVisited(tripDayPlaceId, placeId, visitedMarkReq.isVisited());
+        tripPlaceCommandServiceLegacy.markPlaceAsVisited(tripDayPlaceId, placeId, visitedMarkReq.isVisited());
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 
@@ -98,7 +98,7 @@ public class TripPlaceController implements TripPlaceApi {
                                          @PathVariable String tripDayPlaceId,
                                          @PathVariable String placeId) {
 
-        tripPlaceCommandService.deletePlace(tripDayPlaceId, placeId);
+        tripPlaceCommandServiceLegacy.deletePlace(tripDayPlaceId, placeId);
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingController.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.presentation.tripplace.controller;
 
-import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReqLegacy;
 import kr.co.yeogiga.application.tripplace.service.TripPlaceEditingService;
 import kr.co.yeogiga.application.tripplace.service.TripPlaceSortService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
@@ -28,7 +28,7 @@ public class TripPlaceEditingController implements TripPlaceEditingApi {
     @PostMapping("/{tripId}/days/{day}/places")
     public ResponseEntity<?> assignPlaceToDay(@PathVariable Long tripId,
                                               @PathVariable int day,
-                                              @RequestBody TripPlaceReq.Request place) {
+                                              @RequestBody TripPlaceReqLegacy.Request place) {
 
         tripPlaceEditingService.assignPlaceToDay(tripId, day, place);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.created());
@@ -46,7 +46,7 @@ public class TripPlaceEditingController implements TripPlaceEditingApi {
     @PutMapping("/{tripId}/days/{day}/places")
     public ResponseEntity<?> reorderPlaces(@PathVariable Long tripId,
                                           @PathVariable int day,
-                                          @RequestBody TripPlaceReq.ReorderRequest request) {
+                                          @RequestBody TripPlaceReqLegacy.ReorderRequest request) {
 
         tripPlaceEditingService.reorderPlaces(tripId, day, request);
         return ResponseEntity.ok(SuccessResponse.ok());

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandServiceLegacyTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandServiceLegacyTest.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.application.tripplace.service;
 
-import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReqLegacy;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
@@ -29,13 +29,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class TripPlaceCommandServiceTest {
+public class TripPlaceCommandServiceLegacyTest {
 
     @Mock
     private TripDayPlaceService tripDayPlaceService;
 
     @InjectMocks
-    private TripPlaceCommandService tripPlaceCommandService;
+    private TripPlaceCommandServiceLegacy tripPlaceCommandServiceLegacy;
 
     private final String tripDayPlaceId = "tripDayPlaceId";
 
@@ -51,7 +51,7 @@ public class TripPlaceCommandServiceTest {
         void addPlaceFirst() {
             // given
             given(tripDayPlaceService.readMaxOrderById(tripDayPlaceId)).willReturn(0.0);
-            TripPlaceReq.Request request = TripPlaceReq.Request.builder()
+            TripPlaceReqLegacy.Request request = TripPlaceReqLegacy.Request.builder()
                     .name("목적지1")
                     .latitude(0.0)
                     .longitude(0.0)
@@ -59,7 +59,7 @@ public class TripPlaceCommandServiceTest {
                     .build();
 
             // when
-            tripPlaceCommandService.addNewPlace(tripDayPlaceId, request);
+            tripPlaceCommandServiceLegacy.addNewPlace(tripDayPlaceId, request);
 
             // then
             verify(tripDayPlaceService).savePlace(eq(tripDayPlaceId), placeCaptor.capture());
@@ -73,7 +73,7 @@ public class TripPlaceCommandServiceTest {
         void addPlaceBack() {
             // given
             given(tripDayPlaceService.readMaxOrderById(tripDayPlaceId)).willReturn(20.0);
-            TripPlaceReq.Request request = TripPlaceReq.Request.builder()
+            TripPlaceReqLegacy.Request request = TripPlaceReqLegacy.Request.builder()
                     .name("목적지1")
                     .latitude(0.0)
                     .longitude(0.0)
@@ -81,7 +81,7 @@ public class TripPlaceCommandServiceTest {
                     .build();
 
             // when
-            tripPlaceCommandService.addNewPlace(tripDayPlaceId, request);
+            tripPlaceCommandServiceLegacy.addNewPlace(tripDayPlaceId, request);
 
             // then
             verify(tripDayPlaceService).savePlace(eq(tripDayPlaceId), placeCaptor.capture());
@@ -107,12 +107,12 @@ public class TripPlaceCommandServiceTest {
                     Place.builder().id("id3").name("목적지3").latitude(0.0).longitude(0.0).placeType(PlaceCategory.RESTAURANT).order(30.0).build()
             );
             TripDayPlace tripDayPlace = TripDayPlace.builder().day(1).places(places).build();
-            TripPlaceReq.ReorderRequest reorderRequest = new TripPlaceReq.ReorderRequest(List.of("id3", "id1", "id2"));
+            TripPlaceReqLegacy.ReorderRequest reorderRequest = new TripPlaceReqLegacy.ReorderRequest(List.of("id3", "id1", "id2"));
 
             given(tripDayPlaceService.readById(tripDayPlaceId)).willReturn(Optional.of(tripDayPlace));
 
             // when
-            tripPlaceCommandService.reorderPlaces(tripDayPlaceId, reorderRequest);
+            tripPlaceCommandServiceLegacy.reorderPlaces(tripDayPlaceId, reorderRequest);
 
             // then
             assertEquals(places.get(2).getOrder(), 10.0);
@@ -127,11 +127,11 @@ public class TripPlaceCommandServiceTest {
             // given
             given(tripDayPlaceService.readById(tripDayPlaceId)).willReturn(Optional.empty());
 
-            TripPlaceReq.ReorderRequest reorderRequest = new TripPlaceReq.ReorderRequest(List.of("a"));
+            TripPlaceReqLegacy.ReorderRequest reorderRequest = new TripPlaceReqLegacy.ReorderRequest(List.of("a"));
 
             // when
             CustomException e = assertThrows(CustomException.class, () ->
-                    tripPlaceCommandService.reorderPlaces(tripDayPlaceId, reorderRequest));
+                    tripPlaceCommandServiceLegacy.reorderPlaces(tripDayPlaceId, reorderRequest));
 
             // then
             assertEquals(TripErrorType.TRIP_PLACE_NOT_FOUND, e.getErrorType());
@@ -146,7 +146,7 @@ public class TripPlaceCommandServiceTest {
         boolean isVisited = true;
 
         // when
-        tripPlaceCommandService.markPlaceAsVisited(tripDayPlaceId, placeId, isVisited);
+        tripPlaceCommandServiceLegacy.markPlaceAsVisited(tripDayPlaceId, placeId, isVisited);
 
         // then
         verify(tripDayPlaceService, times(1)).updatePlaceVisited(tripDayPlaceId, placeId, isVisited);
@@ -158,7 +158,7 @@ public class TripPlaceCommandServiceTest {
         // given
 
         // when
-        tripPlaceCommandService.deletePlace(tripDayPlaceId, "placeId");
+        tripPlaceCommandServiceLegacy.deletePlace(tripDayPlaceId, "placeId");
 
         // then
         verify(tripDayPlaceService, times(1)).deletePlace(tripDayPlaceId, "placeId");

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceCommandServiceTest.java
@@ -1,0 +1,129 @@
+package kr.co.yeogiga.application.tripplace.service;
+
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.trip.entity.Place;
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.entity.TripDay;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.trip.service.PlaceService;
+import kr.co.yeogiga.domain.trip.service.TripDayService;
+import kr.co.yeogiga.domain.trip.type.PlaceCategory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class TripPlaceCommandServiceTest {
+
+    @Mock
+    private TripDayService tripDayService;
+
+    @Mock
+    private PlaceService placeService;
+
+    @InjectMocks
+    private TripPlaceCommandService tripPlaceCommandService;
+
+    private final Long tripId = 1L;
+    private final Long tripDayId = 10L;
+
+
+    @Nested
+    @DisplayName("새로운 목적지 추가 테스트")
+    class AddNewsPlaceTest {
+
+        private final int day = 1;
+        private TripDay tripDay;
+        private TripPlaceReq.Request request;
+
+        @Captor
+        private ArgumentCaptor<Place> placeCaptor;
+
+        @BeforeEach
+        void setUp() {
+            tripDay = TripDay.builder()
+                    .trip(mock(Trip.class))
+                    .day(day)
+                    .build();
+
+            ReflectionTestUtils.setField(tripDay, "id", tripDayId);
+
+            request = TripPlaceReq.Request.builder()
+                    .name("목적지1")
+                    .latitude(0.0)
+                    .longitude(0.0)
+                    .placeType(PlaceCategory.RESTAURANT)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("실패 - 여행 일정이 없는 경우")
+        void failWhenTripDayNotFound() {
+            // given
+            given(tripDayService.readByTripIdAndDay(tripId, day)).willReturn(Optional.empty());
+
+            // when
+            CustomException exception = assertThrows(CustomException.class,
+                    () -> tripPlaceCommandService.addNewPlace(tripId, day, request));
+
+            // then
+            assertEquals(TripErrorType.TRIP_DAY_NOT_FOUND, exception.getErrorType());
+            verify(placeService, never()).save(any(Place.class));
+        }
+
+        @Test
+        @DisplayName("가장 처음 추가되는 경우 - 기존에 목적지 없는 상태")
+        void addPlaceFirst() {
+            // given
+            given(tripDayService.readByTripIdAndDay(tripId, day)).willReturn(Optional.ofNullable(tripDay));
+            given(placeService.countByTripDayId(tripDayId)).willReturn(0);
+
+            // when
+            tripPlaceCommandService.addNewPlace(tripId, day, request);
+
+            // then
+            verify(placeService, times(1)).save(placeCaptor.capture());
+
+            Place captured = placeCaptor.getValue();
+            assertEquals(1, captured.getSortOrder());
+        }
+
+        @Test
+        @DisplayName("가장 뒤에 추가되는 경우")
+        void addPlaceBack() {
+            // given
+            given(tripDayService.readByTripIdAndDay(tripId, day)).willReturn(Optional.ofNullable(tripDay));
+            given(placeService.countByTripDayId(tripDayId)).willReturn(3);
+
+            // when
+            tripPlaceCommandService.addNewPlace(tripId, day, request);
+
+            // then
+            verify(placeService, times(1)).save(placeCaptor.capture());
+
+            Place captured = placeCaptor.getValue();
+            assertEquals(4, captured.getSortOrder());
+        }
+
+    }
+}

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingServiceTest.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.application.tripplace.service;
 
-import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReqLegacy;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
@@ -46,7 +46,7 @@ public class TripPlaceEditingServiceTest {
     class AssignPlaceToDayTest {
 
         private final String placeId = "place-id";
-        private final TripPlaceReq.Request request = TripPlaceReq.Request.builder()
+        private final TripPlaceReqLegacy.Request request = TripPlaceReqLegacy.Request.builder()
                 .name("목적지1")
                 .latitude(0.0)
                 .longitude(0.0)
@@ -64,7 +64,7 @@ public class TripPlaceEditingServiceTest {
             tripPlaceEditingService.assignPlaceToDay(tripId, day, request);
 
             // then
-            verify(redisRepository, times(1)).setList(anyString(), any(TripPlaceReq.StoredFormat.class));
+            verify(redisRepository, times(1)).setList(anyString(), any(TripPlaceReqLegacy.StoredFormat.class));
             verify(redisRepository, times(1)).addToSet(eq(dayPlaceSetKey), anyString());
         }
 
@@ -95,11 +95,11 @@ public class TripPlaceEditingServiceTest {
         @DisplayName("목적지 삭제 성공")
         void deletePlaceInEditingSuccess() {
             // given
-            TripPlaceReq.StoredFormat place = new TripPlaceReq.StoredFormat(
+            TripPlaceReqLegacy.StoredFormat place = new TripPlaceReqLegacy.StoredFormat(
                     placeId, "목적지1", 33.123, 126.456, PlaceCategory.RESTAURANT
             );
 
-            given(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class)))
+            given(redisRepository.getList(anyString(), eq(TripPlaceReqLegacy.StoredFormat.class)))
                     .willReturn(List.of(place));
 
             // when
@@ -114,7 +114,7 @@ public class TripPlaceEditingServiceTest {
         @DisplayName("목적지 삭제 실패 - 존재하지 않음")
         void deletePlaceInEditingNotFound() {
             // given
-            given(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class)))
+            given(redisRepository.getList(anyString(), eq(TripPlaceReqLegacy.StoredFormat.class)))
                     .willReturn(List.of());
 
             // when
@@ -130,18 +130,18 @@ public class TripPlaceEditingServiceTest {
     @DisplayName("목적지 순서 수정 성공")
     void reorderPlacesInEditingSuccess() {
         // given
-        List<TripPlaceReq.StoredFormat> storedPlace = List.of(
-                new TripPlaceReq.StoredFormat("place1-id", "목적지1", 33.1, 126.1, PlaceCategory.RESTAURANT),
-                new TripPlaceReq.StoredFormat("place2-id", "목적지2", 33.2, 126.2, PlaceCategory.RESTAURANT),
-                new TripPlaceReq.StoredFormat("place3-id", "목적지3", 33.3, 126.3, PlaceCategory.RESTAURANT)
+        List<TripPlaceReqLegacy.StoredFormat> storedPlace = List.of(
+                new TripPlaceReqLegacy.StoredFormat("place1-id", "목적지1", 33.1, 126.1, PlaceCategory.RESTAURANT),
+                new TripPlaceReqLegacy.StoredFormat("place2-id", "목적지2", 33.2, 126.2, PlaceCategory.RESTAURANT),
+                new TripPlaceReqLegacy.StoredFormat("place3-id", "목적지3", 33.3, 126.3, PlaceCategory.RESTAURANT)
         );
 
-        TripPlaceReq.ReorderRequest request =
-                new TripPlaceReq.ReorderRequest(List.of("place3-id", "place1-id", "place2-id"));
+        TripPlaceReqLegacy.ReorderRequest request =
+                new TripPlaceReqLegacy.ReorderRequest(List.of("place3-id", "place1-id", "place2-id"));
 
         String listKey = "trip:1:day:1:places";
 
-        given(redisRepository.getList(listKey, TripPlaceReq.StoredFormat.class)).willReturn(storedPlace);
+        given(redisRepository.getList(listKey, TripPlaceReqLegacy.StoredFormat.class)).willReturn(storedPlace);
 
         // when
         tripPlaceEditingService.reorderPlaces(tripId, day, request);
@@ -156,11 +156,11 @@ public class TripPlaceEditingServiceTest {
     @DisplayName("편집 중인 여행 일정 조회 성공")
     void getPlacesInEditingSuccess() {
         // given
-        List<TripPlaceReq.StoredFormat> mockPlaces = List.of(
-                new TripPlaceReq.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.RESTAURANT)
+        List<TripPlaceReqLegacy.StoredFormat> mockPlaces = List.of(
+                new TripPlaceReqLegacy.StoredFormat("place-id", "목적지1", 33.123, 126.456, PlaceCategory.RESTAURANT)
         );
 
-        given(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class))).willReturn(mockPlaces);
+        given(redisRepository.getList(anyString(), eq(TripPlaceReqLegacy.StoredFormat.class))).willReturn(mockPlaces);
 
         // when
         List<TripPlaceRes.TempPlaceInfo> result = tripPlaceEditingService.getAssignedPlaces(tripId, day);

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingServiceLegacyTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingServiceLegacyTest.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.application.tripplace.service;
 
-import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReqLegacy;
 import kr.co.yeogiga.domain.trip.entity.Trip;
 import kr.co.yeogiga.domain.trip.service.TripService;
 import kr.co.yeogiga.domain.trip.type.TravelStatus;
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class TripPlaceSavingServiceTest {
+public class TripPlaceSavingServiceLegacyTest {
 
     @Mock
     private TripDayPlaceService tripDayPlaceService;
@@ -46,7 +46,7 @@ public class TripPlaceSavingServiceTest {
     private TripService tripService;
 
     @InjectMocks
-    private TripPlaceSavingService tripPlaceSavingService;
+    private TripPlaceSavingServiceLegacy tripPlaceSavingServiceLegacy;
 
     private final Long tripId = 1L;
     private final int lastDay = 2;
@@ -61,14 +61,14 @@ public class TripPlaceSavingServiceTest {
     @DisplayName("여행 생성 완료 성공 - 여행 전")
     void completeTripSuccessPlanned() {
         // given
-        TripPlaceReq.StoredFormat place1 = new TripPlaceReq.StoredFormat(
+        TripPlaceReqLegacy.StoredFormat place1 = new TripPlaceReqLegacy.StoredFormat(
                 "id1", "장소1", 33.123, 126.456, PlaceCategory.TOURISM
         );
-        TripPlaceReq.StoredFormat place2 = new TripPlaceReq.StoredFormat(
+        TripPlaceReqLegacy.StoredFormat place2 = new TripPlaceReqLegacy.StoredFormat(
                 "id2", "장소2", 33.789, 126.987, PlaceCategory.RESTAURANT
         );
 
-        when(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class)))
+        when(redisRepository.getList(anyString(), eq(TripPlaceReqLegacy.StoredFormat.class)))
                 .thenReturn(List.of(place1))
                 .thenReturn(List.of(place2));
 
@@ -85,10 +85,10 @@ public class TripPlaceSavingServiceTest {
             mockedLocalDateTime.when(LocalDateTime::now).thenReturn(mockNow);
 
             // when
-            tripPlaceSavingService.completeTrip(tripId, lastDay);
+            tripPlaceSavingServiceLegacy.completeTrip(tripId, lastDay);
 
             // then
-            verify(redisRepository, times(2)).getList(anyString(), eq(TripPlaceReq.StoredFormat.class));
+            verify(redisRepository, times(2)).getList(anyString(), eq(TripPlaceReqLegacy.StoredFormat.class));
             verify(tripDayPlaceService, times(1)).saveAll(any());
             verify(redisRepository, times(1)).del(PlaceConstant.dayPlacesKey(tripId, 1));
             verify(redisRepository, times(1)).del(PlaceConstant.dayPlaceSetKey(tripId, 1));
@@ -103,14 +103,14 @@ public class TripPlaceSavingServiceTest {
     @DisplayName("여행 생성 완료 성공 - 여행 중")
     void completeTripSuccessInProgress() {
         // given
-        TripPlaceReq.StoredFormat place1 = new TripPlaceReq.StoredFormat(
+        TripPlaceReqLegacy.StoredFormat place1 = new TripPlaceReqLegacy.StoredFormat(
                 "id1", "장소1", 33.123, 126.456, PlaceCategory.TOURISM
         );
-        TripPlaceReq.StoredFormat place2 = new TripPlaceReq.StoredFormat(
+        TripPlaceReqLegacy.StoredFormat place2 = new TripPlaceReqLegacy.StoredFormat(
                 "id2", "장소2", 33.789, 126.987, PlaceCategory.RESTAURANT
         );
 
-        when(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class)))
+        when(redisRepository.getList(anyString(), eq(TripPlaceReqLegacy.StoredFormat.class)))
                 .thenReturn(List.of(place1))
                 .thenReturn(List.of(place2));
 
@@ -127,10 +127,10 @@ public class TripPlaceSavingServiceTest {
             mockedLocalDateTime.when(LocalDateTime::now).thenReturn(mockNow);
 
             // when
-            tripPlaceSavingService.completeTrip(tripId, lastDay);
+            tripPlaceSavingServiceLegacy.completeTrip(tripId, lastDay);
 
             // then
-            verify(redisRepository, times(2)).getList(anyString(), eq(TripPlaceReq.StoredFormat.class));
+            verify(redisRepository, times(2)).getList(anyString(), eq(TripPlaceReqLegacy.StoredFormat.class));
             verify(tripDayPlaceService, times(1)).saveAll(any());
             verify(redisRepository, times(1)).del(PlaceConstant.dayPlacesKey(tripId, 1));
             verify(redisRepository, times(1)).del(PlaceConstant.dayPlaceSetKey(tripId, 1));
@@ -145,14 +145,14 @@ public class TripPlaceSavingServiceTest {
     @DisplayName("여행 생성 완료 성공 - 여행 후")
     void completeTripSuccessCompleted() {
         // given
-        TripPlaceReq.StoredFormat place1 = new TripPlaceReq.StoredFormat(
+        TripPlaceReqLegacy.StoredFormat place1 = new TripPlaceReqLegacy.StoredFormat(
                 "id1", "장소1", 33.123, 126.456, PlaceCategory.TOURISM
         );
-        TripPlaceReq.StoredFormat place2 = new TripPlaceReq.StoredFormat(
+        TripPlaceReqLegacy.StoredFormat place2 = new TripPlaceReqLegacy.StoredFormat(
                 "id2", "장소2", 33.789, 126.987, PlaceCategory.RESTAURANT
         );
 
-        when(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class)))
+        when(redisRepository.getList(anyString(), eq(TripPlaceReqLegacy.StoredFormat.class)))
                 .thenReturn(List.of(place1))
                 .thenReturn(List.of(place2));
 
@@ -169,10 +169,10 @@ public class TripPlaceSavingServiceTest {
             mockedLocalDateTime.when(LocalDateTime::now).thenReturn(mockNow);
 
             // when
-            tripPlaceSavingService.completeTrip(tripId, lastDay);
+            tripPlaceSavingServiceLegacy.completeTrip(tripId, lastDay);
 
             // then
-            verify(redisRepository, times(2)).getList(anyString(), eq(TripPlaceReq.StoredFormat.class));
+            verify(redisRepository, times(2)).getList(anyString(), eq(TripPlaceReqLegacy.StoredFormat.class));
             verify(tripDayPlaceService, times(1)).saveAll(any());
             verify(redisRepository, times(1)).del(PlaceConstant.dayPlacesKey(tripId, 1));
             verify(redisRepository, times(1)).del(PlaceConstant.dayPlaceSetKey(tripId, 1));

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingServiceTest.java
@@ -1,0 +1,191 @@
+package kr.co.yeogiga.application.tripplace.service;
+
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.service.PlaceService;
+import kr.co.yeogiga.domain.trip.service.TripDayService;
+import kr.co.yeogiga.domain.trip.service.TripService;
+import kr.co.yeogiga.domain.trip.type.PlaceCategory;
+import kr.co.yeogiga.domain.trip.type.TravelStatus;
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import kr.co.yeogiga.infrastructure.redis.constant.PlaceConstant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TripPlaceSavingServiceTest {
+
+    @Mock
+    private TripService tripService;
+
+    @Mock
+    private TripDayService tripDayService;
+
+    @Mock
+    private PlaceService placeService;
+
+    @Mock
+    private RedisRepository redisRepository;
+
+    @InjectMocks
+    private TripPlaceSavingService tripPlaceSavingService;
+
+    private final Long tripId = 1L;
+    private final int lastDay = 2;
+
+    private Trip trip = Trip.builder()
+            .title("title")
+            .travelStatus(TravelStatus.SETTING)
+            .leaderId(1L)
+            .build();
+
+    @Test
+    @DisplayName("여행 생성 완료 성공 - 여행 전")
+    void completeTripSuccessPlanned() {
+        // given
+        TripPlaceReq.StoredFormat place1 = new TripPlaceReq.StoredFormat(
+                "id1", "장소1", 33.123, 126.456, PlaceCategory.TOURISM
+        );
+        TripPlaceReq.StoredFormat place2 = new TripPlaceReq.StoredFormat(
+                "id2", "장소2", 33.789, 126.987, PlaceCategory.RESTAURANT
+        );
+
+        when(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class)))
+                .thenReturn(List.of(place1))
+                .thenReturn(List.of(place2));
+
+        ReflectionTestUtils.setField(trip, "startedAt", LocalDateTime.of(2025, 5, 25, 12, 0));
+        ReflectionTestUtils.setField(trip, "endedAt", LocalDateTime.of(2025, 5, 26, 12, 0));
+
+        when(tripService.readById(tripId)).thenReturn(Optional.of(trip));
+
+        try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+            String date = "2025-05-24T12:00:00Z";
+            Clock clock = Clock.fixed(Instant.parse(date), ZoneId.of("UTC"));
+            LocalDateTime mockNow = LocalDateTime.now(clock);
+            mockedLocalDateTime.when(LocalDateTime::now).thenReturn(mockNow);
+
+            // when
+            tripPlaceSavingService.completeTrip(tripId, lastDay);
+
+            // then
+            verify(redisRepository, times(2)).getList(anyString(), eq(TripPlaceReq.StoredFormat.class));
+            verify(tripDayService, times(2)).save(any());
+            verify(placeService, times(1)).saveAll(any());
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlacesKey(tripId, 1));
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlaceSetKey(tripId, 1));
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlacesKey(tripId, 2));
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlaceSetKey(tripId, 2));
+
+            assertEquals(TravelStatus.PLANNED, trip.getTravelStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("여행 생성 완료 성공 - 여행 중")
+    void completeTripSuccessInProgress() {
+        // given
+        TripPlaceReq.StoredFormat place1 = new TripPlaceReq.StoredFormat(
+                "id1", "장소1", 33.123, 126.456, PlaceCategory.TOURISM
+        );
+        TripPlaceReq.StoredFormat place2 = new TripPlaceReq.StoredFormat(
+                "id2", "장소2", 33.789, 126.987, PlaceCategory.RESTAURANT
+        );
+
+        when(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class)))
+                .thenReturn(List.of(place1))
+                .thenReturn(List.of(place2));
+
+
+        ReflectionTestUtils.setField(trip, "startedAt", LocalDateTime.of(2025, 5, 25, 12, 0));
+        ReflectionTestUtils.setField(trip, "endedAt", LocalDateTime.of(2025, 5, 26, 12, 0));
+
+        when(tripService.readById(tripId)).thenReturn(Optional.of(trip));
+
+        try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+            String date = "2025-05-25T18:00:00Z";
+            Clock clock = Clock.fixed(Instant.parse(date), ZoneId.of("Asia/Seoul"));
+            LocalDateTime mockNow = LocalDateTime.now(clock);
+            mockedLocalDateTime.when(LocalDateTime::now).thenReturn(mockNow);
+
+            // when
+            tripPlaceSavingService.completeTrip(tripId, lastDay);
+
+            // then
+            verify(redisRepository, times(2)).getList(anyString(), eq(TripPlaceReq.StoredFormat.class));
+            verify(tripDayService, times(2)).save(any());
+            verify(placeService, times(1)).saveAll(any());
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlacesKey(tripId, 1));
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlaceSetKey(tripId, 1));
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlacesKey(tripId, 2));
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlaceSetKey(tripId, 2));
+
+            assertEquals(TravelStatus.IN_PROGRESS, trip.getTravelStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("여행 생성 완료 성공 - 여행 후")
+    void completeTripSuccessCompleted() {
+        // given
+        TripPlaceReq.StoredFormat place1 = new TripPlaceReq.StoredFormat(
+                "id1", "장소1", 33.123, 126.456, PlaceCategory.TOURISM
+        );
+        TripPlaceReq.StoredFormat place2 = new TripPlaceReq.StoredFormat(
+                "id2", "장소2", 33.789, 126.987, PlaceCategory.RESTAURANT
+        );
+
+        when(redisRepository.getList(anyString(), eq(TripPlaceReq.StoredFormat.class)))
+                .thenReturn(List.of(place1))
+                .thenReturn(List.of(place2));
+
+
+        ReflectionTestUtils.setField(trip, "startedAt", LocalDateTime.of(2025, 5, 20, 12, 0));
+        ReflectionTestUtils.setField(trip, "endedAt", LocalDateTime.of(2025, 5, 21, 12, 0));
+
+        when(tripService.readById(tripId)).thenReturn(Optional.of(trip));
+
+        try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+            String date = "2025-05-24T12:00:00Z";
+            Clock clock = Clock.fixed(Instant.parse(date), ZoneId.of("UTC"));
+            LocalDateTime mockNow = LocalDateTime.now(clock);
+            mockedLocalDateTime.when(LocalDateTime::now).thenReturn(mockNow);
+
+            // when
+            tripPlaceSavingService.completeTrip(tripId, lastDay);
+
+            // then
+            verify(redisRepository, times(2)).getList(anyString(), eq(TripPlaceReq.StoredFormat.class));
+            verify(tripDayService, times(2)).save(any());
+            verify(placeService, times(1)).saveAll(any());
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlacesKey(tripId, 1));
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlaceSetKey(tripId, 1));
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlacesKey(tripId, 2));
+            verify(redisRepository, times(1)).del(PlaceConstant.dayPlaceSetKey(tripId, 2));
+
+            assertEquals(TravelStatus.COMPLETED, trip.getTravelStatus());
+        }
+    }
+}

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSortServiceTest.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.application.tripplace.service;
 
-import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReqLegacy;
 import kr.co.yeogiga.domain.trip.type.PlaceCategory;
 import kr.co.yeogiga.infrastructure.redis.RedisRepository;
 import kr.co.yeogiga.infrastructure.redis.constant.PlaceConstant;
@@ -44,7 +44,7 @@ class TripPlaceSortServiceTest {
         // given
         String listKey = PlaceConstant.dayPlacesKey(tripId, day);
 
-        given(redisRepository.getList(eq(listKey), eq(TripPlaceReq.StoredFormat.class)))
+        given(redisRepository.getList(eq(listKey), eq(TripPlaceReqLegacy.StoredFormat.class)))
                 .willReturn(Collections.emptyList());
 
         // when
@@ -60,25 +60,25 @@ class TripPlaceSortServiceTest {
         // given
         String listKey = PlaceConstant.dayPlacesKey(tripId, day);
 
-        List<TripPlaceReq.StoredFormat> input = List.of(
-                new TripPlaceReq.StoredFormat("1", "PlaceA", 35.1, 128.1, PlaceCategory.RESTAURANT),
-                new TripPlaceReq.StoredFormat("2", "PlaceB", 35.2, 128.2, PlaceCategory.TOURISM),
-                new TripPlaceReq.StoredFormat("3", "PlaceC", 35.3, 128.3, PlaceCategory.LODGING)
+        List<TripPlaceReqLegacy.StoredFormat> input = List.of(
+                new TripPlaceReqLegacy.StoredFormat("1", "PlaceA", 35.1, 128.1, PlaceCategory.RESTAURANT),
+                new TripPlaceReqLegacy.StoredFormat("2", "PlaceB", 35.2, 128.2, PlaceCategory.TOURISM),
+                new TripPlaceReqLegacy.StoredFormat("3", "PlaceC", 35.3, 128.3, PlaceCategory.LODGING)
         );
 
-        given(redisRepository.getList(eq(listKey), eq(TripPlaceReq.StoredFormat.class)))
+        given(redisRepository.getList(eq(listKey), eq(TripPlaceReqLegacy.StoredFormat.class)))
                 .willReturn(input);
 
         // when
         tripPlaceSortService.sortDayTripPlaces(tripId, day);
 
         // then
-        ArgumentCaptor<Collection<TripPlaceReq.StoredFormat>> captor =
+        ArgumentCaptor<Collection<TripPlaceReqLegacy.StoredFormat>> captor =
                 ArgumentCaptor.forClass(Collection.class);
 
         verify(redisRepository, times(1)).setListAll(eq(listKey), captor.capture());
 
-        List<TripPlaceReq.StoredFormat> saved = new ArrayList<>(captor.getValue());
+        List<TripPlaceReqLegacy.StoredFormat> saved = new ArrayList<>(captor.getValue());
         assertEquals(PlaceCategory.LODGING, saved.get(2).placeCategory());
     }
 
@@ -88,30 +88,30 @@ class TripPlaceSortServiceTest {
         // given
         String listKey = PlaceConstant.dayPlacesKey(tripId, day);
 
-        List<TripPlaceReq.StoredFormat> input = List.of(
-                new TripPlaceReq.StoredFormat("1", "A", 35.0, 128.0, PlaceCategory.RESTAURANT),
-                new TripPlaceReq.StoredFormat("2", "B", 35.1, 128.1, PlaceCategory.RESTAURANT),
-                new TripPlaceReq.StoredFormat("3", "C", 35.2, 128.2, PlaceCategory.RESTAURANT),
-                new TripPlaceReq.StoredFormat("4", "D", 35.3, 128.3, PlaceCategory.LODGING),
-                new TripPlaceReq.StoredFormat("5", "E", 35.4, 128.4, PlaceCategory.TOURISM)
+        List<TripPlaceReqLegacy.StoredFormat> input = List.of(
+                new TripPlaceReqLegacy.StoredFormat("1", "A", 35.0, 128.0, PlaceCategory.RESTAURANT),
+                new TripPlaceReqLegacy.StoredFormat("2", "B", 35.1, 128.1, PlaceCategory.RESTAURANT),
+                new TripPlaceReqLegacy.StoredFormat("3", "C", 35.2, 128.2, PlaceCategory.RESTAURANT),
+                new TripPlaceReqLegacy.StoredFormat("4", "D", 35.3, 128.3, PlaceCategory.LODGING),
+                new TripPlaceReqLegacy.StoredFormat("5", "E", 35.4, 128.4, PlaceCategory.TOURISM)
         );
 
-        given(redisRepository.getList(eq(listKey), eq(TripPlaceReq.StoredFormat.class)))
+        given(redisRepository.getList(eq(listKey), eq(TripPlaceReqLegacy.StoredFormat.class)))
                 .willReturn(input);
 
         // when
         tripPlaceSortService.sortDayTripPlaces(tripId, day);
 
         // then
-        ArgumentCaptor<Collection<TripPlaceReq.StoredFormat>> captor =
+        ArgumentCaptor<Collection<TripPlaceReqLegacy.StoredFormat>> captor =
                 ArgumentCaptor.forClass(Collection.class);
         verify(redisRepository, times(1)).setListAll(eq(listKey), captor.capture());
-        List<TripPlaceReq.StoredFormat> saved = new ArrayList<>(captor.getValue());
+        List<TripPlaceReqLegacy.StoredFormat> saved = new ArrayList<>(captor.getValue());
 
         // 식당 카테고리가 3번 이상 연속하지 않는지 확인
         int maxConsecutiveRestaurants = 0;
         int currentCount = 0;
-        for (TripPlaceReq.StoredFormat place : saved) {
+        for (TripPlaceReqLegacy.StoredFormat place : saved) {
             if (PlaceCategory.RESTAURANT == place.placeCategory()) {
                 currentCount++;
                 maxConsecutiveRestaurants = Math.max(maxConsecutiveRestaurants, currentCount);

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceControllerTest.java
@@ -2,12 +2,12 @@ package kr.co.yeogiga.presentation.tripplace.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.tripplace.dto.TripDaySummaryRes;
-import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReqLegacy;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
 import kr.co.yeogiga.application.tripplace.dto.VisitedMarkReq;
-import kr.co.yeogiga.application.tripplace.service.TripPlaceCommandService;
+import kr.co.yeogiga.application.tripplace.service.TripPlaceCommandServiceLegacy;
 import kr.co.yeogiga.application.tripplace.service.TripPlaceQueryService;
-import kr.co.yeogiga.application.tripplace.service.TripPlaceSavingService;
+import kr.co.yeogiga.application.tripplace.service.TripPlaceSavingServiceLegacy;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
@@ -57,10 +57,10 @@ public class TripPlaceControllerTest {
     private ObjectMapper objectMapper;
 
     @MockBean
-    private TripPlaceSavingService tripPlaceSavingService;
+    private TripPlaceSavingServiceLegacy tripPlaceSavingServiceLegacy;
 
     @MockBean
-    private TripPlaceCommandService tripPlaceCommandService;
+    private TripPlaceCommandServiceLegacy tripPlaceCommandServiceLegacy;
 
     @MockBean
     private TripPlaceQueryService tripPlaceQueryService;
@@ -80,8 +80,8 @@ public class TripPlaceControllerTest {
     @DisplayName("여행 목적지 확정 완료")
     void completeTripSuccess() throws Exception {
         // given
-        TripPlaceReq.CompleteRequest completeRequest = new TripPlaceReq.CompleteRequest(2);
-        doNothing().when(tripPlaceSavingService).completeTrip(tripId, completeRequest.lastDay());
+        TripPlaceReqLegacy.CompleteRequest completeRequest = new TripPlaceReqLegacy.CompleteRequest(2);
+        doNothing().when(tripPlaceSavingServiceLegacy).completeTrip(tripId, completeRequest.lastDay());
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -101,13 +101,13 @@ public class TripPlaceControllerTest {
     @DisplayName("목적지 추가 성공")
     void addNewPlaceSuccess() throws Exception {
         // given
-        TripPlaceReq.Request request = TripPlaceReq.Request.builder()
+        TripPlaceReqLegacy.Request request = TripPlaceReqLegacy.Request.builder()
                 .name("목적지1")
                 .latitude(0.0)
                 .longitude(0.0)
                 .placeType(PlaceCategory.RESTAURANT)
                 .build();
-        doNothing().when(tripPlaceCommandService).addNewPlace(tripDayPlaceId, request);
+        doNothing().when(tripPlaceCommandServiceLegacy).addNewPlace(tripDayPlaceId, request);
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -198,8 +198,8 @@ public class TripPlaceControllerTest {
     @DisplayName("목적지 정렬 성공")
     void reorderPlacesSuccess() throws Exception {
         // given
-        TripPlaceReq.ReorderRequest reorderRequest = new TripPlaceReq.ReorderRequest(List.of("id1", "id2", "id3"));
-        doNothing().when(tripPlaceCommandService).reorderPlaces(tripDayPlaceId, reorderRequest);
+        TripPlaceReqLegacy.ReorderRequest reorderRequest = new TripPlaceReqLegacy.ReorderRequest(List.of("id1", "id2", "id3"));
+        doNothing().when(tripPlaceCommandServiceLegacy).reorderPlaces(tripDayPlaceId, reorderRequest);
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -219,9 +219,9 @@ public class TripPlaceControllerTest {
     @DisplayName("목적지 정렬 실패 - 일차가 존재하지 않음")
     void reorderPlacesFailDayPlaceNotFound() throws Exception {
         // given
-        TripPlaceReq.ReorderRequest reorderRequest = new TripPlaceReq.ReorderRequest(List.of("id1", "id2"));
+        TripPlaceReqLegacy.ReorderRequest reorderRequest = new TripPlaceReqLegacy.ReorderRequest(List.of("id1", "id2"));
         doThrow(new CustomException(TripErrorType.TRIP_PLACE_NOT_FOUND))
-                .when(tripPlaceCommandService).reorderPlaces(tripDayPlaceId, reorderRequest);
+                .when(tripPlaceCommandServiceLegacy).reorderPlaces(tripDayPlaceId, reorderRequest);
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -262,7 +262,7 @@ public class TripPlaceControllerTest {
     @DisplayName("목적지 삭제 성공")
     void deletePlaceSuccess() throws Exception {
         // given
-        doNothing().when(tripPlaceCommandService).deletePlace(tripDayPlaceId, placeId);
+        doNothing().when(tripPlaceCommandServiceLegacy).deletePlace(tripDayPlaceId, placeId);
 
         // when
         ResultActions resultActions = mockMvc.perform(

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingControllerTest.java
@@ -1,7 +1,7 @@
 package kr.co.yeogiga.presentation.tripplace.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.co.yeogiga.application.tripplace.dto.TripPlaceReq;
+import kr.co.yeogiga.application.tripplace.dto.TripPlaceReqLegacy;
 import kr.co.yeogiga.application.tripplace.dto.TripPlaceRes;
 import kr.co.yeogiga.application.tripplace.service.TripPlaceEditingService;
 import kr.co.yeogiga.application.tripplace.service.TripPlaceSortService;
@@ -76,7 +76,7 @@ public class TripPlaceEditingControllerTest {
     @DisplayName("목적지 추가 테스트")
     class AssignPlaceToDayTest {
 
-        private final TripPlaceReq.Request request = TripPlaceReq.Request.builder()
+        private final TripPlaceReqLegacy.Request request = TripPlaceReqLegacy.Request.builder()
                 .name("목적지1")
                 .latitude(0.0)
                 .longitude(0.0)
@@ -130,8 +130,8 @@ public class TripPlaceEditingControllerTest {
     @DisplayName("목적지 수정 성공")
     void reorderPlacesSuccess() throws Exception {
         // given
-        TripPlaceReq.ReorderRequest request =
-                new TripPlaceReq.ReorderRequest(List.of("place3-id", "place1-id", "place2-id"));
+        TripPlaceReqLegacy.ReorderRequest request =
+                new TripPlaceReqLegacy.ReorderRequest(List.of("place3-id", "place1-id", "place2-id"));
 
         doNothing().when(tripPlaceEditingService).reorderPlaces(anyLong(), anyInt(), any());
 


### PR DESCRIPTION
## 배경
 - DB 구조 변경으로 인한, 여행 일정 및 목적지 추가 로직 구현 필요

## 작업 사항
 - 여행 일정  생성 로직 구현 (70d355654be86156c758adad1bcbb325d651563a)
 - 목적지 생성 로직 구현 (2324cfc7fadb1622e3537a9886e96845e399c746)
 - 여행 목적지 확정 로직 구현 (0232583daf5337607ef82d97f3cfaf6f1a0b24ba)
 - 여행 목적지 추가 로직 구현 (ca00fea71883db4c58b73eea22b659f381900043)

## 추가 논의
- 논의는 아니고, 현재 Controller은 기존 레거시 코드를 기준으로 연결되어 있습니다.
그래서, 기존 클래스를 레거시임을 명시하기 위해 클래스명에 레거시를 추가하였습니다. (efb0d16b693fe096d0abe09912267e60b8ef4716)
    - 클래스명 변경 등의 이유로 실제 작업한 내용보다 피알의 크기가 커보일 수있습니다.
- Api연결은 웹/앱에서 혼동이 일어날 것 같아 아직 연동은 하지 않았고, 기존 테스트 코드와 postman을 통해 직접 확인하며 동작 성공 여부를 확인했습니다.