### PR TITLE
Chore(IL-299): 예외 모니터링을 위한 Sentry 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api:2.1.1"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
+
+    /* Sentry */
+    implementation 'io.sentry:sentry-spring-boot-starter-jakarta:8.21.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/co/yeogiga/common/exception/CustomException.java
+++ b/src/main/java/kr/co/yeogiga/common/exception/CustomException.java
@@ -9,11 +9,13 @@ public class CustomException extends RuntimeException {
     private final Object data;
     
     public CustomException(BaseErrorType errorType) {
+        super(errorType.getMessage());
         this.errorType = errorType;
         this.data = null;
     }
     
     public CustomException(BaseErrorType errorType, Object data) {
+        super(errorType.getMessage());
         this.errorType = errorType;
         this.data = data;
     }

--- a/src/main/java/kr/co/yeogiga/common/logging/SentryBeforeSendCallBack.java
+++ b/src/main/java/kr/co/yeogiga/common/logging/SentryBeforeSendCallBack.java
@@ -1,0 +1,57 @@
+package kr.co.yeogiga.common.logging;
+
+import io.sentry.Hint;
+import io.sentry.SentryEvent;
+import io.sentry.SentryOptions;
+import io.sentry.protocol.SentryException;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+public class SentryBeforeSendCallBack implements SentryOptions.BeforeSendCallback {
+    
+    /**
+     * Sentry로 이벤트를 발송하기 전 처리를 수행하는 메서드
+     * - {@code MethodArgumentNotValidException} 발생 시 이슈 메시지 설정
+     * - 동일 타입 예외(이슈) 스택 그룹핑을 방지하기 위한 Fingerprint 설정
+     *
+     * @param sentryEvent   Sentry 이벤트
+     * @param hint          힌트
+     * @return              Sentry 이벤트
+     */
+    @Override
+    public SentryEvent execute(SentryEvent sentryEvent, Hint hint) {
+        handleMethodArgumentNotValidException(sentryEvent);
+        sentryEvent.setFingerprints(List.of(UUID.randomUUID().toString()));
+        return sentryEvent;
+    }
+    
+    /**
+     * {@code MethodArgumentNotValidException} 에러 필드 처리 메서드
+     *
+     * @param sentryEvent   Sentry 이벤트
+     */
+    private void handleMethodArgumentNotValidException(SentryEvent sentryEvent) {
+        if (sentryEvent.getThrowable() != null) {
+            if (sentryEvent.getThrowable() instanceof MethodArgumentNotValidException e) {
+                Map<String, String> errors = new HashMap<>();
+                for (FieldError fieldError : e.getBindingResult().getFieldErrors()) {
+                    errors.put(fieldError.getField(), fieldError.getDefaultMessage());
+                }
+                
+                List<SentryException> exceptions = sentryEvent.getExceptions();
+                
+                if (exceptions != null && !exceptions.isEmpty()) {
+                    SentryException exception = exceptions.get(exceptions.size() - 1);
+                    exception.setValue(errors.toString());
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -3,3 +3,12 @@ spring:
     import: "classpath:application-common.yml"
     activate:
       on-profile: prod
+
+--- # Sentry
+sentry:
+  dsn: ${SENTRY_DSN}
+  exception-resolver-order: -2147483647
+  max-request-body-size: always
+  send-default-pii: true
+  logging:
+    enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,3 +75,12 @@ map:
     uri: ${NAVER_API_URI}
     client-id: ${NAVER_CLIENT_ID}
     client-secret: ${NAVER_CLIENT_SECRET}
+
+--- # Sentry
+sentry:
+  dsn: ${SENTRY_DSN}
+  exception-resolver-order: -2147483647
+  max-request-body-size: always
+  send-default-pii: true
+  logging:
+    enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,12 +75,3 @@ map:
     uri: ${NAVER_API_URI}
     client-id: ${NAVER_CLIENT_ID}
     client-secret: ${NAVER_CLIENT_SECRET}
-
---- # Sentry
-sentry:
-  dsn: ${SENTRY_DSN}
-  exception-resolver-order: -2147483647
-  max-request-body-size: always
-  send-default-pii: true
-  logging:
-    enabled: false


### PR DESCRIPTION
## 배경
- 예외 모니터링을 위한 Sentry 설정 
  - 운영(production) 환경 내 발생하는 예외 추적 및 Stack Trace, 사용자 정보(pii, personal identification information) 확인을 통한 문제 대응 목적

## 작업 사항
- Sentry 디펜던시 설정 | (7964673512e96d6180d371412c6167dc36839b33)
  - [Sentry 공식문서](https://docs.sentry.io/platforms/java/guides/spring-boot/) 참고
  - 운영(prod) 환경에서만 예외 모니터링을 위한 프로퍼티 파일 위치 변경 | (5004c7228f1620dcdbec2f62420e6807ec6402ea)
<!--->

- Sentry 이슈 메시지 설정을 위한 `CustomException` 생성자 수정 | (9bf3e9eb7aa0e413b4362e16b5a04c5544f0d6db)
  - Sentry 이슈 생성 시 `Exception`의 message를 기반으로하여 메시지를 설정하기 때문에 `CustomException` 생성자 내에서 상위 클래스인 `RuntimeException`의 생성자를 호출하여 메시지를 설정하였습니다.
  - 결과적으로 `SentryEvent.value`의 값으로 바인딩
<!--->

- `SentryOption.BeforeSendCallback` 구현 컴포넌트 추가 | (52d00a497920b786ee0de5bce4589a6123bc435c)
  - [Sentry 공식문서 - Filtering](https://docs.sentry.io/platforms/java/guides/spring-boot/configuration/filtering/)을 참고하여 `SentryOption.BeforeSendCallback`의 구현체를 빈으로 등록
  - Fingerprint 설정
    -  Sentry 대시보드 내 동일 타입(제목)의 이슈인 경우 하나의 이슈로 그룹핑되어 나타나, 하나의 예외 당 하나의 이슈로 보기 위해 Fingerprint 설정
  - `MethodArgumentNotValidException` 에러 메시지 처리
    - jakarta.validation 내 제공 메시지 모호성으로 인한 커스텀 에러 메시지 별도 처리
<!--->

## 적용 결과 - Sentry 대시보드
<img width="1716" height="1061" alt="image" src="https://github.com/user-attachments/assets/06ed3f73-677f-4b9f-b0da-5465e42e7f06" />


## 추가 논의
- 현재 Developer 플랜으로 Sentry 가입한 상태입니다. 무료 14일 이후에 기능이 제한되지만 사용은 가능하다고 합니다. 그러나, 해당 부분 차후 한 번 더 확인해보겠습니다.
- 병합 전 ec2 내 환경변수 설정 진행하도록 하겠습니다.
- 프론트 인원들에게 Sentry 접속 방법 전달하겠습니다.