### PR TITLE
Feature(IL-282): 정산 내역 생성 로직 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
@@ -11,12 +11,10 @@ import kr.co.yeogiga.domain.settlement.entity.PayInfo;
 import kr.co.yeogiga.domain.settlement.entity.Settlement;
 import kr.co.yeogiga.domain.settlement.type.SettlementType;
 import lombok.Builder;
-import lombok.Getter;
 
 import java.time.LocalDate;
 import java.util.List;
 
-@Getter
 public class SettlementRequest {
     
     @Schema(name = "SettlementRequest.SettlementDto", description = "정산 내역 생성 요청 DTO")

--- a/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
@@ -1,0 +1,51 @@
+package kr.co.yeogiga.application.settlement.dto;
+
+import kr.co.yeogiga.domain.settlement.entity.PayInfo;
+import kr.co.yeogiga.domain.settlement.entity.Settlement;
+import kr.co.yeogiga.domain.settlement.type.SettlementType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+public class SettlementRequest {
+    
+    @Builder
+    public record SettlementDto (
+            String name,
+            Long totalPrice,
+            LocalDate date,
+            SettlementType type,
+            List<PayInfoDto> payers
+    ) {
+        public Settlement toEntity(Long tripId, Long payerId, boolean isCompleted) {
+            return Settlement.builder()
+                    .tripId(tripId)
+                    .name(name)
+                    .totalPrice(totalPrice)
+                    .date(date)
+                    .type(type)
+                    .payerId(payerId)
+                    .isCompleted(isCompleted)
+                    .build();
+        }
+    }
+    
+    @Builder
+    public record PayInfoDto (
+            Long userId,
+            Long price,
+            boolean isCompleted
+    ) {
+        public PayInfo toEntity(Long settlementId) {
+            return PayInfo.builder()
+                    .userId(userId)
+                    .price(price)
+                    .isCompleted(isCompleted)
+                    .settlementId(settlementId)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
@@ -1,10 +1,12 @@
 package kr.co.yeogiga.application.settlement.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import kr.co.yeogiga.common.validation.EnumValidation;
 import kr.co.yeogiga.domain.settlement.entity.PayInfo;
 import kr.co.yeogiga.domain.settlement.entity.Settlement;
 import kr.co.yeogiga.domain.settlement.type.SettlementType;
@@ -17,21 +19,28 @@ import java.util.List;
 @Getter
 public class SettlementRequest {
     
+    @Schema(name = "SettlementRequest.SettlementDto", description = "정산 내역 생성 요청 DTO")
     @Builder
     public record SettlementDto (
+            @Schema(description = "정산 내역 이름", example = "점심 식사")
             @NotBlank(message = "이름은 필수 입력값입니다.")
             String name,
             
+            @Schema(description = "금액", example = "50000")
             @NotNull(message = "금액은 필수 입력값입니다.")
             @Min(value = 0, message = "최소 금액은 0원입니다.")
             Long totalPrice,
             
+            @Schema(description = "날짜", example = "2025-09-08")
             @NotNull(message = "날짜는 필수 입력값입니다.")
             LocalDate date,
             
+            @Schema(description = "정산 내역 타입", examples = {"ATTRACTION(관광지)", "LODGING(숙소)", "MEAL(식사)", "TRANSPORTATION(이동수단)", "ETC(기타)"})
+            @EnumValidation(target = SettlementType.class, message = "지원하지 않는 정산 내역 타입입니다.")
             @NotNull(message = "타입은 필수 입력값입니다.")
             SettlementType type,
             
+            @Schema(description = "정산 인원 목록")
             @Valid
             @NotNull(message = "정산 인원은 필수 입력값입니다.")
             @NotEmpty(message = "정산 인원은 최소 1명 이상이어야합니다.")
@@ -49,16 +58,20 @@ public class SettlementRequest {
                     .build();
         }
     }
-    
+   
+    @Schema(name = "SettlementRequest.PayInfoDto", description = "인원 별 정산 금액 및 여부")
     @Builder
     public record PayInfoDto (
+            @Schema(description = "사용자 ID", example = "1")
             @NotNull(message = "사용자 id는 필수 입력값입니다.")
             Long userId,
             
+            @Schema(description = "해당 인원의 정산 금액", example = "10000")
             @NotNull(message = "인원 별 정산 금액은 필수 입력값입니다.")
             @Min(value = 0, message = "최소 금액은 0원입니다.")
             Long price,
             
+            @Schema(description = "해당 인원의 정산 완료 여부", examples = {"true", "false"})
             boolean isCompleted
     ) {
         public PayInfo toEntity(Long settlementId) {

--- a/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
@@ -1,5 +1,10 @@
 package kr.co.yeogiga.application.settlement.dto;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import kr.co.yeogiga.domain.settlement.entity.PayInfo;
 import kr.co.yeogiga.domain.settlement.entity.Settlement;
 import kr.co.yeogiga.domain.settlement.type.SettlementType;
@@ -14,10 +19,22 @@ public class SettlementRequest {
     
     @Builder
     public record SettlementDto (
+            @NotBlank(message = "이름은 필수 입력값입니다.")
             String name,
+            
+            @NotNull(message = "금액은 필수 입력값입니다.")
+            @Min(value = 0, message = "최소 금액은 0원입니다.")
             Long totalPrice,
+            
+            @NotNull(message = "날짜는 필수 입력값입니다.")
             LocalDate date,
+            
+            @NotNull(message = "타입은 필수 입력값입니다.")
             SettlementType type,
+            
+            @Valid
+            @NotNull(message = "정산 인원은 필수 입력값입니다.")
+            @NotEmpty(message = "정산 인원은 최소 1명 이상이어야합니다.")
             List<PayInfoDto> payers
     ) {
         public Settlement toEntity(Long tripId, Long payerId, boolean isCompleted) {
@@ -35,8 +52,13 @@ public class SettlementRequest {
     
     @Builder
     public record PayInfoDto (
+            @NotNull(message = "사용자 id는 필수 입력값입니다.")
             Long userId,
+            
+            @NotNull(message = "인원 별 정산 금액은 필수 입력값입니다.")
+            @Min(value = 0, message = "최소 금액은 0원입니다.")
             Long price,
+            
             boolean isCompleted
     ) {
         public PayInfo toEntity(Long settlementId) {

--- a/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementCommandService.java
@@ -1,0 +1,112 @@
+package kr.co.yeogiga.application.settlement.service;
+
+import kr.co.yeogiga.application.settlement.dto.SettlementRequest;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.settlement.entity.PayInfo;
+import kr.co.yeogiga.domain.settlement.entity.Settlement;
+import kr.co.yeogiga.domain.settlement.exception.SettlementErrorType;
+import kr.co.yeogiga.domain.settlement.service.PayInfoService;
+import kr.co.yeogiga.domain.settlement.service.SettlementService;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.trip.exception.TripMemberErrorType;
+import kr.co.yeogiga.domain.trip.service.TripMemberService;
+import kr.co.yeogiga.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SettlementCommandService {
+    private final SettlementService settlementService;
+    private final PayInfoService payInfoService;
+    private final TripMemberService tripMemberService;
+
+    /**
+     * 정산 내역을 생성하는 메서드
+     *
+     * @param tripId    여행 ID
+     * @param userId    작성자 ID
+     * @param dto       정산내역 생성 요청 DTO
+     *
+     *
+     * @throws CustomException  {@code TripErrorType.TRIP_NOT_FOUND} - 존재하지 않는 여행일 경우
+     *                          {@code TripMemberErrorType.EXISTS_NOT_MEMBER} - 여행 멤버가 아닌 정산자가 존재하는 경우
+     *                          {@code SettlementErrorType.NOT_VALID_PRICE} - 정산 내역 금액의 총합이 일치하지 않는 경우
+     */
+    @Transactional
+    public void createSettlement(Long tripId, Long userId, SettlementRequest.SettlementDto dto) {
+        List<User> members = tripMemberService.readAllUserByTripId(tripId);
+        
+        if (members.isEmpty()) {
+            throw new CustomException(TripErrorType.TRIP_NOT_FOUND);
+        }
+        
+        List<SettlementRequest.PayInfoDto> payers = dto.payers();
+        
+        if (!isAllTripMember(payers, members)) {
+            throw new CustomException(TripMemberErrorType.EXISTS_NOT_MEMBER);
+        }
+        
+        if (!isValidPrice(payers, dto.totalPrice())) {
+            throw new CustomException(SettlementErrorType.NOT_VALID_PRICE);
+        }
+        
+        
+        Settlement settlement = dto.toEntity(tripId, userId, isAllCompleted(payers));
+        
+        Long settlementId = settlementService.save(settlement);
+        
+        List<PayInfo> payInfoList = payers.stream()
+                .map(payInfo -> payInfo.toEntity(settlementId))
+                .toList();
+        
+        payInfoService.saveAllInBatch(payInfoList);
+    }
+    
+    /**
+     * 정산할 인원이 모두 여행의 멤버인지 여부를 반환하는 메서드
+     *
+     * @param payers    인원 당 정산 내역 목록
+     * @param members   여행 멤버 목록
+     * @return          정산할 인원이 모두 여행의 멤버인지 여부
+     */
+    private boolean isAllTripMember(List<SettlementRequest.PayInfoDto> payers, List<User> members) {
+        Set<Long> memberIds = members.stream()
+                .map(User::getId)
+                .collect(Collectors.toSet());
+        
+        return payers.stream()
+                .allMatch(payer -> memberIds.contains(payer.userId()));
+    }
+    
+    /**
+     * 인원 별 정산 금액의 총합이 정산 내역의 총합과 일치하는지 여부를 반환하는 메서드
+     *
+     * @param payers        인원 당 정산 내역 목록
+     * @param totalPrice    정산 내역 총합
+     * @return              인원 별 정산 금액의 총합과 정산 내역의 총합이 일치하는지 여부
+     */
+    private boolean isValidPrice(List<SettlementRequest.PayInfoDto> payers, Long totalPrice) {
+        Long sum = payers.stream()
+                .mapToLong(SettlementRequest.PayInfoDto::price)
+                .sum();
+        
+        return sum.equals(totalPrice);
+    }
+    
+    /**
+     * 인원 당 정산 내역 정보가 모두 정산이 완료되었는지 여부를 반환하는 메서드
+     *
+     * @param payers    인원 당 정산 내역 정보 리스트
+     * @return          리스트 내 모든 정산 내역이 정산이 완료되었는지 여부
+     */
+    private boolean isAllCompleted(List<SettlementRequest.PayInfoDto> payers) {
+        return payers.stream()
+                .allMatch(SettlementRequest.PayInfoDto::isCompleted);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/common/validation/EnumValidation.java
+++ b/src/main/java/kr/co/yeogiga/common/validation/EnumValidation.java
@@ -1,0 +1,22 @@
+package kr.co.yeogiga.common.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = {EnumValidator.class})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EnumValidation {
+    String message() default "지원하지 않는 Enum 값입니다.";
+    
+    Class<? extends Payload>[] payload() default {};
+    
+    Class<?>[] groups() default {};
+    
+    Class<? extends java.lang.Enum<?>> target();
+}

--- a/src/main/java/kr/co/yeogiga/common/validation/EnumValidator.java
+++ b/src/main/java/kr/co/yeogiga/common/validation/EnumValidator.java
@@ -1,0 +1,27 @@
+package kr.co.yeogiga.common.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class EnumValidator implements ConstraintValidator<EnumValidation, Enum<?>> {
+    private Set<Enum<?>> enums;
+    
+    @Override
+    public void initialize(EnumValidation constraintAnnotation) {
+        this.enums = Arrays.stream(constraintAnnotation.target().getEnumConstants())
+                .collect(Collectors.toSet());
+    }
+    
+    @Override
+    public boolean isValid(Enum<?> anEnum, ConstraintValidatorContext constraintValidatorContext) {
+        if (anEnum == null) {
+            return false;
+        }
+        
+        return enums.contains(anEnum);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/settlement/entity/PayInfo.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/entity/PayInfo.java
@@ -1,0 +1,40 @@
+package kr.co.yeogiga.domain.settlement.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "pay_info")
+public class PayInfo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+    
+    @Column(nullable = false)
+    private Long price;
+    
+    @Column(name = "is_completed")
+    private boolean isCompleted;
+    
+    @Column(name = "settlement_id", nullable = false)
+    private Long settlementId;
+    
+    @Builder
+    public PayInfo(Long userId, Long price, boolean isCompleted, Long settlementId) {
+        this.userId = userId;
+        this.price = price;
+        this.isCompleted = isCompleted;
+        this.settlementId = settlementId;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/settlement/entity/Settlement.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/entity/Settlement.java
@@ -1,0 +1,65 @@
+package kr.co.yeogiga.domain.settlement.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import kr.co.yeogiga.domain.settlement.type.SettlementType;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "settlement")
+public class Settlement {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "trip_id", nullable = false)
+    private Long tripId;
+    
+    @Column(nullable = false)
+    private String name;
+    
+    @Column(name = "total_price", nullable = false)
+    private Long totalPrice;
+    
+    @Column(nullable = false)
+    private LocalDate date;
+    
+    @Enumerated(value = EnumType.STRING)
+    private SettlementType type;
+    
+    @Column(name = "payer_id", nullable = false)
+    private Long payerId;
+    
+    @Column(name = "is_completed")
+    private boolean isCompleted;
+    
+    @Builder
+    public Settlement(
+            Long tripId,
+            String name,
+            Long totalPrice,
+            LocalDate date,
+            SettlementType type,
+            Long payerId,
+            boolean isCompleted
+    ) {
+        this.tripId = tripId;
+        this.name = name;
+        this.totalPrice = totalPrice;
+        this.date = date;
+        this.type = type;
+        this.payerId = payerId;
+        this.isCompleted = isCompleted;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/settlement/exception/SettlementErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/exception/SettlementErrorType.java
@@ -1,0 +1,32 @@
+package kr.co.yeogiga.domain.settlement.exception;
+
+import kr.co.yeogiga.common.response.error.type.BaseErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Settlement ErrorCode: S0XX
+ */
+@RequiredArgsConstructor
+public enum SettlementErrorType implements BaseErrorType {
+    NOT_VALID_PRICE(HttpStatus.BAD_REQUEST, "S000", "정산 내역 금액 총합이 일치하지 않습니다.");
+    
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+    
+    @Override
+    public HttpStatus getHttpStatus() {
+        return status;
+    }
+    
+    @Override
+    public String getCode() {
+        return code;
+    }
+    
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomPayInfoRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomPayInfoRepository.java
@@ -1,0 +1,9 @@
+package kr.co.yeogiga.domain.settlement.repository;
+
+import kr.co.yeogiga.domain.settlement.entity.PayInfo;
+
+import java.util.List;
+
+public interface CustomPayInfoRepository {
+    void saveAllInBatch(List<PayInfo> payInfos);
+}

--- a/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomPayInfoRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomPayInfoRepositoryImpl.java
@@ -1,0 +1,39 @@
+package kr.co.yeogiga.domain.settlement.repository;
+
+import kr.co.yeogiga.domain.settlement.entity.PayInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomPayInfoRepositoryImpl implements CustomPayInfoRepository {
+    private final JdbcTemplate jdbcTemplate;
+    private final String INSERT_SQL
+            = "INSERT INTO pay_info (user_id, price, is_completed, settlement_id) VALUES (?, ?, ?, ?)";
+    
+    @Override
+    public void saveAllInBatch(List<PayInfo> payInfos) {
+        jdbcTemplate.batchUpdate(
+                INSERT_SQL,
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        PayInfo payInfo = payInfos.get(i);
+                        ps.setLong(1, payInfo.getUserId());
+                        ps.setLong(2, payInfo.getPrice());
+                        ps.setBoolean(3, payInfo.isCompleted());
+                        ps.setLong(4, payInfo.getSettlementId());
+                    }
+                    
+                    @Override
+                    public int getBatchSize() {
+                        return payInfos.size();
+                    }
+                }
+        );
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/settlement/repository/PayInfoRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/repository/PayInfoRepository.java
@@ -1,0 +1,7 @@
+package kr.co.yeogiga.domain.settlement.repository;
+
+import kr.co.yeogiga.domain.settlement.entity.PayInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PayInfoRepository extends JpaRepository<PayInfo, Long>, CustomPayInfoRepository {
+}

--- a/src/main/java/kr/co/yeogiga/domain/settlement/repository/SettlementRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/repository/SettlementRepository.java
@@ -1,0 +1,7 @@
+package kr.co.yeogiga.domain.settlement.repository;
+
+import kr.co.yeogiga.domain.settlement.entity.Settlement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SettlementRepository extends JpaRepository<Settlement, Long> {
+}

--- a/src/main/java/kr/co/yeogiga/domain/settlement/service/PayInfoService.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/service/PayInfoService.java
@@ -1,0 +1,18 @@
+package kr.co.yeogiga.domain.settlement.service;
+
+import kr.co.yeogiga.domain.settlement.entity.PayInfo;
+import kr.co.yeogiga.domain.settlement.repository.PayInfoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PayInfoService {
+    private final PayInfoRepository payInfoRepository;
+    
+    public void saveAllInBatch(List<PayInfo> payInfos) {
+        payInfoRepository.saveAllInBatch(payInfos);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/settlement/service/SettlementService.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/service/SettlementService.java
@@ -1,0 +1,16 @@
+package kr.co.yeogiga.domain.settlement.service;
+
+import kr.co.yeogiga.domain.settlement.entity.Settlement;
+import kr.co.yeogiga.domain.settlement.repository.SettlementRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SettlementService {
+    private final SettlementRepository settlementRepository;
+    
+    public Long save(Settlement settlement) {
+        return settlementRepository.save(settlement).getId();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/settlement/type/SettlementType.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/type/SettlementType.java
@@ -1,7 +1,10 @@
 package kr.co.yeogiga.domain.settlement.type;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor
@@ -13,4 +16,12 @@ public enum SettlementType {
     ETC("기타");
     
     private final String value;
+    
+    @JsonCreator
+    public static SettlementType parse(String input) {
+        return Arrays.stream(values())
+                .filter(type -> type.toString().equals(input))
+                .findFirst()
+                .orElse(null);
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/settlement/type/SettlementType.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/type/SettlementType.java
@@ -1,0 +1,16 @@
+package kr.co.yeogiga.domain.settlement.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SettlementType {
+    ATTRACTION("관광지"),
+    LODGING("숙소"),
+    MEAL("식사"),
+    TRANSPORTATION("이동수단"),
+    ETC("기타");
+    
+    private final String value;
+}

--- a/src/main/java/kr/co/yeogiga/domain/trip/exception/TripMemberErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/exception/TripMemberErrorType.java
@@ -14,7 +14,8 @@ public enum TripMemberErrorType implements BaseErrorType {
     LEADER_CAN_NOT_LEAVE_TRIP(HttpStatus.BAD_REQUEST, "T101", "방장은 여행에서 떠날 수 없습니다. 권한을 위임해주세요."),
     IS_NOT_MEMBER(HttpStatus.BAD_REQUEST, "T102", "해당 여행의 멤버가 아닙니다."),
     CAN_NOT_SELF_KICK(HttpStatus.BAD_REQUEST, "T103", "자기 자신은 추방할 수 없습니다."),
-    ONLY_LEADER(HttpStatus.FORBIDDEN, "T104", "여행 방장만 이용 가능한 기능입니다.");
+    ONLY_LEADER(HttpStatus.FORBIDDEN, "T104", "여행 방장만 이용 가능한 기능입니다."),
+    EXISTS_NOT_MEMBER(HttpStatus.BAD_REQUEST, "T105", "여행 멤버가 아닌 사용자가 존재합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
@@ -12,7 +12,8 @@ public final class EndpointConstants {
     public static final String[] USER_ENDPOINTS = {
             "/api/v1/trip/**",
             "/api/v1/users/**",
-            "/api/v1/places/**"
+            "/api/v1/places/**",
+            "/api/v1/settlement/**"
     };
 
     public static final String[] GUEST_ENDPOINTS = {

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/api/SettlementApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/api/SettlementApi.java
@@ -1,0 +1,76 @@
+package kr.co.yeogiga.presentation.settlement.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.co.yeogiga.application.settlement.dto.SettlementRequest;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@ApiGroup(value = "[정산 API]")
+@Tag(name = "[정산 API]", description = "정산 관련 API")
+public interface SettlementApi {
+    
+    @TrackApi(description = "정산 내역 생성")
+    @Operation(summary = "정산 내역 생성", description = "정산 내역 생성 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "정산 내역 생성 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                             {
+                                                     "code": 201,
+                                                     "message": "요청이 성공하였습니다."
+                                             }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "공지사항 생성 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "유효성 검사 실패", value = """
+                                             {
+                                                  "code": "G002",
+                                                  "errors": {
+                                                      "payers[1].price": "최소 금액은 0원입니다.",
+                                                      "totalPrice": "최소 금액은 0원입니다.",
+                                                      "name": "이름은 필수 입력값입니다."
+                                                  }
+                                              }
+                                    """),
+                            @ExampleObject(name = "정산 내역 총합 금액 불일치", value = """
+                                             {
+                                                   "code": "S000",
+                                                   "message": "정산 내역 금액 총합이 일치하지 않습니다."
+                                             }
+                                    """),
+                            @ExampleObject(name = "여행 멤버가 아닌 정산자가 존재하는 경우", value = """
+                                             {
+                                                  "code": "T105",
+                                                  "message": "여행 멤버가 아닌 사용자가 존재합니다."
+                                             }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "공지사항 생성 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "존재하지 않는 여행",value = """
+                                             {
+                                                 "code": "T006",
+                                                 "message": "해당 여행이 존재하지 않습니다."
+                                             }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> createSettlement(
+            @Parameter(description = "여행 ID") @PathVariable(name = "tripId") Long tripId,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            @Valid @RequestBody SettlementRequest.SettlementDto settlement
+    );
+}

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
@@ -5,6 +5,7 @@ import kr.co.yeogiga.application.settlement.dto.SettlementRequest;
 import kr.co.yeogiga.application.settlement.service.SettlementCommandService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
+import kr.co.yeogiga.presentation.settlement.api.SettlementApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,9 +19,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/settlement")
 @RequiredArgsConstructor
-public class SettlementController {
+public class SettlementController implements SettlementApi {
     private final SettlementCommandService settlementCommandService;
     
+    @Override
     @PostMapping("/{tripId}")
     public ResponseEntity<?> createSettlement(
             @PathVariable(name = "tripId") Long tripId,

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
@@ -1,0 +1,34 @@
+package kr.co.yeogiga.presentation.settlement.controller;
+
+import jakarta.validation.Valid;
+import kr.co.yeogiga.application.settlement.dto.SettlementRequest;
+import kr.co.yeogiga.application.settlement.service.SettlementCommandService;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/settlement")
+@RequiredArgsConstructor
+public class SettlementController {
+    private final SettlementCommandService settlementCommandService;
+    
+    @PostMapping("/{tripId}")
+    public ResponseEntity<?> createSettlement(
+            @PathVariable(name = "tripId") Long tripId,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            @Valid @RequestBody SettlementRequest.SettlementDto settlement
+    ) {
+        settlementCommandService.createSettlement(tripId, userDetails.getUserId(), settlement);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(SuccessResponse.created());
+    }
+}

--- a/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementCommandServiceTest.java
@@ -1,0 +1,224 @@
+package kr.co.yeogiga.application.settlement.service;
+
+import kr.co.yeogiga.application.settlement.dto.SettlementRequest;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.settlement.entity.PayInfo;
+import kr.co.yeogiga.domain.settlement.entity.Settlement;
+import kr.co.yeogiga.domain.settlement.exception.SettlementErrorType;
+import kr.co.yeogiga.domain.settlement.service.PayInfoService;
+import kr.co.yeogiga.domain.settlement.service.SettlementService;
+import kr.co.yeogiga.domain.settlement.type.SettlementType;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.trip.exception.TripMemberErrorType;
+import kr.co.yeogiga.domain.trip.service.TripMemberService;
+import kr.co.yeogiga.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class SettlementCommandServiceTest {
+    @Mock
+    private SettlementService settlementService;
+    
+    @Mock
+    private PayInfoService payInfoService;
+    
+    @Mock
+    private TripMemberService tripMemberService;
+    
+    @InjectMocks
+    private SettlementCommandService settlementCommandService;
+    
+    @Nested
+    @DisplayName("정산 내역 생성")
+    class CreateSettlement {
+        private final Long tripId = 10L;
+        private final Long userId = 1L;
+        
+        private List<User> members = List.of(
+                User.builder().id(1L).build(),
+                User.builder().id(2L).build()
+        );
+        
+        private SettlementRequest.SettlementDto settlementDto = SettlementRequest.SettlementDto.builder()
+                .name("점심 식사")
+                .totalPrice(50000L)
+                .date(LocalDate.now())
+                .type(SettlementType.MEAL)
+                .payers(List.of(
+                        SettlementRequest.PayInfoDto.builder()
+                                .userId(1L)
+                                .price(10000L)
+                                .isCompleted(true)
+                                .build(),
+                        SettlementRequest.PayInfoDto.builder()
+                                .userId(2L)
+                                .price(40000L)
+                                .isCompleted(false)
+                                .build()
+                ))
+                .build();
+        
+        @Captor
+        ArgumentCaptor<Settlement> settlementCaptor;
+        
+        @Captor
+        private ArgumentCaptor<List<PayInfo>> payInfosCaptor;
+        
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(members);
+            when(settlementService.save(any(Settlement.class))).thenReturn(100L);
+            doNothing().when(payInfoService).saveAllInBatch(anyList());
+            
+            // when
+            settlementCommandService.createSettlement(tripId, userId, settlementDto);
+            
+            // then
+            verify(settlementService, times(1)).save(settlementCaptor.capture());
+            verify(payInfoService, times(1)).saveAllInBatch(payInfosCaptor.capture());
+            
+            assertEquals(false, settlementCaptor.getValue().isCompleted());
+            payInfosCaptor.getValue().forEach(payInfo -> assertEquals(100L, payInfo.getSettlementId()));
+        }
+        
+        @Test
+        @DisplayName("성공 - 모든 멤버가 정산이 완료된 경우 해당 정산 내역이 완료가 되는가")
+        void successIfAllCompleted() {
+            // given
+            SettlementRequest.SettlementDto settlementDto = SettlementRequest.SettlementDto.builder()
+                    .name("점심 식사")
+                    .totalPrice(50000L)
+                    .date(LocalDate.now())
+                    .type(SettlementType.MEAL)
+                    .payers(List.of(
+                            SettlementRequest.PayInfoDto.builder()
+                                    .userId(1L)
+                                    .price(10000L)
+                                    .isCompleted(true)
+                                    .build(),
+                            SettlementRequest.PayInfoDto.builder()
+                                    .userId(2L)
+                                    .price(40000L)
+                                    .isCompleted(true)
+                                    .build()
+                    ))
+                    .build();
+            
+            when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(members);
+            when(settlementService.save(any(Settlement.class))).thenReturn(100L);
+            doNothing().when(payInfoService).saveAllInBatch(anyList());
+            
+            // when
+            settlementCommandService.createSettlement(tripId, userId, settlementDto);
+            
+            // then
+            verify(settlementService, times(1)).save(settlementCaptor.capture());
+            verify(payInfoService, times(1)).saveAllInBatch(anyList());
+            
+            assertEquals(true, settlementCaptor.getValue().isCompleted());
+        }
+        
+        @Test
+        @DisplayName("실패 - 여행 미존재")
+        void failIfTripNotFound() {
+            // given
+            when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(Collections.emptyList());
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> settlementCommandService.createSettlement(tripId, userId, settlementDto));
+            
+            // then
+            assertEquals(TripErrorType.TRIP_NOT_FOUND, exception.getErrorType());
+        }
+        
+        @Test
+        @DisplayName("실패 - 정산자에 여행 멤버가 아닌 사용자가 포함된 경우")
+        void failIfExistsNotTripMember() {
+            // given
+            SettlementRequest.SettlementDto settlementDto = SettlementRequest.SettlementDto.builder()
+                    .name("점심 식사")
+                    .totalPrice(50000L)
+                    .date(LocalDate.now())
+                    .type(SettlementType.MEAL)
+                    .payers(List.of(
+                            SettlementRequest.PayInfoDto.builder()
+                                    .userId(1L)
+                                    .price(10000L)
+                                    .isCompleted(true)
+                                    .build(),
+                            SettlementRequest.PayInfoDto.builder()
+                                    .userId(3L)
+                                    .price(40000L)
+                                    .isCompleted(false)
+                                    .build()
+                    ))
+                    .build();
+            
+            when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(members);
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> settlementCommandService.createSettlement(tripId, userId, settlementDto));
+            
+            // then
+            assertEquals(TripMemberErrorType.EXISTS_NOT_MEMBER, exception.getErrorType());
+        }
+        
+        @Test
+        @DisplayName("실패 - 정산 내역 총합 불일치")
+        void failIfTotalPriceNotEquals() {
+            // given
+            SettlementRequest.SettlementDto settlementDto = SettlementRequest.SettlementDto.builder()
+                    .name("점심 식사")
+                    .totalPrice(50000L)
+                    .date(LocalDate.now())
+                    .type(SettlementType.MEAL)
+                    .payers(List.of(
+                            SettlementRequest.PayInfoDto.builder()
+                                    .userId(1L)
+                                    .price(10000L)
+                                    .isCompleted(true)
+                                    .build(),
+                            SettlementRequest.PayInfoDto.builder()
+                                    .userId(2L)
+                                    .price(20000L)
+                                    .isCompleted(false)
+                                    .build()
+                    ))
+                    .build();
+            
+            when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(members);
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> settlementCommandService.createSettlement(tripId, userId, settlementDto));
+            
+            // then
+            assertEquals(SettlementErrorType.NOT_VALID_PRICE, exception.getErrorType());
+        }
+    }
+}

--- a/src/test/java/kr/co/yeogiga/presentation/settlement/controller/SettlementControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/settlement/controller/SettlementControllerTest.java
@@ -1,0 +1,256 @@
+package kr.co.yeogiga.presentation.settlement.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.application.settlement.dto.SettlementRequest;
+import kr.co.yeogiga.application.settlement.service.SettlementCommandService;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
+import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.domain.settlement.exception.SettlementErrorType;
+import kr.co.yeogiga.domain.settlement.type.SettlementType;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.trip.exception.TripMemberErrorType;
+import kr.co.yeogiga.domain.user.entity.User;
+import kr.co.yeogiga.domain.user.type.Role;
+import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = SettlementController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthenticationFilter.class})
+        }
+)
+public class SettlementControllerTest {
+    
+    private MockMvc mockMvc;
+    
+    private CustomUserDetails userDetails;
+    
+    @Autowired
+    private ObjectMapper objectMapper;
+    
+    @MockBean
+    private SettlementCommandService settlementCommandService;
+    
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .defaultRequest(post("/**").with(csrf()))
+                .alwaysDo(print())
+                .build();
+        
+        User user = User.builder()
+                .username("username")
+                .password("password")
+                .nickname("nickname")
+                .email("email")
+                .role(Role.USER)
+                .build();
+        
+        ReflectionTestUtils.setField(user, "id", 1L);
+        
+        userDetails = new CustomUserDetailsImpl(user);
+    }
+    
+    @Nested
+    @DisplayName("정산 내역 생성")
+    class CreateSettlement {
+        private final Long tripId = 1L;
+        
+        private SettlementRequest.SettlementDto settlementDto = SettlementRequest.SettlementDto.builder()
+                .name("점심 식사")
+                .totalPrice(50000L)
+                .date(LocalDate.now())
+                .type(SettlementType.MEAL)
+                .payers(List.of(
+                        SettlementRequest.PayInfoDto.builder()
+                                .userId(1L)
+                                .price(10000L)
+                                .isCompleted(true)
+                                .build(),
+                        SettlementRequest.PayInfoDto.builder()
+                                .userId(2L)
+                                .price(40000L)
+                                .isCompleted(false)
+                                .build()
+                ))
+                .build();
+        
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            doNothing().when(settlementCommandService).createSettlement(tripId, userDetails.getUserId(), settlementDto);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/settlement/{tripId}", tripId)
+                            .with(user(userDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(settlementDto))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.created().message()));
+        }
+        
+        @Test
+        @DisplayName("실패 - 유효성 검증")
+        void failValidation() throws Exception {
+            // given
+            SettlementRequest.SettlementDto settlementDto = SettlementRequest.SettlementDto.builder()
+                    .name("  ")
+                    .totalPrice(-1L)
+                    .date(LocalDate.now())
+                    .type(SettlementType.MEAL)
+                    .payers(List.of(
+                            SettlementRequest.PayInfoDto.builder()
+                                    .userId(1L)
+                                    .price(-2L)
+                                    .isCompleted(true)
+                                    .build(),
+                            SettlementRequest.PayInfoDto.builder()
+                                    .userId(2L)
+                                    .price(40000L)
+                                    .isCompleted(false)
+                                    .build()
+                    ))
+                    .build();
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/settlement/{tripId}", tripId)
+                            .with(user(userDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(settlementDto))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors.name").exists())
+                    .andExpect(jsonPath("$.errors.totalPrice").exists())
+                    .andExpect(jsonPath("$.errors.['payers[0].price']").exists());
+            
+        }
+        
+        @Test
+        @DisplayName("실패 - 여행 미존재")
+        void failIfTripNotFound() throws Exception {
+            // given
+            doThrow(new CustomException(TripErrorType.TRIP_NOT_FOUND)).when(settlementCommandService)
+                    .createSettlement(tripId, userDetails.getUserId(), settlementDto);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/settlement/{tripId}", tripId)
+                            .with(user(userDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(settlementDto))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(TripErrorType.TRIP_NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.message").value(TripErrorType.TRIP_NOT_FOUND.getMessage()));
+        }
+        
+        @Test
+        @DisplayName("실패 - 정산자에 여행 멤버가 아닌 사용자가 포함된 경우")
+        void failIfExistsNotTripMember() throws Exception {
+            // given
+            doThrow(new CustomException(TripMemberErrorType.EXISTS_NOT_MEMBER)).when(settlementCommandService)
+                    .createSettlement(tripId, userDetails.getUserId(), settlementDto);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/settlement/{tripId}", tripId)
+                            .with(user(userDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(settlementDto))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(TripMemberErrorType.EXISTS_NOT_MEMBER.getCode()))
+                    .andExpect(jsonPath("$.message").value(TripMemberErrorType.EXISTS_NOT_MEMBER.getMessage()));
+        }
+        
+        @Test
+        @DisplayName("실패 - 정산 내역 총합 불일치")
+        void failIfTotalPriceNotEquals() throws Exception {
+            // given
+            SettlementRequest.SettlementDto settlementDto = SettlementRequest.SettlementDto.builder()
+                    .name("점심 식사")
+                    .totalPrice(50000L)
+                    .date(LocalDate.now())
+                    .type(SettlementType.MEAL)
+                    .payers(List.of(
+                            SettlementRequest.PayInfoDto.builder()
+                                    .userId(1L)
+                                    .price(10000L)
+                                    .isCompleted(true)
+                                    .build(),
+                            SettlementRequest.PayInfoDto.builder()
+                                    .userId(2L)
+                                    .price(20000L)
+                                    .isCompleted(false)
+                                    .build()
+                    ))
+                    .build();
+            
+            doThrow(new CustomException(SettlementErrorType.NOT_VALID_PRICE)).when(settlementCommandService)
+                    .createSettlement(tripId, userDetails.getUserId(), settlementDto);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/settlement/{tripId}", tripId)
+                            .with(user(userDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(settlementDto))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(SettlementErrorType.NOT_VALID_PRICE.getCode()))
+                    .andExpect(jsonPath("$.message").value(SettlementErrorType.NOT_VALID_PRICE.getMessage()));
+        }
+    }
+}


### PR DESCRIPTION
## 배경
- 가계부(정산) 기능 요구 - 정산 내역 생성 로직 구현

## 작업 사항
- 정산 내역 관련 엔티티 생성 | (428d3ad205e97aab2db414096cf0eeb260ced089)
  - `Settlement`: 정산 내역
  - `PayInfo`: 인원 별 정산 금액 및 여부
<!--->

- 정산 내역 카테고리 타입 enum 클래스 추가 | (9e4eb1531990d0b1ee329f2bc08a5a94221ae416) 
  - 피그마 디자인 기반 카테고리 타입 추가
  - Enum 값 유효성 검증 로직을 위한 `@JsonCreator`, `@EnumValidation` 커스텀 어노테이션, `EnumValidator` 추가 | (8de28df9e380c8d4ab11eda281b12aa90042f8c3)
<!--->

- 정산 내역 저장 도메인 로직 구현 | (5ecce5dada3799d1e3b9a9d5572b233c01c2b327)
  - 인원 별 정산 금액 및 여부 `PayInfo` 엔티티의 경우 BatchInsert를 사용한 삽입
    - 배치 수행 행의 갯수가 크지 않아 `BatchPreparedStatementSetter`를 사용하여 구현 
    - [Spring - JDBC Batch Operations](https://docs.spring.io/spring-framework/reference/data-access/jdbc/advanced.html) 참고
<!--->

- 정산 내역 생성 로직 구현 | (914a0fd32240b41e57cec810ad4b5a06d076e63a)
  - 예외 처리는 아래 인수 기준에서 추가 설명
<!--->

- 정산 내역 생성 api 구현 | (331de02233412e4bc585659070582665082287b3)
<!--->

## 인수 기준
정산 내역 생성 로직(914a0fd32240b41e57cec810ad4b5a06d076e63a)에서 예외 처리가 꽤 있어 해당 부분 '인수 기준' 섹션으로 분리하여 명시하였습니다. 해당 인수 기준에 부합하도록 예외 처리 진행하였습니다.
- [x] 모든 사람이 다 정산은 완료한 경우에 `Settlement.isCompleted`가 true가 되는가?
- [x] 여행이 존재하지않을 경우에 예외가 발생하는가?
- [x] `List<PayInfo>`로 보낸 정산자 목록 중 여행 멤버가 아닌 사용자가 존재할 경우 예외가 발생하는가?
- [x] `List<PayInfo>`의 정산 금액 총합이 `Settlement.totalPrice`와 일치하는가?
- [x] `List<PayInfo>`는 batch insert가 되는가? 


## 추가 논의

  - 원래 여행 일차 [`TripDay`](https://github.com/Team-Ilmansa/yeogiga-was/blob/develop/src/main/java/kr/co/yeogiga/domain/trip/entity/TripDay.java)를 사용하여 `TripDay` - `Settlement` - `PayInfo`로 구현하려 하였으나, 차후 일차 수정 등을 고려하였을 때 `tripId`, `day` 보다는 `tripId`, `LocalDate`가 있는 것이 차후 일차 수정 상황에서 처리가 편할 것 같아 우선은 현재 상태로 구현하였습니다. 
<!--->

- 현재 인원 별 정산 금액 및 여부 `PayInfo` 엔티티가 사용자 한 명마다 계속해서 생겨나게 되어 매우 많은 행이 생겨나게 됩니다. 따라서, `Settlement`에 해당하는 정산자 목록을 MongoDB로 따로 분리할까 고민하였지만 이전에 MySQL로 하기로 하여 우선은 현재 상태로 진행하였습니다. 차후 변경이 필요하면 변경 진행하겠습니다.
<!--->

- batch insert를 `JdbcTempalte`를 통해서 사용하기 때문에 application.yml - `spring.datasource.url` 부분에 `&profileSQL=true&logger=Slf4JLogger&maxQuerySizeToLog=200`을 명시하지 않아주면 로그는 보이지 않는 상태입니다. 해당 부분은 서버에 로그 파일 크기가 커질 것을 고려하여 적용시키지는 않았습니다. 차후 bulk operation 로그 확인 시 p6spy 같은 라이브러리 도입도 고려해봐도 좋을 것 같습니다.
<!--->
