### PR TITLE
Feature(IL-311): 정산 내역 조회 기능 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementQueryService.java
@@ -1,0 +1,38 @@
+package kr.co.yeogiga.application.settlement.service;
+
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.settlement.dto.SettlementDto;
+import kr.co.yeogiga.domain.settlement.exception.SettlementErrorType;
+import kr.co.yeogiga.domain.settlement.service.SettlementService;
+import kr.co.yeogiga.domain.trip.exception.TripMemberErrorType;
+import kr.co.yeogiga.domain.trip.service.TripMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SettlementQueryService {
+    private final SettlementService settlementService;
+    private final TripMemberService tripMemberService;
+    
+    /**
+     * 정산 내역을 조회하는 메서드
+     *
+     * @param tripId        여행 ID
+     * @param userId        사용자 ID
+     * @param settlementId  정산 내역 ID
+     * @return              정산 내역
+     *
+     * @throws CustomException TripMemberErrorType.IS_NOT_MEMBER - 여행 멤버가 아닌 사용자가 요청을 보낸 경우
+     * @throws CustomException SettlementErrorType.NOT_FOUND - 정산 내역이 존재하지 않는 경우
+     */
+    public SettlementDto getSettlement(Long tripId, Long userId, Long settlementId) {
+        if (!tripMemberService.existsByTripIdAndUserId(tripId, userId)) {
+            throw new CustomException(TripMemberErrorType.IS_NOT_MEMBER);
+        }
+        
+        return settlementService.findSettlementDtoById(settlementId)
+                .orElseThrow(() -> new CustomException(SettlementErrorType.NOT_FOUND));
+    }
+    
+}

--- a/src/main/java/kr/co/yeogiga/domain/settlement/dto/PayInfoDto.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/dto/PayInfoDto.java
@@ -1,0 +1,11 @@
+package kr.co.yeogiga.domain.settlement.dto;
+
+public record PayInfoDto(
+        Long id,
+        Long userId,
+        String nickname,
+        String imageUrl,
+        Long price,
+        boolean isCompleted
+) {
+}

--- a/src/main/java/kr/co/yeogiga/domain/settlement/dto/SettlementDto.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/dto/SettlementDto.java
@@ -1,0 +1,18 @@
+package kr.co.yeogiga.domain.settlement.dto;
+
+import kr.co.yeogiga.domain.settlement.type.SettlementType;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record SettlementDto (
+        Long id,
+        String name,
+        Long totalPrice,
+        LocalDate date,
+        SettlementType type,
+        Long payerId,
+        boolean isCompleted,
+        List<PayInfoDto> payers
+) {
+}

