### PR TITLE
Feature(IL-324): 공지 완료 여부 상태 추가

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/notice/dto/NoticeReq.java
+++ b/src/main/java/kr/co/yeogiga/application/notice/dto/NoticeReq.java
@@ -2,6 +2,7 @@ package kr.co.yeogiga.application.notice.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 public class NoticeReq {
@@ -15,7 +16,16 @@ public class NoticeReq {
             
             @Schema(description = "내용", example = "준비물 다시 확인하시고 꼭 챙기십시오.")
             @NotBlank(message = "내용은 필수 입력값입니다.")
+            @Size(max = 200, message = "내용은 최대 200자까지 입력 가능합니다.")
             String description
+    ) {
+    }
+
+    @Builder
+    @Schema(name = "NoticeReq.UpdateCompleted", description = "공지 완료 여부 수정 요청 DTO")
+    public record UpdateCompleted(
+            @Schema(description = "공지 완료 여부", example = "true")
+            boolean completed
     ) {
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/notice/service/NoticeCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/notice/service/NoticeCommandService.java
@@ -14,20 +14,30 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class NoticeCommandService {
     private final NoticeService noticeService;
-    
+    private final TripService tripService;
+
     /**
      * 여행 공지사항을 생성하는 메서드
      *
-     * @param userId    작성자 ID
-     * @param tripId    여행 ID
-     * @param dto       공지사항 요청 DTO
+     * @param userId 작성자 ID
+     * @param tripId 여행 ID
+     * @param dto    공지사항 요청 DTO
      */
+    @Transactional
     public void createNotice(Long userId, Long tripId, NoticeReq.Creation dto) {
+        Trip trip = tripService.readById(tripId)
+                .orElseThrow(() -> new CustomException(TripErrorType.TRIP_NOT_FOUND));
+
+        if (!trip.isLeader(userId)) {
+            throw new CustomException(TripErrorType.PERMISSION_DENIED_NOT_LEADER);
+        }
+
         Notice notice = Notice.builder()
                 .title(dto.title())
                 .description(dto.description())
                 .author(User.builder().id(userId).build())
                 .tripId(tripId)
+                .completed(false)
                 .build();
         
         noticeService.save(notice);

--- a/src/main/java/kr/co/yeogiga/application/notice/service/NoticeCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/notice/service/NoticeCommandService.java
@@ -5,6 +5,9 @@ import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.notice.entity.Notice;
 import kr.co.yeogiga.domain.notice.exception.NoticeErrorType;
 import kr.co.yeogiga.domain.notice.service.NoticeService;
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.trip.service.TripService;
 import kr.co.yeogiga.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -63,7 +66,28 @@ public class NoticeCommandService {
         
         notice.update(dto.title(), dto.description());
     }
-    
+
+    /**
+     * 공지사항 완료 여부를 수정하는 메서드
+     *
+     * @param noticeId 공지사항 ID
+     * @param userId   수정 요청 사용자 ID
+     * @param dto      완료 여부 (true: 완료, false: 미완료)
+     * @throws CustomException NoticeErrorType.NOT_FOUND - 공지사항이 존재하지 않는 경우
+     * @throws CustomException NoticeErrorType.UNAUTHORIZED_AUTHOR - 작성자가 아닌 사용자가 수정하려는 경우
+     */
+    @Transactional
+    public void updateCompleted(Long noticeId, Long userId, NoticeReq.UpdateCompleted dto) {
+        Notice notice = noticeService.readById(noticeId)
+                .orElseThrow(() -> new CustomException(NoticeErrorType.NOT_FOUND));
+
+        if (!notice.isAuthor(userId)) {
+            throw new CustomException(NoticeErrorType.UNAUTHORIZED_AUTHOR);
+        }
+
+        notice.changeCompleted(dto.completed());
+    }
+
     /**
      * 여행 공지사항을 삭제하는 메서드
      *

--- a/src/main/java/kr/co/yeogiga/domain/notice/dto/NoticeDto.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/dto/NoticeDto.java
@@ -12,6 +12,7 @@ public class NoticeDto {
             Long id,
             String title,
             String description,
+            boolean completed,
             LocalDateTime createdAt,
             Long authorId,
             String nickname,
@@ -22,6 +23,7 @@ public class NoticeDto {
                     .id(notice.getId())
                     .title(notice.getTitle())
                     .description(notice.getDescription())
+                    .completed(notice.isCompleted())
                     .createdAt(notice.getCreatedAt())
                     .authorId(notice.getAuthorId())
                     .nickname(notice.getAuthor().getNickname())

--- a/src/main/java/kr/co/yeogiga/domain/notice/entity/Notice.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/entity/Notice.java
@@ -41,18 +41,21 @@ public class Notice extends BaseTimeEntity {
     @Column(name = "author_id", insertable = false, updatable = false)
     private Long authorId;
     
-    @Column(columnDefinition = "TEXT", nullable = false)
+    @Column(length = 200, nullable = false)
     private String description;
     
     @Column(name = "trip_id", nullable = false)
     private Long tripId;
+
+    private boolean completed;
     
     @Builder
-    public Notice(String title, User author, String description, Long tripId) {
+    public Notice(String title, User author, String description, Long tripId, boolean completed) {
         this.title = title;
         this.author = author;
         this.description = description;
         this.tripId = tripId;
+        this.completed = completed;
     }
     
     public void update(String title, String description) {
@@ -62,5 +65,9 @@ public class Notice extends BaseTimeEntity {
     
     public boolean isAuthor(Long userId) {
         return this.author != null && this.authorId.equals(userId);
+    }
+
+    public void changeCompleted(boolean completed) {
+        this.completed = completed;
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/notice/repository/CustomNoticeRepositoryImpl.java
@@ -57,6 +57,7 @@ public class CustomNoticeRepositoryImpl implements CustomNoticeRepository {
                                 notice.id,
                                 notice.title,
                                 notice.description,
+                                notice.completed,
                                 notice.createdAt,
                                 user.id,
                                 user.nickname,

--- a/src/main/java/kr/co/yeogiga/domain/trip/entity/Trip.java
+++ b/src/main/java/kr/co/yeogiga/domain/trip/entity/Trip.java
@@ -69,4 +69,8 @@ public class Trip {
     public void updateInfo(String title) {
         this.title = title;
     }
+
+    public boolean isLeader(Long userId) {
+        return this.leaderId != null && this.leaderId.equals(userId);
+    }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/notice/api/NoticeApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/notice/api/NoticeApi.java
@@ -50,6 +50,24 @@ public interface NoticeApi {
                                                      }
                                              }
                                     """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "공지사항 생성 실패 - 여행 방장이 아닌 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "공지사항 작성자가 아닌 경우", value = """
+                                             {
+                                                    "code": "T007",
+                                                    "message": "여행 방장이 아닙니다."
+                                                }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "공지사항 생성 실패 - 여행이 존재하지 않는 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "여행이 존재하지 않는 경우", value = """
+                                             {
+                                                     "code": "T006",
+                                                     "message": "해당 여행이 존재하지 않습니다."
+                                                 }
+                                    """)
                     }))
     })
     ResponseEntity<?> createNotice(
@@ -73,6 +91,7 @@ public interface NoticeApi {
                                                               "id": 24,
                                                               "title": "준비물 챙기세요.",
                                                               "description": "수건, 양말...",
+                                                              "completed" : "true",
                                                               "createdAt": "2025-07-27T11:56:34.546218",
                                                               "authorId": 13,
                                                               "nickname": "nick13",
@@ -82,6 +101,7 @@ public interface NoticeApi {
                                                               "id": 23,
                                                               "title": "여행 전 주의사항",
                                                               "description": "여행 전 해당 내용 인지하시길 바랍니다.",
+                                                              "completed" : "false",
                                                               "createdAt": "2025-07-27T11:56:29.82594",
                                                               "authorId": 13,
                                                               "nickname": "nick13",
@@ -91,6 +111,7 @@ public interface NoticeApi {
                                                               "id": 22,
                                                               "title": "여행 경비 안내",
                                                               "description": "여행 경비는 인당...",
+                                                              "completed" : "false",
                                                               "createdAt": "2025-07-27T11:56:27.579067",
                                                               "authorId": 13,
                                                               "nickname": "nick13",
@@ -130,6 +151,7 @@ public interface NoticeApi {
                                                        "id": 22,
                                                        "title": "중요 공지입니다.",
                                                        "description": "설명입니다.",
+                                                       "completed" : "true",
                                                        "createdAt": "2025-07-27T11:56:27.579067",
                                                        "authorId": 13,
                                                        "nickname": "nick",
@@ -200,6 +222,43 @@ public interface NoticeApi {
             @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @PathVariable(name = "noticeId") Long noticeId,
             @Valid @RequestBody NoticeReq.Creation request
+    );
+
+    @TrackApi(description = "공지사항 상태 변경 (완료/미완료)")
+    @Operation(summary = "공지사항 상태 변경 (완료/미완료)", description = "공지사항 상태 변경 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "공지사항 상태 변경 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                             {
+                                                  "code": 200,
+                                                  "message": "요청이 성공하였습니다."
+                                              }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "공지사항 상태 변경 실패 - 공지사항의 작성자가 아닌 경우",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "공지사항 작성자가 아닌 경우", value = """
+                                             {
+                                                    "code": "N001",
+                                                    "message": "공지사항의 작성자가 아닙니다."
+                                                }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "공지사항 상태 변경 실패 - 존재하지 않는 공지사항",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "공지사항이 존재하지 않는 경우", value = """
+                                             {
+                                                     "code": "N000",
+                                                     "message": "존재하지 않는 공지사항입니다."
+                                                 }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> updateCompleted(
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            @PathVariable(name = "noticeId") Long noticeId,
+            @RequestBody NoticeReq.UpdateCompleted request
     );
     
     @TrackApi(description = "공지사항 삭제")

--- a/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/notice/controller/NoticeController.java
@@ -15,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -70,7 +71,18 @@ public class NoticeController implements NoticeApi {
         noticeCommandService.updateNotice(noticeId, userDetails.getUserId(), request);
         return ResponseEntity.ok(SuccessResponse.ok());
     }
-    
+
+    @Override
+    @PatchMapping("/{tripId}/notices/{noticeId}/completed")
+    public ResponseEntity<?> updateCompleted(
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            @PathVariable(name = "noticeId") Long noticeId,
+            @RequestBody NoticeReq.UpdateCompleted request
+    ) {
+        noticeCommandService.updateCompleted(noticeId, userDetails.getUserId(), request);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+
     @Override
     @DeleteMapping("/{tripId}/notices/{noticeId}")
     public ResponseEntity<?> deleteNotice(

--- a/src/test/java/kr/co/yeogiga/application/notice/service/NoticeCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/notice/service/NoticeCommandServiceTest.java
@@ -5,6 +5,9 @@ import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.notice.entity.Notice;
 import kr.co.yeogiga.domain.notice.exception.NoticeErrorType;
 import kr.co.yeogiga.domain.notice.service.NoticeService;
+import kr.co.yeogiga.domain.trip.entity.Trip;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.trip.service.TripService;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.type.Role;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,26 +38,33 @@ public class NoticeCommandServiceTest {
     
     @Mock
     private NoticeService noticeService;
-    
+
+    @Mock
+    private TripService tripService;
+
     @InjectMocks
     private NoticeCommandService noticeCommandService;
     
     @Nested
     @DisplayName("공지사항 생성")
     class CreateNotice {
+        private final Long userId = 1L;
+        private final Long tripId = 2L;
+
+        private Trip trip = Trip.builder()
+                .leaderId(userId)
+                .build();
         
         @Test
         @DisplayName("성공")
         void success() {
             // given
-            Long userId = 1L;
-            Long tripId = 2L;
-            
             NoticeReq.Creation dto = NoticeReq.Creation.builder()
                     .title("title")
                     .description("description")
                     .build();
-            
+
+            when(tripService.readById(anyLong())).thenReturn(Optional.ofNullable(trip));
             doNothing().when(noticeService).save(any(Notice.class));
             
             // when
@@ -65,6 +75,47 @@ public class NoticeCommandServiceTest {
                 assertEquals(userId, notice.getAuthor().getId());
                 assertEquals(tripId, notice.getTripId());
             }));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 여행")
+        void failIfTripNotFound() {
+            // given
+            NoticeReq.Creation dto = NoticeReq.Creation.builder()
+                    .title("title")
+                    .description("description")
+                    .build();
+
+            when(tripService.readById(anyLong())).thenReturn(Optional.empty());
+
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> noticeCommandService.createNotice(userId, tripId, dto));
+
+            // then
+            assertEquals(TripErrorType.TRIP_NOT_FOUND, exception.getErrorType());
+        }
+
+        @Test
+        @DisplayName("실패 - 여행 방장 아님")
+        void failUnauthorizedLeader() {
+            // given
+            Long notLeaderId = 2L;
+            Long tripId = 2L;
+
+            NoticeReq.Creation dto = NoticeReq.Creation.builder()
+                    .title("title")
+                    .description("description")
+                    .build();
+
+            when(tripService.readById(anyLong())).thenReturn(Optional.ofNullable(trip));
+
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> noticeCommandService.createNotice(notLeaderId, tripId, dto));
+
+            // then
+            assertEquals(TripErrorType.PERMISSION_DENIED_NOT_LEADER, exception.getErrorType());
         }
     }
     
@@ -129,6 +180,70 @@ public class NoticeCommandServiceTest {
             CustomException exception = assertThrows(CustomException.class, ()
                     -> noticeCommandService.updateNotice(2L, 3L, dto));
             
+            // then
+            assertEquals(NoticeErrorType.UNAUTHORIZED_AUTHOR, exception.getErrorType());
+        }
+    }
+
+    @Nested
+    @DisplayName("공지사항 상태 변경")
+    class UpdateCompleted {
+        User user = User.builder()
+                .id(1L)
+                .nickname("nickname")
+                .role(Role.USER)
+                .build();
+
+        Notice notice = Notice.builder()
+                .tripId(2L)
+                .title("title")
+                .description("description")
+                .author(user)
+                .build();
+
+        NoticeReq.UpdateCompleted dto = NoticeReq.UpdateCompleted.builder()
+                .completed(true)
+                .build();
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            ReflectionTestUtils.setField(notice, "authorId", 1L);
+            when(noticeService.readById(2L)).thenReturn(Optional.of(notice));
+
+            // when
+            noticeCommandService.updateCompleted(2L, 1L, dto);
+
+            // when
+            assertEquals(dto.completed(), notice.isCompleted());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 공지사항")
+        void failIfNoticeNotFound() {
+            // given
+            when(noticeService.readById(anyLong())).thenReturn(Optional.empty());
+
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> noticeCommandService.updateCompleted(2L, 1L, dto));
+
+            // then
+            assertEquals(NoticeErrorType.NOT_FOUND, exception.getErrorType());
+        }
+
+        @Test
+        @DisplayName("실패 - 작성자가 아닌 경우")
+        void failUnauthorizedAuthor() {
+            // given
+            ReflectionTestUtils.setField(notice, "authorId", 1L);
+            when(noticeService.readById(anyLong())).thenReturn(Optional.of(notice));
+
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> noticeCommandService.updateCompleted(2L, 3L, dto));
+
             // then
             assertEquals(NoticeErrorType.UNAUTHORIZED_AUTHOR, exception.getErrorType());
         }

--- a/src/test/java/kr/co/yeogiga/presentation/notice/controller/NoticeControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/notice/controller/NoticeControllerTest.java
@@ -46,6 +46,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -61,20 +62,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         }
 )
 public class NoticeControllerTest {
-    
+
     private MockMvc mockMvc;
-    
+
     private CustomUserDetails userDetails;
-    
+
     @Autowired
     private ObjectMapper objectMapper;
-    
+
     @MockBean
     private NoticeCommandService noticeCommandService;
-    
+
     @MockBean
     private NoticeQueryService noticeQueryService;
-    
+
     @BeforeEach
     void setUp(WebApplicationContext webApplicationContext) {
         this.mockMvc = MockMvcBuilders
@@ -83,7 +84,7 @@ public class NoticeControllerTest {
                 .defaultRequest(post("/**").with(csrf()))
                 .alwaysDo(print())
                 .build();
-        
+
         User user = User.builder()
                 .username("username")
                 .password("password")
@@ -91,17 +92,17 @@ public class NoticeControllerTest {
                 .email("email")
                 .role(Role.USER)
                 .build();
-        
+
         ReflectionTestUtils.setField(user, "id", 1L);
-        
+
         userDetails = new CustomUserDetailsImpl(user);
     }
-    
+
     @Nested
     @DisplayName("공지사항 생성")
     class CreateNotice {
         private final Long tripId = 1L;
-        
+
         @Test
         @DisplayName("성공")
         void success() throws Exception {
@@ -110,9 +111,9 @@ public class NoticeControllerTest {
                     .title("title")
                     .description("description")
                     .build();
-            
+
             doNothing().when(noticeCommandService).createNotice(anyLong(), anyLong(), any(NoticeReq.Creation.class));
-            
+
             // when
             ResultActions resultActions = mockMvc.perform(
                     post("/api/v1/trip/{tripId}/notices", tripId)
@@ -120,12 +121,12 @@ public class NoticeControllerTest {
                             .content(objectMapper.writeValueAsBytes(request))
                             .with(user(userDetails))
             );
-            
+
             // then
             resultActions
                     .andExpect(status().isCreated());
         }
-        
+
         @Test
         @DisplayName("실패 - 유효성 검사")
         void failValidation() throws Exception {
@@ -134,7 +135,7 @@ public class NoticeControllerTest {
                     .title(" ")
                     .description(" ")
                     .build();
-            
+
             // when
             ResultActions resultActions = mockMvc.perform(
                     post("/api/v1/trip/{tripId}/notices", tripId)
@@ -142,16 +143,16 @@ public class NoticeControllerTest {
                             .content(objectMapper.writeValueAsBytes(request))
                             .with(user(userDetails))
             );
-            
+
             // then
             resultActions
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.errors.title").exists())
                     .andExpect(jsonPath("$.errors.description").exists());
-            
+
         }
     }
-    
+
     @Nested
     @DisplayName("전체 공지사항 조회")
     class getNotices {
@@ -168,19 +169,19 @@ public class NoticeControllerTest {
                 .createdAt(LocalDateTime.of(2025, 7, 27, 16, 30))
                 .authorId(userId)
                 .build();
-        
+
         @Test
         @DisplayName("성공")
         void success() throws Exception {
             // given
             when(noticeQueryService.getAllNotices(tripId, pageable)).thenReturn(new PageImpl<>(List.of(noticeDetail)));
-            
+
             // when
             ResultActions resultActions = mockMvc.perform(
                     get("/api/v1/trip/{tripId}/notices", tripId)
                             .with(user(userDetails))
             );
-            
+
             // then
             resultActions
                     .andExpect(status().isOk())
@@ -188,12 +189,12 @@ public class NoticeControllerTest {
                     .andExpect(jsonPath("$.data.content.length()").value(1));
         }
     }
-    
+
     @Nested
     @DisplayName("특정 공지사항 조회")
     class GetNotice {
         private final Long noticeId = 1L;
-        
+
         private NoticeDto.Detail dto = NoticeDto.Detail.builder()
                 .id(noticeId)
                 .title("title")
@@ -202,39 +203,39 @@ public class NoticeControllerTest {
                 .createdAt(LocalDateTime.now().minusDays(1))
                 .imageUrl("http://image.com/image")
                 .build();
-        
-        
+
+
         @Test
         @DisplayName("성공")
         void success() throws Exception {
             // given
             when(noticeQueryService.getNotice(noticeId)).thenReturn(dto);
-            
+
             // when
             ResultActions resultActions = mockMvc.perform(
                     get("/api/v1/trip/{tripId}/notices/{noticeId}", 1L, noticeId)
                             .with(user(userDetails))
             );
-            
+
             // then
             resultActions
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.id").value(dto.id()))
                     .andExpect(jsonPath("$.data.authorId").value(dto.authorId()));
         }
-        
+
         @Test
         @DisplayName("실패 - 존재하지 않는 공지사항")
         void failIfNoticeNotFound() throws Exception {
             // given
             doThrow(new CustomException(NoticeErrorType.NOT_FOUND)).when(noticeQueryService).getNotice(noticeId);
-            
+
             // when
             ResultActions resultActions = mockMvc.perform(
                     get("/api/v1/trip/{tripId}/notices/{noticeId}", 1L, noticeId)
                             .with(user(userDetails))
             );
-            
+
             // then
             resultActions
                     .andExpect(status().isNotFound())
@@ -242,22 +243,22 @@ public class NoticeControllerTest {
                     .andExpect(jsonPath("$.message").value(NoticeErrorType.NOT_FOUND.getMessage()));
         }
     }
-    
+
     @Nested
     @DisplayName("공지사항 수정")
     class UpdateNotice {
-        
+
         private NoticeReq.Creation request = NoticeReq.Creation.builder()
                 .title("new title")
                 .description("new description")
                 .build();
-        
+
         @Test
         @DisplayName("성공")
         void success() throws Exception {
             // given
             doNothing().when(noticeCommandService).updateNotice(eq(1L), eq(1L), any(NoticeReq.Creation.class));
-            
+
             // when
             ResultActions resultActions = mockMvc.perform(
                     put("/api/v1/trip/{tripId}/notices/{noticeId}", 2L, 1L)
@@ -265,20 +266,20 @@ public class NoticeControllerTest {
                             .content(objectMapper.writeValueAsBytes(request))
                             .with(user(userDetails))
             );
-            
+
             // then
             resultActions
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
         }
-        
+
         @Test
         @DisplayName("실패 - 작성자가 아닌 경우")
         void failUnauthorizedAuthor() throws Exception {
             // given
             doThrow(new CustomException(NoticeErrorType.UNAUTHORIZED_AUTHOR))
                     .when(noticeCommandService).updateNotice(eq(1L), eq(1L), any(NoticeReq.Creation.class));
-            
+
             // when
             ResultActions resultActions = mockMvc.perform(
                     put("/api/v1/trip/{tripId}/notices/{noticeId}", 2L, 1L)
@@ -286,20 +287,20 @@ public class NoticeControllerTest {
                             .content(objectMapper.writeValueAsBytes(request))
                             .with(user(userDetails))
             );
-            
+
             // then
             resultActions
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.message").value(NoticeErrorType.UNAUTHORIZED_AUTHOR.getMessage()));
         }
-        
+
         @Test
         @DisplayName("실패 - 공지사항이 존재하지 않는 경우")
         void failIfNoticeNotFound() throws Exception {
             // given
             doThrow(new CustomException(NoticeErrorType.NOT_FOUND))
                     .when(noticeCommandService).updateNotice(eq(1L), eq(1L), any(NoticeReq.Creation.class));
-            
+
             // when
             ResultActions resultActions = mockMvc.perform(
                     put("/api/v1/trip/{tripId}/notices/{noticeId}", 2L, 1L)
@@ -307,14 +308,14 @@ public class NoticeControllerTest {
                             .content(objectMapper.writeValueAsBytes(request))
                             .with(user(userDetails))
             );
-            
+
             // then
             resultActions
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.code").value(NoticeErrorType.NOT_FOUND.getCode()))
                     .andExpect(jsonPath("$.message").value(NoticeErrorType.NOT_FOUND.getMessage()));
         }
-        
+
         @Test
         @DisplayName("실패 - 유효성 검증 실패")
         void failValidation() throws Exception {
@@ -323,7 +324,7 @@ public class NoticeControllerTest {
                     .title(" ")
                     .description(" ")
                     .build();
-            
+
             // when
             ResultActions resultActions = mockMvc.perform(
                     put("/api/v1/trip/{tripId}/notices/{noticeId}", 2L, 1L)
@@ -331,7 +332,7 @@ public class NoticeControllerTest {
                             .content(objectMapper.writeValueAsBytes(request))
                             .with(user(userDetails))
             );
-            
+
             // then
             resultActions
                     .andExpect(status().isBadRequest())
@@ -340,69 +341,97 @@ public class NoticeControllerTest {
                     .andExpect(jsonPath("$.errors.description").exists());
         }
     }
-    
+
     @Nested
-    @DisplayName("공지사항 삭제")
-    class DeleteNotice {
-        private final Long noticeId = 1L;
-        
+    @DisplayName("공지사항 상태 변경")
+    class UpdateCompleted {
         @Test
         @DisplayName("성공")
         void success() throws Exception {
             // given
-            doNothing().when(noticeCommandService).deleteNotice(noticeId, userDetails.getUserId());
-            
+            NoticeReq.UpdateCompleted request = NoticeReq.UpdateCompleted.builder()
+                    .completed(true)
+                    .build();
+
+            doNothing().when(noticeCommandService).updateCompleted(eq(1L), eq(1L), any(NoticeReq.UpdateCompleted.class));
+
             // when
             ResultActions resultActions = mockMvc.perform(
-                    delete("/api/v1/trip/{tripId}/notices/{noticeId}", 1L, noticeId)
+                    patch("/api/v1/trip/{tripId}/notices/{noticeId}/completed", 2L, 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
                             .with(user(userDetails))
             );
-            
+
             // then
             resultActions
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
         }
-        
+    }
+
+    @Nested
+    @DisplayName("공지사항 삭제")
+    class DeleteNotice {
+        private final Long noticeId = 1L;
+
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            doNothing().when(noticeCommandService).deleteNotice(noticeId, userDetails.getUserId());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    delete("/api/v1/trip/{tripId}/notices/{noticeId}", 1L, noticeId)
+                            .with(user(userDetails))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
+
         @Test
         @DisplayName("실패 - 존재하지 않는 공지사항")
         void failIfNoticeNotFound() throws Exception {
             // given
             doThrow(new CustomException(NoticeErrorType.NOT_FOUND)).when(noticeCommandService)
                     .deleteNotice(noticeId, userDetails.getUserId());
-            
+
             // when
             ResultActions resultActions = mockMvc.perform(
                     delete("/api/v1/trip/{tripId}/notices/{noticeId}", 1L, noticeId)
                             .with(user(userDetails))
             );
-            
+
             // then
             resultActions
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.code").value(NoticeErrorType.NOT_FOUND.getCode()))
                     .andExpect(jsonPath("$.message").value(NoticeErrorType.NOT_FOUND.getMessage()));
         }
-        
+
         @Test
         @DisplayName("실패 - 공지사항 작성자가 아닌 경우")
         void failIfUnauthorizedAuthor() throws Exception {
             // given
             doThrow(new CustomException(NoticeErrorType.UNAUTHORIZED_AUTHOR)).when(noticeCommandService)
                     .deleteNotice(noticeId, userDetails.getUserId());
-            
+
             // when
             ResultActions resultActions = mockMvc.perform(
                     delete("/api/v1/trip/{tripId}/notices/{noticeId}", 1L, noticeId)
                             .with(user(userDetails))
             );
-            
+
             // then
             resultActions
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.code").value(NoticeErrorType.UNAUTHORIZED_AUTHOR.getCode()))
                     .andExpect(jsonPath("$.message").value(NoticeErrorType.UNAUTHORIZED_AUTHOR.getMessage()));
-            
+
         }
     }
 }


### PR DESCRIPTION
## 배경
- 공지사항 수행을 완료 상태 설정 및 확인 로직이 존재. 그래서, 해당 로직에 대해서 추가적으로 구현이 필요.

## 작업 사항
- 공지 완료 여부 필드 추가 및 본문 글자 수 제한 (1cef080679a2e6b0b0d6b6fbb303e0e0a807b984)
  - 공지 생성 시,  완료 여부 false 설정 (f1550e3ae8c93d7d64680826478dfea5be872749)
      - 추가적으로, 공지는 방장만 생성 가능하기에, 기존 생성 로직에 방장 확인 로직을 추가하였습니다.
  - 공지 조회 시, 완료 여부 필드 추가 (c15ebdd557be13c50f023af5ded9beb4fd124c6e)
- 공지 완료 여부 상태 변경 로직 추가 (f43793d7c4a84a7f308b7948f29bc04aed431a27)

## 추가 논의
x