### PR TITLE
Fix: 임시 저장 이미지 삭제 로직 수정

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/image/service/TempPlaceImagesCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/image/service/TempPlaceImagesCommandService.java
@@ -27,11 +27,11 @@ public class TempPlaceImagesCommandService {
      * - MongoDB 문서에서 이미지 삭제 - imageIds
      * - AWS S3에서 이미지 삭제 - urls
      *
-     * @param tempPlaceImageId 임시 저장소 ID
-     * @param deleteDto        이미지 삭제 정보 객체
+     * @param tripDayPlaceId 여행일차 ID
+     * @param deleteDto      이미지 삭제 정보 객체
      */
-    public void removeTempImages(String tempPlaceImageId, ImageDeleteDto deleteDto) {
-        tempPlaceImagesService.deleteImages(tempPlaceImageId, deleteDto.imageIds());
+    public void removeTempImages(String tripDayPlaceId, ImageDeleteDto deleteDto) {
+        tempPlaceImagesService.deleteImages(tripDayPlaceId, deleteDto.imageIds());
         imageDeleteProcessor.process(deleteDto.urls());
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTempPlaceImagesRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTempPlaceImagesRepository.java
@@ -6,5 +6,5 @@ import java.util.List;
 
 public interface CustomTempPlaceImagesRepository {
     void saveImage(String tripDayPlaceId, Image image);
-    void deleteImages(String id, List<String> imageIds);
+    void deleteImages(String tripDayPlaceId, List<String> imageIds);
 }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTempPlaceImagesRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTempPlaceImagesRepositoryImpl.java
@@ -31,8 +31,8 @@ public class CustomTempPlaceImagesRepositoryImpl implements CustomTempPlaceImage
     }
 
     @Override
-    public void deleteImages(String id, List<String> imageIds) {
-        Query query = new Query(Criteria.where("_id").is(id));
+    public void deleteImages(String tripDayPlaceId, List<String> imageIds) {
+        Query query = new Query(Criteria.where("tripDayPlaceId").is(tripDayPlaceId));
         Update update = new Update().pull("images", Query.query(Criteria.where("id").in(imageIds)));
         mongoTemplate.updateFirst(query, update, TempPlaceImages.class);
     }

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/service/TempPlaceImagesService.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/service/TempPlaceImagesService.java
@@ -26,7 +26,7 @@ public class TempPlaceImagesService {
         tempPlaceImagesRepository.deleteById(id);
     }
 
-    public void deleteImages(String id, List<String> imageIds) {
-        tempPlaceImagesRepository.deleteImages(id, imageIds);
+    public void deleteImages(String tripDayPlaceId, List<String> imageIds) {
+        tempPlaceImagesRepository.deleteImages(tripDayPlaceId, imageIds);
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/image/controller/ImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/image/controller/ImageController.java
@@ -58,11 +58,11 @@ public class ImageController implements ImageApi {
     }
 
     @Override
-    @DeleteMapping("/{tripId}/day-place/temp-images/{tempPlaceImageId}")
+    @DeleteMapping("/{tripId}/day-place/temp-images/{tripDayPlaceId}")
     public ResponseEntity<?> removeTempImages(@PathVariable Long tripId,
-                                              @PathVariable String tempPlaceImageId,
+                                              @PathVariable String tripDayPlaceId,
                                               @RequestBody ImageDeleteDto deleteDto) {
-        tempPlaceImagesCommandService.removeTempImages(tempPlaceImageId, deleteDto);
+        tempPlaceImagesCommandService.removeTempImages(tripDayPlaceId, deleteDto);
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/image/controller/ImageControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/image/controller/ImageControllerTest.java
@@ -149,11 +149,10 @@ public class ImageControllerTest {
         List<String> urls = List.of("https://image1.com", "https://image2.com");
 
         ImageDeleteDto deleteDto = new ImageDeleteDto(imageIds, urls);
-        String tempPlaceImageId = "tempPlaceImage-Id";
 
         // when
         ResultActions resultActions = mockMvc.perform(
-                delete("/api/v1/trip/{tripId}/day-place/temp-images/{tempPlaceImageId}}", tripId, tempPlaceImageId)
+                delete("/api/v1/trip/{tripId}/day-place/temp-images/{tripDayPlaceId}}", tripId, tripDayPlaceId)
                         .content(objectMapper.writeValueAsBytes(deleteDto))
                         .contentType(MediaType.APPLICATION_JSON)
         );


### PR DESCRIPTION
## 배경
- 현재 임시 저장 이미지를 삭제하기 위해 임시 저장 이미지의 id를 통해 삭제
- 임시 저장 이미지 id의 값을 주지 않기 때문에, 여행 일차 id를 통해 삭제해야 함.

## 작업 사항
- 임시 저장 이미지 삭제 로직 수정

## 추가 논의
- x