--- a/src/main/java/kr/co/yeogiga/domain/settlement/exception/SettlementErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/exception/SettlementErrorType.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
  */
 @RequiredArgsConstructor
 public enum SettlementErrorType implements BaseErrorType {
-    NOT_VALID_PRICE(HttpStatus.BAD_REQUEST, "S000", "정산 내역 금액 총합이 일치하지 않습니다.");
+    NOT_VALID_PRICE(HttpStatus.BAD_REQUEST, "S000", "정산 내역 금액 총합이 일치하지 않습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "존재하지 않는 정산 내역 입니다.");
     
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomSettlementRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomSettlementRepository.java
@@ -1,0 +1,9 @@
+package kr.co.yeogiga.domain.settlement.repository;
+
+import kr.co.yeogiga.domain.settlement.dto.SettlementDto;
+
+import java.util.Optional;
+
+public interface CustomSettlementRepository {
+    Optional<SettlementDto> findSettlementDtoById(Long id);
+}

--- a/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomSettlementRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomSettlementRepositoryImpl.java
@@ -1,0 +1,59 @@
+package kr.co.yeogiga.domain.settlement.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.group.GroupBy;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.co.yeogiga.domain.settlement.dto.PayInfoDto;
+import kr.co.yeogiga.domain.settlement.dto.SettlementDto;
+import kr.co.yeogiga.domain.settlement.entity.QPayInfo;
+import kr.co.yeogiga.domain.settlement.entity.QSettlement;
+import kr.co.yeogiga.domain.user.entity.QUser;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class CustomSettlementRepositoryImpl implements CustomSettlementRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+    
+    private final QSettlement settlement = QSettlement.settlement;
+    private final QPayInfo payInfo = QPayInfo.payInfo;
+    private final QUser user = QUser.user;
+    
+    @Override
+    public Optional<SettlementDto> findSettlementDtoById(Long id) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .from(settlement)
+                        .join(payInfo).on(settlement.id.eq(payInfo.settlementId))
+                        .join(user).on(payInfo.userId.eq(user.id))
+                        .transform(
+                                GroupBy.groupBy(settlement.id).as(
+                                        Projections.constructor(
+                                                SettlementDto.class,
+                                                settlement.id,
+                                                settlement.name,
+                                                settlement.totalPrice,
+                                                settlement.date,
+                                                settlement.type,
+                                                settlement.payerId,
+                                                settlement.isCompleted,
+                                                GroupBy.list(
+                                                        Projections.constructor(
+                                                                PayInfoDto.class,
+                                                                payInfo.id,
+                                                                payInfo.userId,
+                                                                user.nickname,
+                                                                user.imageUrl,
+                                                                payInfo.price,
+                                                                payInfo.isCompleted
+                                                        )
+                                                )
+                                        )
+                                )
+                        ).get(id)
+        );
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/settlement/repository/SettlementRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/repository/SettlementRepository.java
@@ -3,5 +3,5 @@ package kr.co.yeogiga.domain.settlement.repository;
 import kr.co.yeogiga.domain.settlement.entity.Settlement;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SettlementRepository extends JpaRepository<Settlement, Long> {
+public interface SettlementRepository extends JpaRepository<Settlement, Long>, CustomSettlementRepository {
 }

--- a/src/main/java/kr/co/yeogiga/domain/settlement/service/SettlementService.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/service/SettlementService.java
@@ -1,9 +1,12 @@
 package kr.co.yeogiga.domain.settlement.service;
 
+import kr.co.yeogiga.domain.settlement.dto.SettlementDto;
 import kr.co.yeogiga.domain.settlement.entity.Settlement;
 import kr.co.yeogiga.domain.settlement.repository.SettlementRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -12,5 +15,9 @@ public class SettlementService {
     
     public Long save(Settlement settlement) {
         return settlementRepository.save(settlement).getId();
+    }
+    
+    public Optional<SettlementDto> findSettlementDtoById(Long id) {
+        return settlementRepository.findSettlementDtoById(id);
     }
 }

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/QueryDslConfig.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/QueryDslConfig.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.infrastructure.config;
 
+import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.querydsl.sql.MySQLTemplates;
 import com.querydsl.sql.SQLTemplates;
@@ -12,7 +13,7 @@ public class QueryDslConfig {
 
     @Bean
     public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
-        return new JPAQueryFactory(entityManager);
+        return new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
     }
     
     @Bean

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/api/SettlementApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/api/SettlementApi.java
@@ -33,7 +33,7 @@ public interface SettlementApi {
                                              }
                                     """)
                     })),
-            @ApiResponse(responseCode = "400", description = "공지사항 생성 실패",
+            @ApiResponse(responseCode = "400", description = "정산 내역 생성 실패",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(name = "유효성 검사 실패", value = """
                                              {
@@ -58,7 +58,7 @@ public interface SettlementApi {
                                              }
                                     """)
                     })),
-            @ApiResponse(responseCode = "404", description = "공지사항 생성 실패",
+            @ApiResponse(responseCode = "404", description = "정샌 내역 생성 실패",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(name = "존재하지 않는 여행",value = """
                                              {
@@ -72,5 +72,69 @@ public interface SettlementApi {
             @Parameter(description = "여행 ID") @PathVariable(name = "tripId") Long tripId,
             @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @Valid @RequestBody SettlementRequest.SettlementDto settlement
+    );
+    
+    @TrackApi(description = "정산 내역 조회")
+    @Operation(summary = "정산 내역 조회", description = "정산 내역 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "정산 내역 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                             {
+                                                  "id": 1,
+                                                  "name": "주유소",
+                                                  "totalPrice": 50000,
+                                                  "date": "2025-09-07",
+                                                  "type": "TRANSPORTATION",
+                                                  "payerId": 16,
+                                                  "isCompleted": false,
+                                                  "payers": [
+                                                      {
+                                                          "id": 1,
+                                                          "userId": 15,
+                                                          "nickname": "nick15",
+                                                          "imageUrl": "https://image.com/1",
+                                                          "price": 10000,
+                                                          "isCompleted": false
+                                                      },
+                                                      {
+                                                          "id": 2,
+                                                          "userId": 16,
+                                                          "nickname": "nick16",
+                                                          "imageUrl": null,
+                                                          "price": 20000,
+                                                          "isCompleted": true
+                                                      }
+                                                  ]
+                                              }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "정산 내역 조회 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "여행 멤버가 아닌 경우", value = """
+                                             {
+                                                   "code": "T102",
+                                                   "message": "해당 여행의 멤버가 아닙니다."
+                                               }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "정산 내역 조회 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "정산 내역 미존재",value = """
+                                             {
+                                                  "code": "S001",
+                                                  "message": "존재하지 않는 정산 내역 입니다."
+                                              }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getSettlement(
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            
+            @Parameter(description = "여행 ID")
+            @PathVariable(name ="tripId") Long tripId,
+            
+            @Parameter(description = "정산 내역 ID")
+            @PathVariable(name = "settlementId") Long settlementId
     );
 }

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
@@ -44,6 +44,6 @@ public class SettlementController implements SettlementApi {
             @PathVariable(name = "settlementId") Long settlementId
     ) {
         return ResponseEntity
-                .ok(settlementQueryService.getSettlement(tripId, userDetails.getUserId(), settlementId));
+                .ok(SuccessResponse.from(settlementQueryService.getSettlement(tripId, userDetails.getUserId(), settlementId)));
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.presentation.settlement.controller;
 import jakarta.validation.Valid;
 import kr.co.yeogiga.application.settlement.dto.SettlementRequest;
 import kr.co.yeogiga.application.settlement.service.SettlementCommandService;
+import kr.co.yeogiga.application.settlement.service.SettlementQueryService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.presentation.settlement.api.SettlementApi;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,13 +19,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/settlement")
+@RequestMapping("/api/v1/trip")
 @RequiredArgsConstructor
 public class SettlementController implements SettlementApi {
     private final SettlementCommandService settlementCommandService;
+    private final SettlementQueryService settlementQueryService;
     
     @Override
-    @PostMapping("/{tripId}")
+    @PostMapping("/{tripId}/settlements")
     public ResponseEntity<?> createSettlement(
             @PathVariable(name = "tripId") Long tripId,
             @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
@@ -32,5 +35,15 @@ public class SettlementController implements SettlementApi {
         settlementCommandService.createSettlement(tripId, userDetails.getUserId(), settlement);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(SuccessResponse.created());
+    }
+    
+    @GetMapping("/{tripId}/settlements/{settlementId}")
+    public ResponseEntity<?> getSettlement(
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            @PathVariable(name ="tripId") Long tripId,
+            @PathVariable(name = "settlementId") Long settlementId
+    ) {
+        return ResponseEntity
+                .ok(settlementQueryService.getSettlement(tripId, userDetails.getUserId(), settlementId));
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
@@ -37,6 +37,7 @@ public class SettlementController implements SettlementApi {
                 .body(SuccessResponse.created());
     }
     
+    @Override
     @GetMapping("/{tripId}/settlements/{settlementId}")
     public ResponseEntity<?> getSettlement(
             @AuthenticationPrincipal CustomUserDetailsImpl userDetails,

--- a/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementQueryServiceTest.java
@@ -1,0 +1,109 @@
+package kr.co.yeogiga.application.settlement.service;
+
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.settlement.dto.PayInfoDto;
+import kr.co.yeogiga.domain.settlement.dto.SettlementDto;
+import kr.co.yeogiga.domain.settlement.exception.SettlementErrorType;
+import kr.co.yeogiga.domain.settlement.service.SettlementService;
+import kr.co.yeogiga.domain.settlement.type.SettlementType;
+import kr.co.yeogiga.domain.trip.exception.TripMemberErrorType;
+import kr.co.yeogiga.domain.trip.service.TripMemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class SettlementQueryServiceTest {
+    @Mock
+    private SettlementService settlementService;
+    
+    @Mock
+    private TripMemberService tripMemberService;
+    
+    @InjectMocks
+    private SettlementQueryService settlementQueryService;
+    
+    @Nested
+    @DisplayName("정산 내역 조회")
+    class GetSettlement {
+        private final Long tripId = 1L;
+        private final Long userId = 1L;
+        private final Long settlementId = 1L;
+        
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            PayInfoDto payInfoDto1 = new PayInfoDto(10L, userId, "nick1", "http://image.com/1", 10000L, true);
+            PayInfoDto payInfoDto2 = new PayInfoDto(11L, 2L, "nick2", "http://image.com/2", 10000L, false);
+            
+            SettlementDto settlementDto = new SettlementDto(
+                    settlementId,
+                    "점심",
+                    20000L,
+                    LocalDate.now(),
+                    SettlementType.MEAL,
+                    userId,
+                    false,
+                    List.of(payInfoDto1, payInfoDto2)
+            );
+            
+            when(tripMemberService.existsByTripIdAndUserId(tripId, userId)).thenReturn(true);
+            when(settlementService.findSettlementDtoById(settlementId))
+                    .thenReturn(Optional.of(settlementDto));
+            
+            // when
+            SettlementDto result = settlementQueryService.getSettlement(tripId, userId, settlementId);
+            
+            // then
+            assertEquals(settlementId, result.id());
+            assertEquals("점심", result.name());
+            assertEquals(userId, result.payerId());
+            assertFalse(result.isCompleted());
+            assertEquals(10L, result.payers().get(0).id());
+            assertEquals(11L, result.payers().get(1).id());
+        }
+        
+        @Test
+        @DisplayName("실패 - 여행 멤버가 아닌 경우")
+        void failIfNotTripMember() {
+            // given
+            when(tripMemberService.existsByTripIdAndUserId(tripId, userId)).thenReturn(false);
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> settlementQueryService.getSettlement(tripId, userId, settlementId));
+            
+            // then
+            assertEquals(TripMemberErrorType.IS_NOT_MEMBER, exception.getErrorType());
+        }
+        
+        @Test
+        @DisplayName("실패 - 정산 내역이 존재하지 않는 경우")
+        void failIfSettlementNotFound() {
+            // given
+            when(tripMemberService.existsByTripIdAndUserId(tripId, userId)).thenReturn(true);
+            when(settlementService.findSettlementDtoById(settlementId)).thenReturn(Optional.empty());
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> settlementQueryService.getSettlement(tripId, userId, settlementId));
+            
+            // then
+            assertEquals(SettlementErrorType.NOT_FOUND, exception.getErrorType());
+        }
+    }
+}

--- a/src/test/java/kr/co/yeogiga/presentation/settlement/controller/SettlementControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/settlement/controller/SettlementControllerTest.java
@@ -3,11 +3,14 @@ package kr.co.yeogiga.presentation.settlement.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.yeogiga.application.settlement.dto.SettlementRequest;
 import kr.co.yeogiga.application.settlement.service.SettlementCommandService;
+import kr.co.yeogiga.application.settlement.service.SettlementQueryService;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.domain.settlement.dto.PayInfoDto;
+import kr.co.yeogiga.domain.settlement.dto.SettlementDto;
 import kr.co.yeogiga.domain.settlement.exception.SettlementErrorType;
 import kr.co.yeogiga.domain.settlement.type.SettlementType;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
@@ -36,9 +39,11 @@ import java.util.List;
 
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -61,6 +66,9 @@ public class SettlementControllerTest {
     
     @MockBean
     private SettlementCommandService settlementCommandService;
+    
+    @MockBean
+    private SettlementQueryService settlementQueryService;
     
     @BeforeEach
     void setUp(WebApplicationContext webApplicationContext) {
@@ -116,7 +124,7 @@ public class SettlementControllerTest {
             
             // when
             ResultActions resultActions = mockMvc.perform(
-                    post("/api/v1/settlement/{tripId}", tripId)
+                    post("/api/v1/trip/{tripId}/settlements", tripId)
                             .with(user(userDetails))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsBytes(settlementDto))
@@ -153,7 +161,7 @@ public class SettlementControllerTest {
             
             // when
             ResultActions resultActions = mockMvc.perform(
-                    post("/api/v1/settlement/{tripId}", tripId)
+                    post("/api/v1/trip/{tripId}/settlements", tripId)
                             .with(user(userDetails))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsBytes(settlementDto))
@@ -251,6 +259,89 @@ public class SettlementControllerTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value(SettlementErrorType.NOT_VALID_PRICE.getCode()))
                     .andExpect(jsonPath("$.message").value(SettlementErrorType.NOT_VALID_PRICE.getMessage()));
+        }
+    }
+    
+    @Nested
+    @DisplayName("정산 내역 조회")
+    class GetSettlement {
+        private final Long tripId = 1L;
+        private final Long settlementId = 1L;
+        
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            PayInfoDto payInfoDto1 = new PayInfoDto(10L, userDetails.getUserId(), "nick1", "http://image.com/1", 10000L, true);
+            PayInfoDto payInfoDto2 = new PayInfoDto(11L, 2L, "nick2", "http://image.com/2", 10000L, false);
+            
+            SettlementDto settlementDto = new SettlementDto(
+                    settlementId,
+                    "점심",
+                    20000L,
+                    LocalDate.now(),
+                    SettlementType.MEAL,
+                    userDetails.getUserId(),
+                    false,
+                    List.of(payInfoDto1, payInfoDto2)
+            );
+            
+            when(settlementQueryService.getSettlement(tripId, userDetails.getUserId(), settlementId))
+                    .thenReturn(settlementDto);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip/{tripId}/settlements/{settlementId}", tripId, settlementId)
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.id").value(settlementId))
+                    .andExpect(jsonPath("$.data.name").value("점심"))
+                    .andExpect(jsonPath("$.data.payers[0].userId").value(1L))
+                    .andExpect(jsonPath("$.data.payers[1].userId").value(2L));
+        }
+        
+        @Test
+        @DisplayName("실패 - 여행 멤버가 아닌 경우")
+        void failIfNotMember() throws Exception {
+            // given
+            doThrow(new CustomException(TripMemberErrorType.IS_NOT_MEMBER)).when(settlementQueryService)
+                    .getSettlement(tripId, userDetails.getUserId(), settlementId);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip/{tripId}/settlements/{settlementId}", tripId, settlementId)
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(TripMemberErrorType.IS_NOT_MEMBER.getCode()))
+                    .andExpect(jsonPath("$.message").value(TripMemberErrorType.IS_NOT_MEMBER.getMessage()));
+        }
+        
+        @Test
+        @DisplayName("실패 - 정산 내역 미존재")
+        void failIfSettlementNotFound() throws Exception {
+            // given
+            doThrow(new CustomException(SettlementErrorType.NOT_FOUND)).when(settlementQueryService)
+                    .getSettlement(tripId, userDetails.getUserId(), settlementId);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip/{tripId}/settlements/{settlementId}", tripId, settlementId)
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(SettlementErrorType.NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.message").value(SettlementErrorType.NOT_FOUND.getMessage()));
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/settlement/controller/SettlementControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/settlement/controller/SettlementControllerTest.java
@@ -185,7 +185,7 @@ public class SettlementControllerTest {
             
             // when
             ResultActions resultActions = mockMvc.perform(
-                    post("/api/v1/settlement/{tripId}", tripId)
+                    post("/api/v1/trip/{tripId}/settlements", tripId)
                             .with(user(userDetails))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsBytes(settlementDto))
@@ -207,7 +207,7 @@ public class SettlementControllerTest {
             
             // when
             ResultActions resultActions = mockMvc.perform(
-                    post("/api/v1/settlement/{tripId}", tripId)
+                    post("/api/v1/trip/{tripId}/settlements", tripId)
                             .with(user(userDetails))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsBytes(settlementDto))
@@ -248,7 +248,7 @@ public class SettlementControllerTest {
             
             // when
             ResultActions resultActions = mockMvc.perform(
-                    post("/api/v1/settlement/{tripId}", tripId)
+                    post("/api/v1/trip/{tripId}/settlements", tripId)
                             .with(user(userDetails))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsBytes(settlementDto))


### PR DESCRIPTION
## 배경
- 정산 내역 조회 기능 필요

## 작업 사항
- `JpaQueryFactory` 생성자 호출 시 `JPQLTemplates.DEFAULT` 인자 추가 | (9c9cd7d1028a032164026b0dc671411d2c353c34)
  - [관련 이슈](https://github.com/querydsl/querydsl/issues/3428)
  - `.transform()`, `GroupBy.groupBy().as()` 메서드 사용 시 hibernate 6에서는 사라진 `ScrollableResults.get(int)` 메서드를 호출하여 `NoSuchMethodError`가 발생하는 문제가 존재합니다. (hibernate 5에서는 해당 메서드가 존재)
  - 위 내용 '추가 논의' 부분에서 추가 설명
- 정산 내역 조회 도메인 로직 구현 | (f59e013f9bd74689c79e06f9e23ea75236ec6b42)
- 정산 내역 조회 로직 구현 | (58bcb89ce7178451237d50c06a724728ade454da)
- 정산 내역 조회 api 구현 | (bcfc70c1d8a10dbfdfd7eda2b49a7ac6e66ac4c4)
  - 정산 내역 조회 api 응답값(body) `SuccessResponse` 누락으로 인한 추가 | (d56ed7dd92a9f2e2d010195bea91a82003c53ddc)

## 추가 논의

### 1. JpaQueryFactory 생성자 호출 시 JPQLTemplates 명시

```java
public class JPAQueryFactory implements JPQLQueryFactory {
    private final @Nullable JPQLTemplates templates;
    private final Supplier<EntityManager> entityManager;

    public JPAQueryFactory(EntityManager entityManager) {
        this.entityManager = () -> {
            return entityManager;
        };
        this.templates = null;
    }

    public JPAQueryFactory(JPQLTemplates templates, EntityManager entityManager) {
        this.entityManager = () -> {
            return entityManager;
        };
        this.templates = templates;
    }
```

위와 같이 기존에 사용하던 `new JPAQueryFactory(EntityManger entityManager)` 사용 시에 JPQLTemplates 부분이 null로 설정되기 때문에 기본적으로 `Hibernate5Templates`을 사용 → `HibernateHandler`를 사용해 Hibernate에서 제공하는 쿼리 기준을 바탕으로 쿼리를 생성하기 때문에 hibernate5에서만 존재하는 `ScrollableResults.get(int)` 메서드를 호출하게 되는 것입니다.

해결 방법으로는 아래 2가지 방법이 있는 것 같습니다.

- `List<Tuple>`로 결과를 받아온 다음에 Repository 메서드 내부에서 변형
- `JPQLTemplates.DEFAULT`를 생성자 인자로 주어 JPA 쿼리 기준을 바탕으로 쿼리를 생성하도록 변경

첫 번째 방법은 매번 메서드에서 처리 과정을 거쳐야하기 때문에 아래 방법으로 진행하였습니다.

### 2. SettlementController 엔드포인트 변경
RESTful API 명명 규칙을 준수하기 위해 엔드포인트 변경하였습니다.
해당 내용 병합 시 프론트 인원에게도 전달하겠습니다.