### PR TITLE
Feature(IL-326): 정산 내역 전체 조회 기능 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementQueryService.java
@@ -9,6 +9,11 @@ import kr.co.yeogiga.domain.trip.service.TripMemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class SettlementQueryService {
@@ -35,4 +40,22 @@ public class SettlementQueryService {
                 .orElseThrow(() -> new CustomException(SettlementErrorType.NOT_FOUND));
     }
     
+    /**
+     * 전체 정산 내역 목록을 조회하는 메서드
+     *
+     * @param tripId    여행 ID
+     * @param userId    사용자 ID
+     * @return          날짜를 Key, 해당 날짜의 정산 내역 목록을 Value로 가지는 정산 내역 목록 Map
+     *
+     * @throws CustomException TripMemberErrorType.IS_NOT_MEMBER - 여행 멤버가 아닌 사용자가 요청을 보낸 경우
+     */
+    public Map<LocalDate, List<SettlementDto>> getAllSettlement(Long tripId, Long userId) {
+        if (!tripMemberService.existsByTripIdAndUserId(tripId, userId)) {
+            throw new CustomException(TripMemberErrorType.IS_NOT_MEMBER);
+        }
+        
+        List<SettlementDto> settlements = settlementService.readAllSettlementDtoByTripId(tripId);
+        
+        return settlements.stream().collect(Collectors.groupingBy(SettlementDto::date));
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomSettlementRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomSettlementRepository.java
@@ -2,8 +2,10 @@ package kr.co.yeogiga.domain.settlement.repository;
 
 import kr.co.yeogiga.domain.settlement.dto.SettlementDto;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CustomSettlementRepository {
     Optional<SettlementDto> findSettlementDtoById(Long id);
+    List<SettlementDto> findAllSettlementDtoByTripId(Long tripId);
 }

--- a/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomSettlementRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomSettlementRepositoryImpl.java
@@ -1,6 +1,5 @@
 package kr.co.yeogiga.domain.settlement.repository;
 
-import com.querydsl.core.Tuple;
 import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -11,6 +10,8 @@ import kr.co.yeogiga.domain.settlement.entity.QSettlement;
 import kr.co.yeogiga.domain.user.entity.QUser;
 import lombok.RequiredArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -55,5 +56,41 @@ public class CustomSettlementRepositoryImpl implements CustomSettlementRepositor
                                 )
                         ).get(id)
         );
