### PR TITLE
Refactor: 정산 내역 조회 도메인 로직 수정

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementQueryService.java
@@ -36,7 +36,7 @@ public class SettlementQueryService {
             throw new CustomException(TripMemberErrorType.IS_NOT_MEMBER);
         }
         
-        return settlementService.findSettlementDtoById(settlementId)
+        return settlementService.readSettlementDtoById(settlementId)
                 .orElseThrow(() -> new CustomException(SettlementErrorType.NOT_FOUND));
     }
     

--- a/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomSettlementRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomSettlementRepositoryImpl.java
@@ -30,6 +30,7 @@ public class CustomSettlementRepositoryImpl implements CustomSettlementRepositor
                         .from(settlement)
                         .join(payInfo).on(settlement.id.eq(payInfo.settlementId))
                         .join(user).on(payInfo.userId.eq(user.id))
+                        .where(settlement.id.eq(id))
                         .transform(
                                 GroupBy.groupBy(settlement.id).as(
                                         Projections.constructor(

--- a/src/main/java/kr/co/yeogiga/domain/settlement/service/SettlementService.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/service/SettlementService.java
@@ -18,7 +18,7 @@ public class SettlementService {
         return settlementRepository.save(settlement).getId();
     }
     
-    public Optional<SettlementDto> findSettlementDtoById(Long id) {
+    public Optional<SettlementDto> readSettlementDtoById(Long id) {
         return settlementRepository.findSettlementDtoById(id);
     }
     

--- a/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementQueryServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementQueryServiceTest.java
@@ -64,7 +64,7 @@ public class SettlementQueryServiceTest {
             );
             
             when(tripMemberService.existsByTripIdAndUserId(tripId, userId)).thenReturn(true);
-            when(settlementService.findSettlementDtoById(settlementId))
+            when(settlementService.readSettlementDtoById(settlementId))
                     .thenReturn(Optional.of(settlementDto));
             
             // when
@@ -98,7 +98,7 @@ public class SettlementQueryServiceTest {
         void failIfSettlementNotFound() {
             // given
             when(tripMemberService.existsByTripIdAndUserId(tripId, userId)).thenReturn(true);
-            when(settlementService.findSettlementDtoById(settlementId)).thenReturn(Optional.empty());
+            when(settlementService.readSettlementDtoById(settlementId)).thenReturn(Optional.empty());
             
             // when
             CustomException exception = assertThrows(CustomException.class, ()


### PR DESCRIPTION
## 배경
- 정산 내역 조회 도메인 로직 내 `where` 절 누락 및 메서드명 컨벤션 불일치 문제 인식

## 작업 사항
- 정산 내역 조회 쿼리 메서드 내 `where` 절 추가 | (a9628c2e724ae44388d3294682d011fc04dbde31)
- 정산 내역 조회 도메인 서비스 메서드 이름 변경 | (ce8253d28e37f0583f4ec8e98a53abeaa2efb99c)
  - `find...()` → `read...()`
  - 이에 따른 코드 수정 | (170aae744a09de62c6f2effa20632f3e98969602)