### PR TITLE
Feature: 탈퇴 사용자 로그인 시 에러 응답 필드 추가

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
@@ -63,7 +63,7 @@ public class SignInDto {
             String imageUrl,
             LocalDate deletionExpiration
     ) {
-        public static WithdrawnUserInfo fromEntity(User user) {
+        public static WithdrawnUserInfo from(User user) {
             return WithdrawnUserInfo.builder()
                     .userId(user.getId())
                     .nickname(user.getNickname())

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/SignInDto.java
@@ -2,10 +2,10 @@ package kr.co.yeogiga.application.auth.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import kr.co.yeogiga.domain.user.entity.User;
 import lombok.Builder;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 public class SignInDto {
 
@@ -59,12 +59,16 @@ public class SignInDto {
     @Builder
     public record WithdrawnUserInfo(
             Long userId,
+            String nickname,
+            String imageUrl,
             LocalDate deletionExpiration
     ) {
-        public static WithdrawnUserInfo of(Long userId, LocalDateTime deletedAt) {
+        public static WithdrawnUserInfo fromEntity(User user) {
             return WithdrawnUserInfo.builder()
-                    .userId(userId)
-                    .deletionExpiration(deletedAt.toLocalDate().plusDays(7))
+                    .userId(user.getId())
+                    .nickname(user.getNickname())
+                    .imageUrl(user.getImageUrl())
+                    .deletionExpiration(user.getDeletedAt().toLocalDate().plusDays(7))
                     .build();
         }
     }

--- a/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
@@ -67,7 +67,7 @@ public class AuthService {
         if (user.isDeleted()) {
             throw new CustomException(
                     UserErrorType.ALREADY_WITHDRAW,
-                    SignInDto.WithdrawnUserInfo.of(user.getId(), user.getDeletedAt())
+                    SignInDto.WithdrawnUserInfo.fromEntity(user)
             );
         }
 

--- a/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
@@ -67,7 +67,7 @@ public class AuthService {
         if (user.isDeleted()) {
             throw new CustomException(
                     UserErrorType.ALREADY_WITHDRAW,
-                    SignInDto.WithdrawnUserInfo.fromEntity(user)
+                    SignInDto.WithdrawnUserInfo.from(user)
             );
         }
 

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -104,7 +104,7 @@ public class OAuthManagementService {
                     if (user.isDeleted()) {
                         throw new CustomException(
                                 UserErrorType.ALREADY_WITHDRAW,
-                                SignInDto.WithdrawnUserInfo.of(user.getId(), user.getDeletedAt())
+                                SignInDto.WithdrawnUserInfo.fromEntity(user)
                         );
                     }
 

--- a/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/OAuthManagementService.java
@@ -104,7 +104,7 @@ public class OAuthManagementService {
                     if (user.isDeleted()) {
                         throw new CustomException(
                                 UserErrorType.ALREADY_WITHDRAW,
-                                SignInDto.WithdrawnUserInfo.fromEntity(user)
+                                SignInDto.WithdrawnUserInfo.from(user)
                         );
                     }
 

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
@@ -111,13 +111,15 @@ public interface AuthApi {
                                     """),
                             @ExampleObject(name = "이미 탈퇴된 사용자", description = "탈퇴(Soft Delete)된 사용자에 대한 응답", value = """
                                         {
-                                              "code": "U003",
-                                              "message": "이미 회원탈퇴한 사용자입니다.",
-                                              "data": {
-                                                  "userId": 1,
-                                                  "deletionExpiration": "2025-08-13"
-                                              }
-                                          }
+                                               "code": "U003",
+                                               "message": "이미 회원탈퇴한 사용자입니다.",
+                                               "data": {
+                                                   "userId": 16,
+                                                   "nickname": "nick16",
+                                                   "imageUrl": null,
+                                                   "deletionExpiration": "2025-08-29"
+                                               }
+                                           }
                                     """),
                             @ExampleObject(name = "인증 실패", description = "아이디 또는 비밀번호 불일치", value = """
                                         {

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/OAuthApi.java
@@ -73,13 +73,15 @@ public interface OAuthApi {
                                     """),
                             @ExampleObject(name = "이미 탈퇴한 사용자", description = "탈퇴(Soft Delete)된 사용자에 대한 응답", value = """
                                         {
-                                              "code": "U003",
-                                              "message": "이미 회원탈퇴한 사용자입니다.",
-                                              "data": {
-                                                  "userId": 1,
-                                                  "deletionExpiration": "2025-08-13"
-                                              }
-                                          }
+                                               "code": "U003",
+                                               "message": "이미 회원탈퇴한 사용자입니다.",
+                                               "data": {
+                                                   "userId": 16,
+                                                   "nickname": "nick16",
+                                                   "imageUrl": null,
+                                                   "deletionExpiration": "2025-08-29"
+                                               }
+                                           }
                                     """)
                     }))
     })

--- a/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
@@ -291,6 +291,8 @@ public class AuthServiceTest {
             assertEquals(UserErrorType.ALREADY_WITHDRAW, exception.getErrorType());
             SignInDto.WithdrawnUserInfo withdrawnUserInfo = (SignInDto.WithdrawnUserInfo) exception.getData();
             assertEquals(1L, withdrawnUserInfo.userId());
+            assertEquals("testnick", withdrawnUserInfo.nickname());
+            assertThat(withdrawnUserInfo.imageUrl()).isNull();
             assertEquals(LocalDate.now().plusDays(7), withdrawnUserInfo.deletionExpiration());
         }
     }

--- a/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
@@ -33,7 +33,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -480,7 +479,13 @@ public class AuthControllerTest {
             
             doThrow(new CustomException(
                     UserErrorType.ALREADY_WITHDRAW,
-                    SignInDto.WithdrawnUserInfo.of(1L, LocalDateTime.now()))
+                    SignInDto.WithdrawnUserInfo.builder()
+                            .userId(1L)
+                            .nickname("nickname")
+                            .imageUrl("https://image.com")
+                            .deletionExpiration(LocalDate.now().plusDays(7))
+                            .build()
+                    )
             ).when(authService).signIn(request);
             
             // when
@@ -497,6 +502,8 @@ public class AuthControllerTest {
                     .andExpect(jsonPath("$.code").value(UserErrorType.ALREADY_WITHDRAW.getCode()))
                     .andExpect(jsonPath("$.message").value(UserErrorType.ALREADY_WITHDRAW.getMessage()))
                     .andExpect(jsonPath("$.data.userId").value(1L))
+                    .andExpect(jsonPath("$.data.nickname").value("nickname"))
+                    .andExpect(jsonPath("$.data.imageUrl").value("https://image.com"))
                     .andExpect(jsonPath("$.data.deletionExpiration").value(LocalDate.now().plusDays(7).toString()));
         }
     }

--- a/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/oauth/controller/OAuthControllerTest.java
@@ -49,8 +49,6 @@ public class OAuthControllerTest {
     @MockBean
     private OAuthManagementService oAuthManagementService;
     
-    
-
     @BeforeEach
     void setUp(WebApplicationContext webApplicationContext) {
         this.mockMvc = MockMvcBuilders


### PR DESCRIPTION
## 배경
- 탈퇴한 사용자 로그인 시 에러 응답 내 필드 추가 요청
  - 닉네임
  - 프로필 이미지 url

## 작업 사항
- 탈퇴 사용자 정보 DTO(`SignInDto.WithdrawnUserInfo`) 내 필드 추가 | (924394d6182facf62d5735801fcadccfbd57a96e)
  - `String nickname`
  - `String imageUrl`

## 추가 논의
- PR 병합 이후 프론트 파트에게 변경 사항 전달하겠습니다.