+    }
+    
+    @Override
+    public List<SettlementDto> findAllSettlementDtoByTripId(Long tripId) {
+        Collection<SettlementDto> result = jpaQueryFactory
+                .from(settlement)
+                .where(settlement.tripId.eq(tripId))
+                .join(payInfo).on(settlement.id.eq(payInfo.settlementId))
+                .join(user).on(payInfo.userId.eq(user.id))
+                .transform(
+                        GroupBy.groupBy(settlement.id).as(
+                                Projections.constructor(
+                                        SettlementDto.class,
+                                        settlement.id,
+                                        settlement.name,
+                                        settlement.totalPrice,
+                                        settlement.date,
+                                        settlement.type,
+                                        settlement.payerId,
+                                        settlement.isCompleted,
+                                        GroupBy.list(
+                                                Projections.constructor(
+                                                        PayInfoDto.class,
+                                                        payInfo.id,
+                                                        payInfo.userId,
+                                                        user.nickname,
+                                                        user.imageUrl,
+                                                        payInfo.price,
+                                                        payInfo.isCompleted
+                                                )
+                                        )
+                                )
+                        )
+                ).values();
+
+        return new ArrayList<>(result);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/settlement/service/SettlementService.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/service/SettlementService.java
@@ -6,6 +6,7 @@ import kr.co.yeogiga.domain.settlement.repository.SettlementRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -19,5 +20,9 @@ public class SettlementService {
     
     public Optional<SettlementDto> findSettlementDtoById(Long id) {
         return settlementRepository.findSettlementDtoById(id);
+    }
+    
+    public List<SettlementDto> readAllSettlementDtoByTripId(Long tripId) {
+        return settlementRepository.findAllSettlementDtoByTripId(tripId);
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/api/SettlementApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/api/SettlementApi.java
@@ -137,4 +137,174 @@ public interface SettlementApi {
             @Parameter(description = "정산 내역 ID")
             @PathVariable(name = "settlementId") Long settlementId
     );
+    
+    @TrackApi(description = "정산 내역 전체 조회")
+    @Operation(summary = "정산 내역 전체 조회", description = "정산 내역 전체 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "정산 내역 전체 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                             {
+                                                 "code": 200,
+                                                 "message": "요청이 성공하였습니다.",
+                                                 "data": {
+                                                     "2025-09-08": [
+                                                         {
+                                                             "id": 4,
+                                                             "name": "숙소",
+                                                             "totalPrice": 30000,
+                                                             "date": "2025-09-08",
+                                                             "type": "LODGING",
+                                                             "payerId": 16,
+                                                             "isCompleted": true,
+                                                             "payers": [
+                                                                 {
+                                                                     "id": 7,
+                                                                     "userId": 15,
+                                                                     "nickname": "nick15",
+                                                                     "imageUrl": "https://image.com/15",
+                                                                     "price": 10000,
+                                                                     "isCompleted": true
+                                                                 },
+                                                                 {
+                                                                     "id": 8,
+                                                                     "userId": 16,
+                                                                     "nickname": "nick16",
+                                                                     "imageUrl": null,
+                                                                     "price": 20000,
+                                                                     "isCompleted": true
+                                                                 }
+                                                             ]
+                                                         },
+                                                         {
+                                                             "id": 5,
+                                                             "name": "2팀 저녁 숙소",
+                                                             "totalPrice": 50000,
+                                                             "date": "2025-09-08",
+                                                             "type": "LODGING",
+                                                             "payerId": 16,
+                                                             "isCompleted": false,
+                                                             "payers": [
+                                                                 {
+                                                                     "id": 9,
+                                                                     "userId": 15,
+                                                                     "nickname": "nick15",
+                                                                     "imageUrl": "https://image.com/15",
+                                                                     "price": 10000,
+                                                                     "isCompleted": false
+                                                                 },
+                                                                 {
+                                                                     "id": 10,
+                                                                     "userId": 16,
+                                                                     "nickname": "nick16",
+                                                                     "imageUrl": null,
+                                                                     "price": 20000,
+                                                                     "isCompleted": true
+                                                                 }
+                                                             ]
+                                                         }
+                                                     ],
+                                                     "2025-09-07": [
+                                                         {
+                                                             "id": 1,
+                                                             "name": "주유소",
+                                                             "totalPrice": 50000,
+                                                             "date": "2025-09-07",
+                                                             "type": "TRANSPORT",
+                                                             "payerId": 16,
+                                                             "isCompleted": false,
+                                                             "payers": [
+                                                                 {
+                                                                     "id": 1,
+                                                                     "userId": 15,
+                                                                     "nickname": "nick15",
+                                                                     "imageUrl": "https://image.com/15",
+                                                                     "price": 10000,
+                                                                     "isCompleted": false
+                                                                 },
+                                                                 {
+                                                                     "id": 2,
+                                                                     "userId": 16,
+                                                                     "nickname": "nick16",
+                                                                     "imageUrl": null,
+                                                                     "price": 20000,
+                                                                     "isCompleted": true
+                                                                 }
+                                                             ]
+                                                         },
+                                                         {
+                                                             "id": 2,
+                                                             "name": "점심",
+                                                             "totalPrice": 30000,
+                                                             "date": "2025-09-07",
+                                                             "type": "RESTAURANT",
+                                                             "payerId": 16,
+                                                             "isCompleted": true,
+                                                             "payers": [
+                                                                 {
+                                                                     "id": 3,
+                                                                     "userId": 15,
+                                                                     "nickname": "nick15",
+                                                                     "imageUrl": "https://image.com/15",
+                                                                     "price": 10000,
+                                                                     "isCompleted": true
+                                                                 },
+                                                                 {
+                                                                     "id": 4,
+                                                                     "userId": 16,
+                                                                     "nickname": "nick16",
+                                                                     "imageUrl": null,
+                                                                     "price": 20000,
+                                                                     "isCompleted": true
+                                                                 }
+                                                             ]
+                                                         },
+                                                         {
+                                                             "id": 3,
+                                                             "name": "저녁",
+                                                             "totalPrice": 30000,
+                                                             "date": "2025-09-07",
+                                                             "type": "RESTAURANT",
+                                                             "payerId": 16,
+                                                             "isCompleted": true,
+                                                             "payers": [
+                                                                 {
+                                                                     "id": 5,
+                                                                     "userId": 15,
+                                                                     "nickname": "nick15",
+                                                                     "imageUrl": "https://image.com/15",
+                                                                     "price": 10000,
+                                                                     "isCompleted": true
+                                                                 },
+                                                                 {
+                                                                     "id": 6,
+                                                                     "userId": 16,
+                                                                     "nickname": "nick16",
+                                                                     "imageUrl": null,
+                                                                     "price": 20000,
+                                                                     "isCompleted": true
+                                                                 }
+                                                             ]
+                                                         }
+                                                     ]
+                                                 }
+                                             }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "정산 내역 전체 조회 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "여행 멤버가 아닌 경우", value = """
+                                             {
+                                                   "code": "T102",
+                                                   "message": "해당 여행의 멤버가 아닙니다."
+                                               }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getAllSettlement(
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            
+            @Parameter(description = "여행 ID")
+            @PathVariable(name ="tripId") Long tripId
+    );
 }

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
@@ -48,6 +48,7 @@ public class SettlementController implements SettlementApi {
                 .ok(SuccessResponse.from(settlementQueryService.getSettlement(tripId, userDetails.getUserId(), settlementId)));
     }
     
+    @Override
     @GetMapping("/{tripId}/settlements")
     public ResponseEntity<?> getAllSettlement(
             @AuthenticationPrincipal CustomUserDetailsImpl userDetails,

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
@@ -47,4 +47,13 @@ public class SettlementController implements SettlementApi {
         return ResponseEntity
                 .ok(SuccessResponse.from(settlementQueryService.getSettlement(tripId, userDetails.getUserId(), settlementId)));
     }
+    
+    @GetMapping("/{tripId}/settlements")
+    public ResponseEntity<?> getAllSettlement(
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            @PathVariable(name ="tripId") Long tripId
+    ) {
+        return ResponseEntity
+                .ok(SuccessResponse.from(settlementQueryService.getAllSettlement(tripId, userDetails.getUserId())));
+    }
 }

--- a/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementQueryServiceTest.java
@@ -18,8 +18,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -104,6 +106,73 @@ public class SettlementQueryServiceTest {
             
             // then
             assertEquals(SettlementErrorType.NOT_FOUND, exception.getErrorType());
+        }
+    }
+    
+    @Nested
+    @DisplayName("정산 내역 전체 조회")
+    class GetAllSettlement {
+        private final Long tripId = 1L;
+        private final Long userId = 1L;
+        private final Long settlementId = 1L;
+        
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            PayInfoDto payInfoDto1 = new PayInfoDto(10L, userId, "nick1", "http://image.com/1", 10000L, true);
+            PayInfoDto payInfoDto2 = new PayInfoDto(11L, 2L, "nick2", "http://image.com/2", 10000L, false);
+            PayInfoDto payInfoDto3 = new PayInfoDto(20L, userId, "nick1", "http://image.com/1", 10000L, true);
+            PayInfoDto payInfoDto4 = new PayInfoDto(21L, 2L, "nick2", "http://image.com/2", 40000L, true);
+            
+            SettlementDto settlementDto1 = new SettlementDto(
+                    settlementId,
+                    "마트 장보기",
+                    20000L,
+                    LocalDate.now(),
+                    SettlementType.ETC,
+                    userId,
+                    false,
+                    List.of(payInfoDto1, payInfoDto2)
+            );
+            
+            SettlementDto settlementDto2 = new SettlementDto(
+                    settlementId,
+                    "주류",
+                    50000L,
+                    LocalDate.now().minusDays(1),
+                    SettlementType.ETC,
+                    userId,
+                    true,
+                    List.of(payInfoDto3, payInfoDto4)
+            );
+            
+            
+            when(tripMemberService.existsByTripIdAndUserId(tripId, userId)).thenReturn(true);
+            when(settlementService.readAllSettlementDtoByTripId(tripId)).thenReturn(List.of(settlementDto1, settlementDto2));
+            
+            // when
+            Map<LocalDate, List<SettlementDto>> result = settlementQueryService.getAllSettlement(tripId, userId);
+            
+            // then
+            assertThat(result.get(LocalDate.now())).hasSize(1);
+            assertThat(result.get(LocalDate.now().minusDays(1))).hasSize(1);
+            assertEquals("마트 장보기", result.get(LocalDate.now()).get(0).name());
+            assertEquals("주류", result.get(LocalDate.now().minusDays(1)).get(0).name());
+        }
+        
+        @Test
+        @DisplayName("실패 - 여행 멤버가 아닌 경우")
+        void failIfNotMember() {
+            // given
+            when(tripMemberService.existsByTripIdAndUserId(tripId, userId)).thenReturn(false);
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> settlementQueryService.getAllSettlement(tripId, userId));
+            
+            // then
+            assertEquals(TripMemberErrorType.IS_NOT_MEMBER, exception.getErrorType());
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/settlement/controller/SettlementControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/settlement/controller/SettlementControllerTest.java
@@ -35,7 +35,9 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -342,6 +344,85 @@ public class SettlementControllerTest {
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.code").value(SettlementErrorType.NOT_FOUND.getCode()))
                     .andExpect(jsonPath("$.message").value(SettlementErrorType.NOT_FOUND.getMessage()));
+        }
+    }
+    
+    @Nested
+    @DisplayName("정산 내역 전체 조회")
+    class GetAllSettlement {
+        private final Long settlementId = 1L;
+        private final Long tripId = 1L;
+        
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            PayInfoDto payInfoDto1 = new PayInfoDto(10L, userDetails.getUserId(), "nick1", "http://image.com/1", 10000L, true);
+            PayInfoDto payInfoDto2 = new PayInfoDto(11L, 2L, "nick2", "http://image.com/2", 10000L, false);
+            PayInfoDto payInfoDto3 = new PayInfoDto(20L, userDetails.getUserId(), "nick1", "http://image.com/1", 10000L, true);
+            PayInfoDto payInfoDto4 = new PayInfoDto(21L, 2L, "nick2", "http://image.com/2", 40000L, true);
+            
+            SettlementDto settlementDto1 = new SettlementDto(
+                    settlementId,
+                    "마트 장보기",
+                    20000L,
+                    LocalDate.now(),
+                    SettlementType.ETC,
+                    userDetails.getUserId(),
+                    false,
+                    List.of(payInfoDto1, payInfoDto2)
+            );
+            
+            SettlementDto settlementDto2 = new SettlementDto(
+                    settlementId,
+                    "주류",
+                    50000L,
+                    LocalDate.now().minusDays(1),
+                    SettlementType.ETC,
+                    userDetails.getUserId(),
+                    true,
+                    List.of(payInfoDto3, payInfoDto4)
+            );
+            
+            Map<LocalDate, List<SettlementDto>> map = new HashMap<>();
+            
+            map.put(LocalDate.now(), List.of(settlementDto1));
+            map.put(LocalDate.now().minusDays(1), List.of(settlementDto2));
+            
+            when(settlementQueryService.getAllSettlement(tripId, userDetails.getUserId())).thenReturn(map);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip/{tripId}/settlements", tripId)
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data." + LocalDate.now()).isArray())
+                    .andExpect(jsonPath("$.data." + LocalDate.now().minusDays(1)).isArray());
+            
+        }
+        
+        @Test
+        @DisplayName("실패 - 여행 멤버가 아닌 경우")
+        void failIfNotMember() throws Exception {
+            // given
+            doThrow(new CustomException(TripMemberErrorType.IS_NOT_MEMBER)).when(settlementQueryService)
+                    .getAllSettlement(tripId, userDetails.getUserId());
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/trip/{tripId}/settlements", tripId)
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(TripMemberErrorType.IS_NOT_MEMBER.getCode()))
+                    .andExpect(jsonPath("$.message").value(TripMemberErrorType.IS_NOT_MEMBER.getMessage()));
         }
     }
 }


### PR DESCRIPTION
## 배경
- 정산 내역 전체 조회 기능 요구

## 작업 사항
- 정산 내역 전체 조회 도메인 로직 구현 | (91825cebb7e7561f21ff1345c1c5ae7326119c80)
- 정산 내역 전체 조회 로직 구현 | (77524399d3be1b16cc7a6485ca31c196cf3f8a02)
- 정산 내역 전체 조회 api 작성 | (016a5a43140e9100cb2f44097a11b0b091f2d8a5)

## 추가 논의
- `SettlementService` 내 메서드명 오류 발견 - 차후 수정 예정 
  - `findSettlementDtoById()` → `readSettlementDtoById()`
- 정산 내역 조회(단일) QueryDsl 구문 내 `where`절 누락 발견- 차후 수정 예정
  ```java
  // CustomSettlementRepositoryImpl
      @Override
      public Optional<SettlementDto> findSettlementDtoById(Long id) {
          return Optional.ofNullable(
                  jpaQueryFactory
                          .from(settlement)
                          .join(payInfo).on(settlement.id.eq(payInfo.settlementId)).
                          .join(user).on(payInfo.userId.eq(user.id))
                          .transform(
                          // ...
  ```
