### PR TITLE
Feature(IL-334): 정산 내역 삭제 기능 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementCommandService.java
@@ -109,4 +109,32 @@ public class SettlementCommandService {
         return payers.stream()
                 .allMatch(SettlementRequest.PayInfoDto::isCompleted);
     }
+    
+    /**
+     * 정산 내역을 삭제하는 메서드
+     *
+     * @param tripId        여행 ID
+     * @param userId        사용자 ID
+     * @param settlementId  정산 내역 ID
+     *
+     * @throws CustomException TripMemberErrorType.IS_NOT_MEMBER - 요청자가 여행 멤버가 아닐 경우
+     * @throws CustomException SettlementErrorType.NOT_FOUND - 정산 내역이 존재하지 않을 경우
+     * @throws CustomException SettlementErrorType.IS_NOT_PAYER - 요청자가 정산 생성자가 아닐 경우
+     */
+    @Transactional
+    public void deleteSettlement(Long tripId, Long userId, Long settlementId) {
+        if (!tripMemberService.existsByTripIdAndUserId(tripId, userId)) {
+            throw new CustomException(TripMemberErrorType.IS_NOT_MEMBER);
+        }
+        
+        Long payerId = settlementService.readPayerIdById(settlementId)
+                .orElseThrow(() -> new CustomException(SettlementErrorType.NOT_FOUND));
+        
+        if (!payerId.equals(userId)) {
+            throw new CustomException(SettlementErrorType.IS_NOT_PAYER);
+        }
+        
+        payInfoService.deleteBySettlementId(settlementId);
+        settlementService.deleteById(settlementId);
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/settlement/exception/SettlementErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/exception/SettlementErrorType.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum SettlementErrorType implements BaseErrorType {
     NOT_VALID_PRICE(HttpStatus.BAD_REQUEST, "S000", "정산 내역 금액 총합이 일치하지 않습니다."),
-    NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "존재하지 않는 정산 내역 입니다.");
+    NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "존재하지 않는 정산 내역 입니다."),
+    IS_NOT_PAYER(HttpStatus.FORBIDDEN, "S002", "정산자가 아닙니다.");
     
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomSettlementRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomSettlementRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface CustomSettlementRepository {
+    Optional<Long> findPayerIdById(Long id);
     Optional<SettlementDto> findSettlementDtoById(Long id);
     List<SettlementDto> findAllSettlementDtoByTripId(Long tripId);
 }

--- a/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomSettlementRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomSettlementRepositoryImpl.java
@@ -24,6 +24,17 @@ public class CustomSettlementRepositoryImpl implements CustomSettlementRepositor
     private final QUser user = QUser.user;
     
     @Override
