### PR TITLE
Feature(IL-335): 날씨 조회 로직 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/weather/dto/WeatherRes.java
+++ b/src/main/java/kr/co/yeogiga/application/weather/dto/WeatherRes.java
@@ -1,0 +1,12 @@
+package kr.co.yeogiga.application.weather.dto;
+
+import kr.co.yeogiga.infrastructure.weather.dto.WeatherItemDto;
+
+public record WeatherRes(
+        String category,
+        String fcstValue
+) {
+    public static WeatherRes from(WeatherItemDto dto) {
+        return new WeatherRes(dto.category(), dto.fcstValue());
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/weather/service/WeatherService.java
+++ b/src/main/java/kr/co/yeogiga/application/weather/service/WeatherService.java
@@ -1,0 +1,49 @@
+package kr.co.yeogiga.application.weather.service;
+
+import kr.co.yeogiga.application.weather.dto.WeatherRes;
+import kr.co.yeogiga.common.util.ForecastTimeUtil;
+import kr.co.yeogiga.infrastructure.weather.WeatherClient;
+import kr.co.yeogiga.infrastructure.weather.dto.WeatherItemDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WeatherService {
+    private final WeatherClient weatherClient;
+
+    /**
+     * 해당 격자 공간(nx, ny)에서 현재 시각에 가까운(올림) 시간의 날씨를 조회하는 메서드
+     *
+     * @param nx 격자 x
+     * @param ny 격자 y
+     * @return 해당 격자 공간에 대한 날씨 예측 정보
+     */
+    public List<WeatherRes> getRoundedForecast(int nx, int ny) {
+        LocalDateTime now = LocalDateTime.now();
+
+        // 조회 기준 날짜 및 시간 (현재보다 작고 가장 가까운 시각)
+        String[] base = ForecastTimeUtil.calcBaseDateTime(now);
+        String baseDate = base[0];
+        String baseTime = base[1];
+
+        // 날씨를 조회하고자 하는 시간 (현재 시각 올림)
+        String[] target = ForecastTimeUtil.calcTargetFcst(now);
+        String targetDate = target[0];
+        String targetTime = target[1];
+
+        List<WeatherItemDto> items = weatherClient.callVillageFcst(baseDate, baseTime, nx, ny);
+
+        // 조회하고자 하는 시간을 필터링하여 반환
+        return items.stream()
+                .filter(it -> targetDate.equals(it.fcstDate())
+                        && targetTime.equals(it.fcstTime()))
+                .map(WeatherRes::from)
+                .toList();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/common/util/ForecastTimeUtil.java
+++ b/src/main/java/kr/co/yeogiga/common/util/ForecastTimeUtil.java
@@ -1,0 +1,56 @@
+package kr.co.yeogiga.common.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class ForecastTimeUtil {
+    private static final int[] BASE_HOURS = {2, 5, 8, 11, 14, 17, 20, 23};
+
+    private static final DateTimeFormatter DATE = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    /**
+     * 날씨 요청 기준 날짜 및 시간 계산
+     */
+    public static String[] calcBaseDateTime(LocalDateTime now) {
+        LocalDate date = now.toLocalDate();
+        int hour = now.getHour();
+
+        int chosenHour = 23;
+        if (hour < 2) {
+            date = date.minusDays(1);
+        } else {
+            for (int h : BASE_HOURS) {
+                if (hour < h) break;
+                chosenHour = h;
+            }
+        }
+
+        return new String[]{
+                date.format(DATE),
+                String.format("%02d00", chosenHour)
+        };
+    }
+
+    /**
+     * 날씨 예측을 위해 현재시간 대비 날짜 및 시간 계산
+     */
+    public static String[] calcTargetFcst(LocalDateTime now) {
+        LocalDate date = now.toLocalDate();
+        int hour = now.getHour();
+        int minute = now.getMinute();
+
+        if (minute > 0) {
+            hour++;
+            if (hour == 24) {
+                hour = 0;
+                date = date.plusDays(1);
+            }
+        }
+
+        return new String[]{
+                date.format(DATE),
+                String.format("%02d00", hour)
+        };
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
@@ -6,7 +6,7 @@ public final class EndpointConstants {
     public static final String[] PUBLIC_ENDPOINTS = {
             "/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**",
             "/webjars/**", "/error", "/api-checker/**", "/v1/api/link/checker/**",
-            "/api/v1/auth/**", "/api/v1/oauth/sign-in/**"
+            "/api/v1/auth/**", "/api/v1/oauth/sign-in/**", "/api/v1/weather"
     };
 
     public static final String[] USER_ENDPOINTS = {

--- a/src/main/java/kr/co/yeogiga/infrastructure/properties/WeatherProperties.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/properties/WeatherProperties.java
@@ -1,0 +1,19 @@
+package kr.co.yeogiga.infrastructure.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "weather")
+public class WeatherProperties {
+    private String baseUrl;
+    private String path;
+    private String serviceKey;
+    private String pageNo;
+    private String numOfRows;
+    private String dataType;
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/weather/WeatherClient.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/weather/WeatherClient.java
@@ -1,0 +1,77 @@
+package kr.co.yeogiga.infrastructure.weather;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.common.response.error.type.CommonErrorType;
+import kr.co.yeogiga.infrastructure.properties.WeatherProperties;
+import kr.co.yeogiga.infrastructure.weather.dto.WeatherItemDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WeatherClient {
+    private final ObjectMapper objectMapper;
+    private final WeatherProperties weatherProperties;
+
+    /**
+     * 기준 날짜 및 시간을 통해 격자 공간에 대한 날씨를 조회하는 메서드
+     * - 공공 데이터 포털 open api 사용
+     *
+     * @param baseDate 기준 날짜
+     * @param baseTime 기준 시간
+     * @param nx       격자 x
+     * @param ny       격자 y
+     * @return 해당 격자 공간에 대한 날씨 예측 정보
+     */
+    public List<WeatherItemDto> callVillageFcst(String baseDate, String baseTime, int nx, int ny) {
+        URI uri = UriComponentsBuilder.fromUriString(weatherProperties.getBaseUrl())
+                .path(weatherProperties.getPath())
+                .queryParam("serviceKey", weatherProperties.getServiceKey())
+                .queryParam("pageNo", weatherProperties.getPageNo())
+                .queryParam("numOfRows", weatherProperties.getNumOfRows())
+                .queryParam("dataType", weatherProperties.getDataType())
+                .queryParam("base_date", baseDate)
+                .queryParam("base_time", baseTime)
+                .queryParam("nx", nx)
+                .queryParam("ny", ny)
+                .build(true)
+                .toUri();
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(
+                    uri,
+                    HttpMethod.GET,
+                    null,
+                    String.class
+            );
+
+            JsonNode rootNode = objectMapper.readTree(response.getBody());
+            JsonNode items = rootNode
+                    .path("response")
+                    .path("body")
+                    .path("items")
+                    .path("item");
+
+            return objectMapper.readValue(items.traverse(), new TypeReference<>() {
+            });
+
+        } catch (Exception e) {
+            log.error("[ERROR] Could not fetch forecast from PublicData API - {}", e.getMessage());
+            throw new CustomException(CommonErrorType.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/weather/dto/WeatherItemDto.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/weather/dto/WeatherItemDto.java
@@ -1,0 +1,9 @@
+package kr.co.yeogiga.infrastructure.weather.dto;
+
+public record WeatherItemDto(
+        String fcstDate,
+        String fcstTime,
+        String category,
+        String fcstValue
+) {
+}

--- a/src/main/java/kr/co/yeogiga/presentation/weather/api/WeatherApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/weather/api/WeatherApi.java
@@ -1,0 +1,53 @@
+package kr.co.yeogiga.presentation.weather.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@ApiGroup(value = "[날씨 관련 API]")
+@Tag(name = "[날씨 관련 API]", description = "날씨 관련 API")
+public interface WeatherApi {
+
+    @TrackApi(description = "날씨 조회")
+    @Operation(summary = "날씨 조회", description = "날씨 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "날씨 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                             {
+                                                 "code": 200,
+                                                 "message": "요청이 성공하였습니다.",
+                                                 "data": [
+                                                     {
+                                                         "category": "TMP",
+                                                         "fcstValue": "17"
+                                                     },
+                                                     {
+                                                         "category": "UUU",
+                                                         "fcstValue": "-0.7"
+                                                     },
+                                                     {
+                                                         "category": "VVV",
+                                                         "fcstValue": "-1.9"
+                                                     }
+                                                 ]
+                                             }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getWeather(
+            @Parameter(description = "현재 격자 공간 x")
+            @RequestParam int nx,
+
+            @Parameter(description = "현재 격자 공간 y")
+            @RequestParam int ny
+    );
+}

--- a/src/main/java/kr/co/yeogiga/presentation/weather/controller/WeatherController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/weather/controller/WeatherController.java
@@ -1,0 +1,27 @@
+package kr.co.yeogiga.presentation.weather.controller;
+
+import kr.co.yeogiga.application.weather.service.WeatherService;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/weather")
+@RequiredArgsConstructor
+public class WeatherController {
+    private final WeatherService weatherService;
+
+    @GetMapping
+    public ResponseEntity<?> getWeather(
+            @RequestParam int nx,
+            @RequestParam int ny
+    ) {
+        return ResponseEntity.ok(
+                SuccessResponse.from(weatherService.getRoundedForecast(nx, ny))
+        );
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/weather/controller/WeatherController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/weather/controller/WeatherController.java
@@ -2,6 +2,7 @@ package kr.co.yeogiga.presentation.weather.controller;
 
 import kr.co.yeogiga.application.weather.service.WeatherService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.presentation.weather.api.WeatherApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,9 +13,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/weather")
 @RequiredArgsConstructor
-public class WeatherController {
+public class WeatherController implements WeatherApi {
     private final WeatherService weatherService;
 
+    @Override
     @GetMapping
     public ResponseEntity<?> getWeather(
             @RequestParam int nx,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,3 +75,13 @@ map:
     uri: ${NAVER_API_URI}
     client-id: ${NAVER_CLIENT_ID}
     client-secret: ${NAVER_CLIENT_SECRET}
+
+--- # weather
+weather:
+  base-url: ${WEATHER_BASE_URL}
+  path: ${WEATHER_PATH}
+  service-key:  ${WEATHER_SERVICE_KEY}
+  page-no: ${WEATHER_PAGE_NO}
+  num-of-rows: ${WEATHER_NUM}
+  data-type: ${WEATHER_DATA_TYPE}
+

--- a/src/test/java/kr/co/yeogiga/application/weather/service/WeatherServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/weather/service/WeatherServiceTest.java
@@ -1,0 +1,58 @@
+package kr.co.yeogiga.application.weather.service;
+
+import kr.co.yeogiga.application.weather.dto.WeatherRes;
+import kr.co.yeogiga.common.util.ForecastTimeUtil;
+import kr.co.yeogiga.infrastructure.weather.WeatherClient;
+import kr.co.yeogiga.infrastructure.weather.dto.WeatherItemDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class WeatherServiceTest {
+
+    @Mock
+    private WeatherClient weatherClient;
+
+    @InjectMocks
+    private WeatherService weatherService;
+
+    @Test
+    @DisplayName("날씨 조회 테스트")
+    void getRoundedForecastTest() {
+        int nx = 55, ny = 127;
+
+        try (MockedStatic<ForecastTimeUtil> mocked = mockStatic(ForecastTimeUtil.class)) {
+            // given
+            mocked.when(() -> ForecastTimeUtil.calcBaseDateTime(Mockito.any(LocalDateTime.class)))
+                    .thenReturn(new String[]{"20250920", "0200"});
+            mocked.when(() -> ForecastTimeUtil.calcTargetFcst(Mockito.any(LocalDateTime.class)))
+                    .thenReturn(new String[]{"20250920", "0300"});
+
+            when(weatherClient.callVillageFcst("20250920", "0200", nx, ny))
+                    .thenReturn(List.of(
+                            new WeatherItemDto("20250920", "0200", "UUU", "-1.9"),
+                            new WeatherItemDto("20250920", "0300", "TMP", "18"),
+                            new WeatherItemDto("20250920", "0300", "POP", "60")
+                    ));
+
+            // when
+            List<WeatherRes> result = weatherService.getRoundedForecast(nx, ny);
+
+            // then
+            assertThat(result).hasSize(2);
+        }
+    }
+}

--- a/src/test/java/kr/co/yeogiga/presentation/weather/controller/WeatherControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/weather/controller/WeatherControllerTest.java
@@ -1,0 +1,76 @@
+package kr.co.yeogiga.presentation.weather.controller;
+
+import kr.co.yeogiga.application.weather.dto.WeatherRes;
+import kr.co.yeogiga.application.weather.service.WeatherService;
+import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
+import kr.co.yeogiga.infrastructure.weather.dto.WeatherItemDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = WeatherController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthenticationFilter.class})
+        }
+)
+public class WeatherControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private WeatherService weatherService;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .alwaysDo(print())
+                .build();
+    }
+
+    @Test
+    @DisplayName("날씨 조회 테스트")
+    void getWeatherTest() throws Exception {
+        // given
+        List<WeatherRes> response = List.of(
+                WeatherRes.from(new WeatherItemDto("20250920", "0200", "UUU", "-1.9")),
+                WeatherRes.from(new WeatherItemDto("20250920", "0200", "VEC", "23"))
+        );
+        int nx = 55, ny = 127;
+
+        when(weatherService.getRoundedForecast(nx, ny)).thenReturn(response);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/weather")
+                        .queryParam("nx", String.valueOf(nx))
+                        .queryParam("ny", String.valueOf(ny))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].category").value(response.get(0).category()))
+                .andExpect(jsonPath("$.data[0].fcstValue").value(response.get(0).fcstValue()));
+    }
+}


### PR DESCRIPTION
## 배경
- 공공데이터 날씨 조회 api가 보안 정책으로 인해 브라우저에서 호출이 안되어 프록시로 접근해야함. 
보안적 안정성을 위해 서버에서 조회 후 반환하는 형식으로 진행.

## 작업 사항
- 공공데이터에서 날씨 조회 로직 구현 (012ff97ad461afc4e311b644b5ead7490d190114)
- 날씨 조회를 위한 기준 시간대 및 예측 시간대 util 클래스 생성 (cecb2ed1a30c17ecdb26767a4acd1251a381913d)
  - 조회 가능 시간은 02:00, 05:00, ... , 23:00 으로 3시간 단위 총 8개 존재.
  - 현재 시간대를 기준보다 빠르고 가장 가까운 시간을 기준 시간대로 설정.
      - 만약 02:00보다 앞이면, 전날의 23:00 선택
  - 조회 예측 시간(클라이언트에 반환)은 현재 시간을 올림하여 반환.
      - 만약 현재 시간이 03:13이라면 04:00 데이터 반환
- 날씨 조회 로직 및 api 구현 (eebe0662f9edd8fcbcf7b135e67219fcb327e2b4) (58910d70e0579d5200e5d9c337a485ac866ac580)

## 추가 논의
x