+    public Optional<Long> findPayerIdById(Long id) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .select(settlement.payerId)
+                        .from(settlement)
+                        .where(settlement.id.eq(id))
+                        .fetchFirst()
+        );
+    }
+    
+    @Override
     public Optional<SettlementDto> findSettlementDtoById(Long id) {
         return Optional.ofNullable(
                 jpaQueryFactory

--- a/src/main/java/kr/co/yeogiga/domain/settlement/repository/PayInfoRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/repository/PayInfoRepository.java
@@ -2,6 +2,12 @@ package kr.co.yeogiga.domain.settlement.repository;
 
 import kr.co.yeogiga.domain.settlement.entity.PayInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PayInfoRepository extends JpaRepository<PayInfo, Long>, CustomPayInfoRepository {
+    @Modifying
+    @Query(value = "DELETE FROM pay_info WHERE settlement_id = :settlementId", nativeQuery = true)
+    void deleteBySettlementId(@Param(value = "settlementId") Long settlementId);
 }

--- a/src/main/java/kr/co/yeogiga/domain/settlement/repository/SettlementRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/repository/SettlementRepository.java
@@ -2,6 +2,12 @@ package kr.co.yeogiga.domain.settlement.repository;
 
 import kr.co.yeogiga.domain.settlement.entity.Settlement;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SettlementRepository extends JpaRepository<Settlement, Long>, CustomSettlementRepository {
+    @Modifying
+    @Query(value = "DELETE FROM settlement WHERE id = :id", nativeQuery = true)
+    void deleteById(@Param(value = "id") Long id);
 }

--- a/src/main/java/kr/co/yeogiga/domain/settlement/service/PayInfoService.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/service/PayInfoService.java
@@ -15,4 +15,8 @@ public class PayInfoService {
     public void saveAllInBatch(List<PayInfo> payInfos) {
         payInfoRepository.saveAllInBatch(payInfos);
     }
+    
+    public void deleteBySettlementId(Long settlementId) {
+        payInfoRepository.deleteBySettlementId(settlementId);
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/settlement/service/SettlementService.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/service/SettlementService.java
@@ -18,11 +18,23 @@ public class SettlementService {
         return settlementRepository.save(settlement).getId();
     }
     
+    public Optional<Settlement> readById(Long id) {
+        return settlementRepository.findById(id);
+    }
+    
+    public Optional<Long> readPayerIdById(Long id) {
+        return settlementRepository.findPayerIdById(id);
+    }
+    
     public Optional<SettlementDto> readSettlementDtoById(Long id) {
         return settlementRepository.findSettlementDtoById(id);
     }
     
     public List<SettlementDto> readAllSettlementDtoByTripId(Long tripId) {
         return settlementRepository.findAllSettlementDtoByTripId(tripId);
+    }
+    
+    public void deleteById(Long id) {
+        settlementRepository.deleteById(id);
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/api/SettlementApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/api/SettlementApi.java
@@ -307,4 +307,54 @@ public interface SettlementApi {
             @Parameter(description = "여행 ID")
             @PathVariable(name ="tripId") Long tripId
     );
+    
+    @TrackApi(description = "정산 내역 삭제")
+    @Operation(summary = "정산 내역 삭제", description = "정산 내역 삭제 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "정산 내역 삭제 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                            {
+                                                "code": 200,
+                                                "message": "요청이 성공하였습니다."
+                                            }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "정산 내역 삭제 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "여행 멤버가 아닌 경우", value = """
+                                             {
+                                                   "code": "T102",
+                                                   "message": "해당 여행의 멤버가 아닙니다."
+                                               }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "정산 내역 삭제 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "요청자가 정산 생성자가 아닌 경우", value = """
+                                             {
+                                                 "code": "S002",
+                                                 "message": "정산자가 아닙니다."
+                                             }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "정산 내역 삭제 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "정산 내역 미존재",value = """
+                                             {
+                                                  "code": "S001",
+                                                  "message": "존재하지 않는 정산 내역 입니다."
+                                              }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> deleteSettlement(
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            
+            @Parameter(description = "여행 ID")
+            @PathVariable(name = "tripId") Long tripId,
+            
+            @Parameter(description = "정산 내역 ID")
+            @PathVariable(name = "settlementId") Long settlementId
+    );
 }

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -56,5 +57,15 @@ public class SettlementController implements SettlementApi {
     ) {
         return ResponseEntity
                 .ok(SuccessResponse.from(settlementQueryService.getAllSettlement(tripId, userDetails.getUserId())));
+    }
+    
+    @DeleteMapping("/{tripId}/settlements/{settlementId}")
+    public ResponseEntity<?> deleteSettlement(
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            @PathVariable(name = "tripId") Long tripId,
+            @PathVariable(name = "settlementId") Long settlementId
+    ) {
+        settlementCommandService.deleteSettlement(tripId, userDetails.getUserId(), settlementId);
+        return ResponseEntity.ok(SuccessResponse.ok());
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
@@ -59,6 +59,7 @@ public class SettlementController implements SettlementApi {
                 .ok(SuccessResponse.from(settlementQueryService.getAllSettlement(tripId, userDetails.getUserId())));
     }
     
+    @Override
     @DeleteMapping("/{tripId}/settlements/{settlementId}")
     public ResponseEntity<?> deleteSettlement(
             @AuthenticationPrincipal CustomUserDetailsImpl userDetails,

--- a/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementCommandServiceTest.java
@@ -25,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -219,6 +220,75 @@ public class SettlementCommandServiceTest {
             
             // then
             assertEquals(SettlementErrorType.NOT_VALID_PRICE, exception.getErrorType());
+        }
+    }
+    
+    @Nested
+    @DisplayName("정산 내역 삭제")
+    class DeleteSettlement {
+        private final Long tripId = 1L;
+        private final Long userId = 1L;
+        private final Long settlementId = 1L;
+        
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            when(tripMemberService.existsByTripIdAndUserId(tripId, userId)).thenReturn(true);
+            when(settlementService.readPayerIdById(settlementId)).thenReturn(Optional.of(userId));
+            doNothing().when(payInfoService).deleteBySettlementId(settlementId);
+            doNothing().when(settlementService).deleteById(settlementId);
+            
+            // when
+            settlementCommandService.deleteSettlement(tripId, userId, settlementId);
+            
+            // then
+            verify(payInfoService, times(1)).deleteBySettlementId(settlementId);
+            verify(settlementService, times(1)).deleteById(settlementId);
+        }
+        
+        @Test
+        @DisplayName("실패 - 요청자가 여행 멤버가 아닐 경우")
+        void failIfNotMember() {
+            // given
+            when(tripMemberService.existsByTripIdAndUserId(tripId, userId)).thenReturn(false);
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> settlementCommandService.deleteSettlement(tripId, userId, settlementId));
+            
+            // then
+            assertEquals(TripMemberErrorType.IS_NOT_MEMBER, exception.getErrorType());
+        }
+        
+        @Test
+        @DisplayName("실패 - 정산 내역이 존재하지 않을 경우")
+        void failIfSettlementNotFound() {
+            // given
+            when(tripMemberService.existsByTripIdAndUserId(tripId, userId)).thenReturn(true);
+            when(settlementService.readPayerIdById(settlementId)).thenReturn(Optional.empty());
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> settlementCommandService.deleteSettlement(tripId, userId, settlementId));
+            
+            // then
+            assertEquals(SettlementErrorType.NOT_FOUND, exception.getErrorType());
+        }
+        
+        @Test
+        @DisplayName("실패 - 요청자가 정산 생성자가 아닌 경우")
+        void failIfIsNotPayer() {
+            // given
+            when(tripMemberService.existsByTripIdAndUserId(tripId, userId)).thenReturn(true);
+            when(settlementService.readPayerIdById(settlementId)).thenReturn(Optional.of(2L));
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> settlementCommandService.deleteSettlement(tripId, userId, settlementId));
+            
+            // then
+            assertEquals(SettlementErrorType.IS_NOT_PAYER, exception.getErrorType());
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/settlement/controller/SettlementControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/settlement/controller/SettlementControllerTest.java
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -423,6 +424,52 @@ public class SettlementControllerTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value(TripMemberErrorType.IS_NOT_MEMBER.getCode()))
                     .andExpect(jsonPath("$.message").value(TripMemberErrorType.IS_NOT_MEMBER.getMessage()));
+        }
+    }
+    
+    @Nested
+    @DisplayName("정산 내역 삭제")
+    class DeleteSettlement {
+        private final Long tripId = 1L;
+        private final Long settlementId = 1L;
+        
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            doNothing().when(settlementCommandService).deleteSettlement(tripId, userDetails.getUserId(), settlementId);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    delete("/api/v1/trip/{tripId}/settlements/{settlementsId}", tripId, settlementId)
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(SuccessResponse.ok().code()))
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
+        
+        @Test
+        @DisplayName("요청자가 정산 생성자가 아닌 경우")
+        void failIfIsNotPayer() throws Exception {
+            // given
+            doThrow(new CustomException(SettlementErrorType.IS_NOT_PAYER))
+                    .when(settlementCommandService).deleteSettlement(tripId, userDetails.getUserId(), settlementId);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    delete("/api/v1/trip/{tripId}/settlements/{settlementsId}", tripId, settlementId)
+                            .with(user(userDetails))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value(SettlementErrorType.IS_NOT_PAYER.getCode()))
+                    .andExpect(jsonPath("$.message").value(SettlementErrorType.IS_NOT_PAYER.getMessage()));
         }
     }
 }


### PR DESCRIPTION
## 배경
- 정산 내역 삭제 기능 필요

## 작업 사항
- 정산 내역 삭제 도메인 로직 구현 | (7c191552cd5054f2bd65628538069ffcdf3a3a20)
  - Spring-Data-JPA 네이밍 쿼리 메서드 이용 시 엔티티 조회 후 개별 삭제 처리 → `@Query` 어노테이션을 통한 조회 쿼리 제거 및 일괄 삭제 처리
- 정산 내역 삭제 로직 구현 | (86991cd752ce20145f8c603e62093839170718fc)
- 정산 내역 삭제 api 구현 | (bec8b974256967a4840c70dbf00ba88b737102fd)

## 추가 논의
- 현재 정산 내역 생성 시 생성자(`Figma화면: (나)라고 표시`)가 해당 정산 내역의 정산자이자 생성자로 해당 사용자의 PK가 `payerId`로 해당 정산 내역이 등록됩니다. 따라서, 해당 정산 내역의 생성자만 삭제가 가능하도록 처리해놓았습니다.