### PR TITLE
Feature(IL-343): 정산 내역 수정 로직 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
@@ -56,6 +56,7 @@ public class SettlementRequest {
                     .build();
         }
         
+        @Schema(hidden = true)
         public boolean isValidPrice() {
             return this.totalPrice == payers.stream()
                     .mapToLong(PayInfoDto::price)

--- a/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
@@ -44,7 +44,7 @@ public class SettlementRequest {
             @NotEmpty(message = "정산 인원은 최소 1명 이상이어야합니다.")
             List<PayInfoDto> payers
     ) {
-        public Settlement toEntity(Long tripId, Long payerId, boolean isCompleted) {
+        public Settlement toEntity(Long tripId, Long payerId) {
             return Settlement.builder()
                     .tripId(tripId)
                     .name(name)
@@ -52,7 +52,6 @@ public class SettlementRequest {
                     .date(date)
                     .type(type)
                     .payerId(payerId)
-                    .isCompleted(isCompleted)
                     .build();
         }
         
@@ -74,16 +73,12 @@ public class SettlementRequest {
             @Schema(description = "해당 인원의 정산 금액", example = "10000")
             @NotNull(message = "인원 별 정산 금액은 필수 입력값입니다.")
             @Min(value = 0, message = "최소 금액은 0원입니다.")
-            Long price,
-            
-            @Schema(description = "해당 인원의 정산 완료 여부", examples = {"true", "false"})
-            boolean isCompleted
+            Long price
     ) {
         public PayInfo toEntity(Long settlementId) {
             return PayInfo.builder()
                     .userId(userId)
                     .price(price)
-                    .isCompleted(isCompleted)
                     .settlementId(settlementId)
                     .build();
         }

--- a/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
@@ -55,6 +55,12 @@ public class SettlementRequest {
                     .isCompleted(isCompleted)
                     .build();
         }
+        
+        public boolean isValidPrice() {
+            return this.totalPrice == payers.stream()
+                    .mapToLong(PayInfoDto::price)
+                    .sum();
+        }
     }
    
     @Schema(name = "SettlementRequest.PayInfoDto", description = "인원 별 정산 금액 및 여부")

--- a/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementCommandService.java
@@ -16,7 +16,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -52,7 +54,7 @@ public class SettlementCommandService {
             throw new CustomException(TripMemberErrorType.EXISTS_NOT_MEMBER);
         }
         
-        if (!isValidPrice(payers, dto.totalPrice())) {
+        if (!dto.isValidPrice()) {
             throw new CustomException(SettlementErrorType.NOT_VALID_PRICE);
         }
         
@@ -85,21 +87,6 @@ public class SettlementCommandService {
     }
     
     /**
-     * 인원 별 정산 금액의 총합이 정산 내역의 총합과 일치하는지 여부를 반환하는 메서드
-     *
-     * @param payers        인원 당 정산 내역 목록
-     * @param totalPrice    정산 내역 총합
-     * @return              인원 별 정산 금액의 총합과 정산 내역의 총합이 일치하는지 여부
-     */
-    private boolean isValidPrice(List<SettlementRequest.PayInfoDto> payers, Long totalPrice) {
-        Long sum = payers.stream()
-                .mapToLong(SettlementRequest.PayInfoDto::price)
-                .sum();
-        
-        return sum.equals(totalPrice);
-    }
-    
-    /**
      * 인원 당 정산 내역 정보가 모두 정산이 완료되었는지 여부를 반환하는 메서드
      *
      * @param payers    인원 당 정산 내역 정보 리스트
@@ -108,6 +95,129 @@ public class SettlementCommandService {
     private boolean isAllCompleted(List<SettlementRequest.PayInfoDto> payers) {
         return payers.stream()
                 .allMatch(SettlementRequest.PayInfoDto::isCompleted);
+    }
+    
+    /**
+     * 정산 내역을 갱신하는 메서드
+     *
+     * @param tripId        여행 ID
+     * @param userId        사용자 ID
+     * @param settlementId  정산 내역 ID
+     * @param dto           정산 내역 갱신 요청 DTO
+     *
+     * @throws CustomException TripErrorType.TRIP_NOT_FOUND - 여행이 존재하지 않는 경우
+     * @throws CustomException SettlementErrorType.IS_NOT_PAYER - 해당 정산 내역의 작성자가 아닌 경우
+     * @throws CustomException TripMemberErrorType.EXISTS_NOT_MEMBER - 여행 멤버가 아닌 분담자가 존재하는 경우
+     * @throws CustomException SettlementErrorType.NOT_VALID_PRICE - 정산 내역 금액의 총합이 일치하지 않는 경우
+     */
+    @Transactional
+    public void updateSettlement(Long tripId, Long userId, Long settlementId, SettlementRequest.SettlementDto dto) {
+        List<User> members = tripMemberService.readAllUserByTripId(tripId);
+        
+        if (members.isEmpty()) {
+            throw new CustomException(TripErrorType.TRIP_NOT_FOUND);
+        }
+        
+        Settlement settlement = settlementService.readById(settlementId)
+                .orElseThrow(() -> new CustomException(SettlementErrorType.NOT_FOUND));
+        
+        if (!settlement.isPayer(userId)) {
+            throw new CustomException(SettlementErrorType.IS_NOT_PAYER);
+        }
+        
+        List<SettlementRequest.PayInfoDto> payers = dto.payers();
+        
+        if (!isAllTripMember(payers, members)) {
+            throw new CustomException(TripMemberErrorType.EXISTS_NOT_MEMBER);
+        }
+        
+        if (!dto.isValidPrice()) {
+            throw new CustomException(SettlementErrorType.NOT_VALID_PRICE);
+        }
+     
+        // TODO: Settlement - PayInfo 연관관계 설정 후 수정 예정
+        List<PayInfo> payInfos = payInfoService.readAllBySettlementId(settlementId);
+        
+        settlement.update(dto.name(), dto.totalPrice(), dto.date(), dto.type(), isAllCompleted(payers));
+        synchronizePayInfo(payInfos, payers, settlementId);
+    }
+    
+    /**
+     * 정산 내역 수정 시 인당 분담 내역({@code PayInfo}) 추가, 수정, 삭제를 처리하는 메서드
+     *
+     * @param oldPayInfos   기존의 인당 분담 내역 목록
+     * @param newPayInfos   수정할 인당 분담 내역 목록
+     * @param settlementId  정산 내역 ID
+     */
+    private void synchronizePayInfo(
+            List<PayInfo> oldPayInfos,
+            List<SettlementRequest.PayInfoDto> newPayInfos,
+            Long settlementId
+    ) {
+        Map<Long, SettlementRequest.PayInfoDto> newPayInfoMap = newPayInfos.stream()
+                .collect(Collectors.toMap(
+                        payInfoDto -> payInfoDto.userId(),
+                        Function.identity()
+                ));
+        
+        addPayInfo(oldPayInfos, newPayInfos, settlementId);
+        updatePayInfo(oldPayInfos, newPayInfoMap);
+        deletePayInfo(oldPayInfos, newPayInfoMap);
+    }
+    
+    /**
+     * 분담 내역 수정 후, 삭제할 분담 내역을 처리하는 메서드
+     *
+     * @param oldPayInfos   기존의 인당 분담 내역 목록
+     * @param newPayInfoMap 분담자 ID를 Key로 가지는 인당 분담 내역 Map
+     */
+    private void deletePayInfo(List<PayInfo> oldPayInfos, Map<Long, SettlementRequest.PayInfoDto> newPayInfoMap) {
+        List<Long> deletedPayInfoIds = oldPayInfos.stream()
+                .filter(payInfo -> !newPayInfoMap.containsKey(payInfo.getUserId()))
+                .map(PayInfo::getId)
+                .toList();
+        
+        if (!deletedPayInfoIds.isEmpty()) {
+            payInfoService.deleteByIds(deletedPayInfoIds);
+        }
+    }
+    
+    /**
+     * 분담 내역 수정 후, 갱신할 분담 내역을 처리하는 메서드
+     *
+     * @param oldPayInfos   기존의 인당 분담 내역 목록
+     * @param newPayInfoMap 분담자 ID를 Key로 가지는 인당 분담 내역 Map
+     */
+    private void updatePayInfo(List<PayInfo> oldPayInfos, Map<Long, SettlementRequest.PayInfoDto> newPayInfoMap) {
+        oldPayInfos.forEach(payInfo -> {
+            SettlementRequest.PayInfoDto payInfoDto = newPayInfoMap.get(payInfo.getUserId());
+            
+            if (payInfoDto != null) {
+                payInfo.update(payInfoDto.price(), payInfoDto.isCompleted());
+            }
+        });
+    }
+    
+    /**
+     * 분담 내역 수정 후, 추가할 분담 내역을 처리하는 메서드
+     *
+     * @param oldPayInfos   기존의 인당 분담 내역 목록
+     * @param newPayInfos   새로운 인당 분담 내역 목록
+     * @param settlementId  정산 내역 ID
+     */
+    private void addPayInfo(List<PayInfo> oldPayInfos, List<SettlementRequest.PayInfoDto> newPayInfos, Long settlementId) {
+        List<Long> oldPayers = oldPayInfos.stream()
+                .map(payInfo -> payInfo.getUserId())
+                .toList();
+        
+        List<PayInfo> addedPayInfos = newPayInfos.stream()
+                .filter(payInfoDto -> !oldPayers.contains(payInfoDto.userId()))
+                .map(payInfoDto -> payInfoDto.toEntity(settlementId))
+                .toList();
+        
+        if (!addedPayInfos.isEmpty()) {
+            payInfoService.saveAllInBatch(addedPayInfos);
+        }
     }
     
     /**

--- a/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementCommandService.java
@@ -59,7 +59,7 @@ public class SettlementCommandService {
         }
         
         
-        Settlement settlement = dto.toEntity(tripId, userId, isAllCompleted(payers));
+        Settlement settlement = dto.toEntity(tripId, userId);
         
         Long settlementId = settlementService.save(settlement);
         
@@ -84,17 +84,6 @@ public class SettlementCommandService {
         
         return payers.stream()
                 .allMatch(payer -> memberIds.contains(payer.userId()));
-    }
-    
-    /**
-     * 인원 당 정산 내역 정보가 모두 정산이 완료되었는지 여부를 반환하는 메서드
-     *
-     * @param payers    인원 당 정산 내역 정보 리스트
-     * @return          리스트 내 모든 정산 내역이 정산이 완료되었는지 여부
-     */
-    private boolean isAllCompleted(List<SettlementRequest.PayInfoDto> payers) {
-        return payers.stream()
-                .allMatch(SettlementRequest.PayInfoDto::isCompleted);
     }
     
     /**
@@ -138,7 +127,7 @@ public class SettlementCommandService {
         // TODO: Settlement - PayInfo 연관관계 설정 후 수정 예정
         List<PayInfo> payInfos = payInfoService.readAllBySettlementId(settlementId);
         
-        settlement.update(dto.name(), dto.totalPrice(), dto.date(), dto.type(), isAllCompleted(payers));
+        settlement.update(dto.name(), dto.totalPrice(), dto.date(), dto.type());
         synchronizePayInfo(payInfos, payers, settlementId);
     }
     
@@ -193,7 +182,7 @@ public class SettlementCommandService {
             SettlementRequest.PayInfoDto payInfoDto = newPayInfoMap.get(payInfo.getUserId());
             
             if (payInfoDto != null) {
-                payInfo.update(payInfoDto.price(), payInfoDto.isCompleted());
+                payInfo.update(payInfoDto.price());
             }
         });
     }

--- a/src/main/java/kr/co/yeogiga/domain/settlement/entity/PayInfo.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/entity/PayInfo.java
@@ -37,4 +37,9 @@ public class PayInfo {
         this.isCompleted = isCompleted;
         this.settlementId = settlementId;
     }
+    
+    public void update(Long price, boolean isCompleted) {
+        this.price = price;
+        this.isCompleted = isCompleted;
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/settlement/entity/PayInfo.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/entity/PayInfo.java
@@ -38,8 +38,7 @@ public class PayInfo {
         this.settlementId = settlementId;
     }
     
-    public void update(Long price, boolean isCompleted) {
+    public void update(Long price) {
         this.price = price;
-        this.isCompleted = isCompleted;
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/settlement/entity/Settlement.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/entity/Settlement.java
@@ -63,12 +63,11 @@ public class Settlement {
         this.isCompleted = isCompleted;
     }
     
-    public void update(String name, Long totalPrice, LocalDate date, SettlementType type, boolean isCompleted) {
+    public void update(String name, Long totalPrice, LocalDate date, SettlementType type) {
         this.name = name;
         this.totalPrice = totalPrice;
         this.date = date;
         this.type = type;
-        this.isCompleted = isCompleted;
     }
     
     public boolean isPayer(Long id) {

--- a/src/main/java/kr/co/yeogiga/domain/settlement/entity/Settlement.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/entity/Settlement.java
@@ -62,4 +62,16 @@ public class Settlement {
         this.payerId = payerId;
         this.isCompleted = isCompleted;
     }
+    
+    public void update(String name, Long totalPrice, LocalDate date, SettlementType type, boolean isCompleted) {
+        this.name = name;
+        this.totalPrice = totalPrice;
+        this.date = date;
+        this.type = type;
+        this.isCompleted = isCompleted;
+    }
+    
+    public boolean isPayer(Long id) {
+        return payerId.equals(id);
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/settlement/repository/PayInfoRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/repository/PayInfoRepository.java
@@ -6,8 +6,16 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface PayInfoRepository extends JpaRepository<PayInfo, Long>, CustomPayInfoRepository {
+    List<PayInfo> findAllBySettlementId(Long settlementId);
+    
     @Modifying
     @Query(value = "DELETE FROM pay_info WHERE settlement_id = :settlementId", nativeQuery = true)
     void deleteBySettlementId(@Param(value = "settlementId") Long settlementId);
+    
+    @Modifying
+    @Query(value = "DELETE FROM pay_info WHERE id in :ids")
+    void deleteByIds(@Param(value = "ids") List<Long> ids);
 }

--- a/src/main/java/kr/co/yeogiga/domain/settlement/service/PayInfoService.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/service/PayInfoService.java
@@ -12,11 +12,19 @@ import java.util.List;
 public class PayInfoService {
     private final PayInfoRepository payInfoRepository;
     
+    public List<PayInfo> readAllBySettlementId(Long settlementId) {
+        return payInfoRepository.findAllBySettlementId(settlementId);
+    }
+    
     public void saveAllInBatch(List<PayInfo> payInfos) {
         payInfoRepository.saveAllInBatch(payInfos);
     }
     
     public void deleteBySettlementId(Long settlementId) {
         payInfoRepository.deleteBySettlementId(settlementId);
+    }
+    
+    public void deleteByIds(List<Long> ids) {
+        payInfoRepository.deleteByIds(ids);
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/api/SettlementApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/api/SettlementApi.java
@@ -308,6 +308,80 @@ public interface SettlementApi {
             @PathVariable(name ="tripId") Long tripId
     );
     
+    @TrackApi(description = "정산 내역 수정")
+    @Operation(summary = "정산 내역 수정", description = "정산 내역 수정 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "정산 내역 수정 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                             {
+                                                     "code": 200,
+                                                     "message": "요청이 성공하였습니다."
+                                             }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "정산 내역 수정 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "유효성 검사 실패", value = """
+                                             {
+                                                  "code": "G002",
+                                                  "errors": {
+                                                      "payers[1].price": "최소 금액은 0원입니다.",
+                                                      "totalPrice": "최소 금액은 0원입니다.",
+                                                      "name": "이름은 필수 입력값입니다."
+                                                  }
+                                              }
+                                    """),
+                            @ExampleObject(name = "정산 내역 총합 금액 불일치", value = """
+                                             {
+                                                   "code": "S000",
+                                                   "message": "정산 내역 금액 총합이 일치하지 않습니다."
+                                             }
+                                    """),
+                            @ExampleObject(name = "여행 멤버가 아닌 정산자가 존재하는 경우", value = """
+                                             {
+                                                  "code": "T105",
+                                                  "message": "여행 멤버가 아닌 사용자가 존재합니다."
+                                             }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "정샌 내역 수정 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "요청자가 정산자가 아닌 경우",value = """
+                                             {
+                                                  "code": "S002",
+                                                  "message": "정산자가 아닙니다."
+                                              }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "정샌 내역 수정 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "존재하지 않는 여행",value = """
+                                             {
+                                                 "code": "T006",
+                                                 "message": "해당 여행이 존재하지 않습니다."
+                                             }
+                                    """),
+                            @ExampleObject(name = "존재하지 않는 정산 내역",value = """
+                                             {
+                                                  "code": "S001",
+                                                  "message": "존재하지 않는 정산 내역 입니다."
+                                              }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> updateSettlement(
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            
+            @Parameter(description = "여행 ID")
+            @PathVariable(name = "tripId") Long tripId,
+            
+            @Parameter(description = "정산 내역 ID")
+            @PathVariable(name = "settlementId") Long settlementId,
+            
+            @Valid @RequestBody SettlementRequest.SettlementDto settlement
+    );
+    
     @TrackApi(description = "정산 내역 삭제")
     @Operation(summary = "정산 내역 삭제", description = "정산 내역 삭제 API")
     @ApiResponses({

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
@@ -60,6 +60,7 @@ public class SettlementController implements SettlementApi {
                 .ok(SuccessResponse.from(settlementQueryService.getAllSettlement(tripId, userDetails.getUserId())));
     }
     
+    @Override
     @PutMapping("/{tripId}/settlements/{settlementId}")
     public ResponseEntity<?> updateSettlement(
             @AuthenticationPrincipal CustomUserDetailsImpl userDetails,

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
@@ -65,7 +65,7 @@ public class SettlementController implements SettlementApi {
             @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @PathVariable(name = "tripId") Long tripId,
             @PathVariable(name = "settlementId") Long settlementId,
-            @RequestBody SettlementRequest.SettlementDto settlement
+            @Valid @RequestBody SettlementRequest.SettlementDto settlement
     ) {
         settlementCommandService.updateSettlement(tripId, userDetails.getUserId(), settlementId, settlement);
         

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -53,10 +54,22 @@ public class SettlementController implements SettlementApi {
     @GetMapping("/{tripId}/settlements")
     public ResponseEntity<?> getAllSettlement(
             @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
-            @PathVariable(name ="tripId") Long tripId
+            @PathVariable(name = "tripId") Long tripId
     ) {
         return ResponseEntity
                 .ok(SuccessResponse.from(settlementQueryService.getAllSettlement(tripId, userDetails.getUserId())));
+    }
+    
+    @PutMapping("/{tripId}/settlements/{settlementId}")
+    public ResponseEntity<?> updateSettlement(
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            @PathVariable(name = "tripId") Long tripId,
+            @PathVariable(name = "settlementId") Long settlementId,
+            @RequestBody SettlementRequest.SettlementDto settlement
+    ) {
+        settlementCommandService.updateSettlement(tripId, userDetails.getUserId(), settlementId, settlement);
+        
+        return ResponseEntity.ok(SuccessResponse.ok());
     }
     
     @Override

--- a/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementCommandServiceTest.java
@@ -12,6 +12,7 @@ import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.exception.TripMemberErrorType;
 import kr.co.yeogiga.domain.trip.service.TripMemberService;
 import kr.co.yeogiga.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.util.Collections;
@@ -29,9 +31,11 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -289,6 +293,308 @@ public class SettlementCommandServiceTest {
             
             // then
             assertEquals(SettlementErrorType.IS_NOT_PAYER, exception.getErrorType());
+        }
+    }
+    
+    @Nested
+    @DisplayName("정산 내역 갱신")
+    class UpdateSettlement {
+        private final Long tripId = 1L;
+        private final Long userId = 1L;
+        private final Long settlementId = 1L;
+        
+        private Settlement settlement;
+        private PayInfo payInfo1;
+        private PayInfo payInfo2;
+        
+        private User member1;
+        private User member2;
+        private User member3;
+        
+        private SettlementRequest.SettlementDto settlementDto;
+        
+        @Captor
+        ArgumentCaptor<List<Long>> deletedPayInfoIds;
+        
+        @Captor
+        ArgumentCaptor<List<PayInfo>> addedPayInfos;
+        
+        @BeforeEach
+        void setUp() {
+            settlement = Settlement.builder()
+                    .tripId(tripId)
+                    .name("점심 식사")
+                    .totalPrice(50000L)
+                    .date(LocalDate.of(2025, 10, 6))
+                    .type(SettlementType.RESTAURANT)
+                    .payerId(userId)
+                    .isCompleted(false)
+                    .build();
+            
+            ReflectionTestUtils.setField(settlement, "id", settlementId);
+            
+            payInfo1 = PayInfo.builder()
+                    .userId(userId)
+                    .price(20000L)
+                    .isCompleted(true)
+                    .settlementId(settlement.getId())
+                    .build();
+            
+            payInfo2 = PayInfo.builder()
+                    .userId(2L)
+                    .price(30000L)
+                    .isCompleted(false)
+                    .settlementId(settlement.getId())
+                    .build();
+            
+            ReflectionTestUtils.setField(payInfo1, "id", 1L);
+            ReflectionTestUtils.setField(payInfo2, "id", 2L);
+            
+            member1 = User.builder()
+                    .id(userId)
+                    .nickname("nick1")
+                    .build();
+            
+            member2 = User.builder()
+                    .id(2L)
+                    .nickname("nick2")
+                    .build();
+            
+            member3 = User.builder()
+                    .id(3L)
+                    .nickname("nick3")
+                    .build();
+        }
+        
+        @Test
+        @DisplayName("성공 - 새로운 분담자 추가 및 기존 분담자 삭제")
+        void success() {
+            // given
+            when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(List.of(member1, member2, member3));
+            when(settlementService.readById(settlementId)).thenReturn(Optional.of(settlement));
+            when(payInfoService.readAllBySettlementId(settlementId)).thenReturn(List.of(payInfo1, payInfo2));
+            
+            List<SettlementRequest.PayInfoDto> payInfoDtos = List.of(
+                    SettlementRequest.PayInfoDto.builder()
+                            .userId(1L)
+                            .price(10000L)
+                            .isCompleted(true)
+                            .build(),
+                    SettlementRequest.PayInfoDto.builder()
+                            .userId(3L)
+                            .price(50000L)
+                            .isCompleted(true)
+                            .build()
+            );
+            
+            settlementDto = SettlementRequest.SettlementDto.builder()
+                    .name("점심 식사 - 2")
+                    .date(LocalDate.of(2025, 10, 6))
+                    .totalPrice(60000L)
+                    .type(SettlementType.RESTAURANT)
+                    .payers(payInfoDtos)
+                    .build();
+            
+            // when
+            settlementCommandService.updateSettlement(tripId, userId, settlementId, settlementDto);
+            
+            // then
+            assertEquals(settlementDto.name(), settlement.getName());
+            assertEquals(settlementDto.totalPrice(), settlement.getTotalPrice());
+            assertTrue(settlement.isCompleted());
+            
+            assertEquals(10000L, payInfo1.getPrice());
+            
+            verify(payInfoService, times(1)).deleteByIds(deletedPayInfoIds.capture());
+            verify(payInfoService, times(1)).saveAllInBatch(addedPayInfos.capture());
+            
+            assertEquals(payInfo2.getId(), deletedPayInfoIds.getValue().get(0));
+            PayInfo payInfo = addedPayInfos.getValue().get(0);
+            assertEquals(3L, payInfo.getUserId());
+            assertEquals(50000L, payInfo.getPrice());
+            assertTrue(payInfo.isCompleted());
+        }
+        
+        @Test
+        @DisplayName("성공 - 정산 내역만 수정된 경우")
+        void successIfOnlySettlementChanged() {
+            // given
+            when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(List.of(member1, member2, member3));
+            when(settlementService.readById(settlementId)).thenReturn(Optional.of(settlement));
+            when(payInfoService.readAllBySettlementId(settlementId)).thenReturn(List.of(payInfo1, payInfo2));
+            
+            List<SettlementRequest.PayInfoDto> payInfoDtos = List.of(
+                    SettlementRequest.PayInfoDto.builder()
+                            .userId(userId)
+                            .price(20000L)
+                            .isCompleted(true)
+                            .build(),
+                    SettlementRequest.PayInfoDto.builder()
+                            .userId(2L)
+                            .price(30000L)
+                            .isCompleted(false)
+                            .build()
+            );
+            
+            settlementDto = SettlementRequest.SettlementDto.builder()
+                    .name("점심 식사 - new")
+                    .date(LocalDate.of(2025, 10, 6))
+                    .totalPrice(50000L)
+                    .type(SettlementType.RESTAURANT)
+                    .payers(payInfoDtos)
+                    .build();
+            
+            // when
+            settlementCommandService.updateSettlement(tripId, userId, settlementId, settlementDto);
+            
+            // then
+            assertEquals(settlementDto.name(), settlement.getName());
+            
+            verify(payInfoService, never()).deleteByIds(anyList());
+            verify(payInfoService, never()).saveAllInBatch(anyList());
+        }
+        
+        @Test
+        @DisplayName("실패 - 여행이 존재하지 않는 경우")
+        void failIfTripNotFound() {
+            // given
+            when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(Collections.emptyList());
+            
+            List<SettlementRequest.PayInfoDto> payInfoDtos = List.of(
+                    SettlementRequest.PayInfoDto.builder()
+                            .userId(userId)
+                            .price(20000L)
+                            .isCompleted(true)
+                            .build(),
+                    SettlementRequest.PayInfoDto.builder()
+                            .userId(2L)
+                            .price(30000L)
+                            .isCompleted(false)
+                            .build()
+            );
+            
+            settlementDto = SettlementRequest.SettlementDto.builder()
+                    .name("점심 식사 - new")
+                    .date(LocalDate.of(2025, 10, 6))
+                    .totalPrice(50000L)
+                    .type(SettlementType.RESTAURANT)
+                    .payers(payInfoDtos)
+                    .build();
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> settlementCommandService.updateSettlement(tripId, userId, settlementId, settlementDto));
+        
+            // then
+            assertEquals(TripErrorType.TRIP_NOT_FOUND, exception.getErrorType());
+        }
+        
+        @Test
+        @DisplayName("실패 - 해당 정산 내역의 작성자가 아닌 경우")
+        void failIfNotPayer() {
+            // given
+            when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(List.of(member1, member2, member3));
+            when(settlementService.readById(settlementId)).thenReturn(Optional.of(settlement));
+            
+            List<SettlementRequest.PayInfoDto> payInfoDtos = List.of(
+                    SettlementRequest.PayInfoDto.builder()
+                            .userId(userId)
+                            .price(20000L)
+                            .isCompleted(true)
+                            .build(),
+                    SettlementRequest.PayInfoDto.builder()
+                            .userId(2L)
+                            .price(30000L)
+                            .isCompleted(false)
+                            .build()
+            );
+            
+            settlementDto = SettlementRequest.SettlementDto.builder()
+                    .name("점심 식사 - new")
+                    .date(LocalDate.of(2025, 10, 6))
+                    .totalPrice(50000L)
+                    .type(SettlementType.RESTAURANT)
+                    .payers(payInfoDtos)
+                    .build();
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> settlementCommandService.updateSettlement(tripId, 2L, settlementId, settlementDto));
+            
+            // then
+            assertEquals(SettlementErrorType.IS_NOT_PAYER, exception.getErrorType());
+        }
+        
+        @Test
+        @DisplayName("실패 - 여행 멤버가 아닌 분담자가 존재하는 경우")
+        void failIfExistsNotMember() {
+            // given
+            when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(List.of(member1, member2, member3));
+            when(settlementService.readById(settlementId)).thenReturn(Optional.of(settlement));
+            
+            List<SettlementRequest.PayInfoDto> payInfoDtos = List.of(
+                    SettlementRequest.PayInfoDto.builder()
+                            .userId(userId)
+                            .price(20000L)
+                            .isCompleted(true)
+                            .build(),
+                    SettlementRequest.PayInfoDto.builder()
+                            .userId(4L)
+                            .price(30000L)
+                            .isCompleted(false)
+                            .build()
+            );
+            
+            settlementDto = SettlementRequest.SettlementDto.builder()
+                    .name("점심 식사 - new")
+                    .date(LocalDate.of(2025, 10, 6))
+                    .totalPrice(50000L)
+                    .type(SettlementType.RESTAURANT)
+                    .payers(payInfoDtos)
+                    .build();
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> settlementCommandService.updateSettlement(tripId, userId, settlementId, settlementDto));
+            
+            // then
+            assertEquals(TripMemberErrorType.EXISTS_NOT_MEMBER, exception.getErrorType());
+        }
+        
+        @Test
+        @DisplayName("실패 - 정산 내역 금액의 총합이 일치하지 않는 경우")
+        void failIfNotValidPrice() {
+            // given
+            when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(List.of(member1, member2, member3));
+            when(settlementService.readById(settlementId)).thenReturn(Optional.of(settlement));
+            
+            List<SettlementRequest.PayInfoDto> payInfoDtos = List.of(
+                    SettlementRequest.PayInfoDto.builder()
+                            .userId(userId)
+                            .price(20000L)
+                            .isCompleted(true)
+                            .build(),
+                    SettlementRequest.PayInfoDto.builder()
+                            .userId(2L)
+                            .price(40000L)
+                            .isCompleted(false)
+                            .build()
+            );
+            
+            settlementDto = SettlementRequest.SettlementDto.builder()
+                    .name("점심 식사 - new")
+                    .date(LocalDate.of(2025, 10, 6))
+                    .totalPrice(50000L)
+                    .type(SettlementType.RESTAURANT)
+                    .payers(payInfoDtos)
+                    .build();
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> settlementCommandService.updateSettlement(tripId, userId, settlementId, settlementDto));
+            
+            // then
+            assertEquals(SettlementErrorType.NOT_VALID_PRICE, exception.getErrorType());
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementCommandServiceTest.java
@@ -74,12 +74,10 @@ public class SettlementCommandServiceTest {
                         SettlementRequest.PayInfoDto.builder()
                                 .userId(1L)
                                 .price(10000L)
-                                .isCompleted(true)
                                 .build(),
                         SettlementRequest.PayInfoDto.builder()
                                 .userId(2L)
                                 .price(40000L)
-                                .isCompleted(false)
                                 .build()
                 ))
                 .build();
@@ -122,12 +120,10 @@ public class SettlementCommandServiceTest {
                             SettlementRequest.PayInfoDto.builder()
                                     .userId(1L)
                                     .price(10000L)
-                                    .isCompleted(true)
                                     .build(),
                             SettlementRequest.PayInfoDto.builder()
                                     .userId(2L)
                                     .price(40000L)
-                                    .isCompleted(true)
                                     .build()
                     ))
                     .build();
@@ -142,8 +138,6 @@ public class SettlementCommandServiceTest {
             // then
             verify(settlementService, times(1)).save(settlementCaptor.capture());
             verify(payInfoService, times(1)).saveAllInBatch(anyList());
-            
-            assertEquals(true, settlementCaptor.getValue().isCompleted());
         }
         
         @Test
@@ -173,12 +167,10 @@ public class SettlementCommandServiceTest {
                             SettlementRequest.PayInfoDto.builder()
                                     .userId(1L)
                                     .price(10000L)
-                                    .isCompleted(true)
                                     .build(),
                             SettlementRequest.PayInfoDto.builder()
                                     .userId(3L)
                                     .price(40000L)
-                                    .isCompleted(false)
                                     .build()
                     ))
                     .build();
@@ -206,12 +198,10 @@ public class SettlementCommandServiceTest {
                             SettlementRequest.PayInfoDto.builder()
                                     .userId(1L)
                                     .price(10000L)
-                                    .isCompleted(true)
                                     .build(),
                             SettlementRequest.PayInfoDto.builder()
                                     .userId(2L)
                                     .price(20000L)
-                                    .isCompleted(false)
                                     .build()
                     ))
                     .build();
@@ -378,12 +368,10 @@ public class SettlementCommandServiceTest {
                     SettlementRequest.PayInfoDto.builder()
                             .userId(1L)
                             .price(10000L)
-                            .isCompleted(true)
                             .build(),
                     SettlementRequest.PayInfoDto.builder()
                             .userId(3L)
                             .price(50000L)
-                            .isCompleted(true)
                             .build()
             );
             
@@ -401,7 +389,6 @@ public class SettlementCommandServiceTest {
             // then
             assertEquals(settlementDto.name(), settlement.getName());
             assertEquals(settlementDto.totalPrice(), settlement.getTotalPrice());
-            assertTrue(settlement.isCompleted());
             
             assertEquals(10000L, payInfo1.getPrice());
             
@@ -412,7 +399,6 @@ public class SettlementCommandServiceTest {
             PayInfo payInfo = addedPayInfos.getValue().get(0);
             assertEquals(3L, payInfo.getUserId());
             assertEquals(50000L, payInfo.getPrice());
-            assertTrue(payInfo.isCompleted());
         }
         
         @Test
@@ -427,12 +413,10 @@ public class SettlementCommandServiceTest {
                     SettlementRequest.PayInfoDto.builder()
                             .userId(userId)
                             .price(20000L)
-                            .isCompleted(true)
                             .build(),
                     SettlementRequest.PayInfoDto.builder()
                             .userId(2L)
                             .price(30000L)
-                            .isCompleted(false)
                             .build()
             );
             
@@ -464,12 +448,10 @@ public class SettlementCommandServiceTest {
                     SettlementRequest.PayInfoDto.builder()
                             .userId(userId)
                             .price(20000L)
-                            .isCompleted(true)
                             .build(),
                     SettlementRequest.PayInfoDto.builder()
                             .userId(2L)
                             .price(30000L)
-                            .isCompleted(false)
                             .build()
             );
             
@@ -500,12 +482,10 @@ public class SettlementCommandServiceTest {
                     SettlementRequest.PayInfoDto.builder()
                             .userId(userId)
                             .price(20000L)
-                            .isCompleted(true)
                             .build(),
                     SettlementRequest.PayInfoDto.builder()
                             .userId(2L)
                             .price(30000L)
-                            .isCompleted(false)
                             .build()
             );
             
@@ -536,12 +516,10 @@ public class SettlementCommandServiceTest {
                     SettlementRequest.PayInfoDto.builder()
                             .userId(userId)
                             .price(20000L)
-                            .isCompleted(true)
                             .build(),
                     SettlementRequest.PayInfoDto.builder()
                             .userId(4L)
                             .price(30000L)
-                            .isCompleted(false)
                             .build()
             );
             
@@ -572,12 +550,10 @@ public class SettlementCommandServiceTest {
                     SettlementRequest.PayInfoDto.builder()
                             .userId(userId)
                             .price(20000L)
-                            .isCompleted(true)
                             .build(),
                     SettlementRequest.PayInfoDto.builder()
                             .userId(2L)
                             .price(40000L)
-                            .isCompleted(false)
                             .build()
             );
             

--- a/src/test/java/kr/co/yeogiga/presentation/settlement/controller/SettlementControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/settlement/controller/SettlementControllerTest.java
@@ -111,12 +111,10 @@ public class SettlementControllerTest {
                         SettlementRequest.PayInfoDto.builder()
                                 .userId(1L)
                                 .price(10000L)
-                                .isCompleted(true)
                                 .build(),
                         SettlementRequest.PayInfoDto.builder()
                                 .userId(2L)
                                 .price(40000L)
-                                .isCompleted(false)
                                 .build()
                 ))
                 .build();
@@ -154,12 +152,10 @@ public class SettlementControllerTest {
                             SettlementRequest.PayInfoDto.builder()
                                     .userId(1L)
                                     .price(-2L)
-                                    .isCompleted(true)
                                     .build(),
                             SettlementRequest.PayInfoDto.builder()
                                     .userId(2L)
                                     .price(40000L)
-                                    .isCompleted(false)
                                     .build()
                     ))
                     .build();
@@ -238,12 +234,10 @@ public class SettlementControllerTest {
                             SettlementRequest.PayInfoDto.builder()
                                     .userId(1L)
                                     .price(10000L)
-                                    .isCompleted(true)
                                     .build(),
                             SettlementRequest.PayInfoDto.builder()
                                     .userId(2L)
                                     .price(20000L)
-                                    .isCompleted(false)
                                     .build()
                     ))
                     .build();
@@ -489,12 +483,10 @@ public class SettlementControllerTest {
                     SettlementRequest.PayInfoDto.builder()
                             .userId(userDetails.getUserId())
                             .price(20000L)
-                            .isCompleted(true)
                             .build(),
                     SettlementRequest.PayInfoDto.builder()
                             .userId(2L)
                             .price(30000L)
-                            .isCompleted(false)
                             .build()
             );
             

--- a/src/test/java/kr/co/yeogiga/presentation/settlement/controller/SettlementControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/settlement/controller/SettlementControllerTest.java
@@ -35,6 +35,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +49,7 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -470,6 +472,90 @@ public class SettlementControllerTest {
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.code").value(SettlementErrorType.IS_NOT_PAYER.getCode()))
                     .andExpect(jsonPath("$.message").value(SettlementErrorType.IS_NOT_PAYER.getMessage()));
+        }
+    }
+    
+    @Nested
+    @DisplayName("정산 내역 수정")
+    class UpdateSettlement {
+        private final Long tripId = 1L;
+        private final Long settlementId = 1L;
+        
+        private SettlementRequest.SettlementDto settlementDto;
+        
+        @BeforeEach
+        void setUp() {
+            List<SettlementRequest.PayInfoDto> payInfoDtos = List.of(
+                    SettlementRequest.PayInfoDto.builder()
+                            .userId(userDetails.getUserId())
+                            .price(20000L)
+                            .isCompleted(true)
+                            .build(),
+                    SettlementRequest.PayInfoDto.builder()
+                            .userId(2L)
+                            .price(30000L)
+                            .isCompleted(false)
+                            .build()
+            );
+            
+            settlementDto = SettlementRequest.SettlementDto.builder()
+                    .name("점심 식사 - new")
+                    .date(LocalDate.of(2025, 10, 6))
+                    .totalPrice(50000L)
+                    .type(SettlementType.RESTAURANT)
+                    .payers(payInfoDtos)
+                    .build();
+        }
+        
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            doNothing().when(settlementCommandService)
+                    .updateSettlement(tripId, userDetails.getUserId(), settlementId, settlementDto);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    put("/api/v1/trip/{tripId}/settlements/{settlementId}", tripId, settlementId)
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsBytes(settlementDto))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
+        
+        @Test
+        @DisplayName("실패 - 유효성 검증 실패")
+        void failValidation() throws Exception {
+            // given
+            doNothing().when(settlementCommandService)
+                    .updateSettlement(tripId, userDetails.getUserId(), settlementId, settlementDto);
+            
+            SettlementRequest.SettlementDto settlementDto = SettlementRequest.SettlementDto.builder()
+                    .name("  ")
+                    .totalPrice(-1L)
+                    .date(LocalDate.of(2025, 10, 7))
+                    .type(SettlementType.RESTAURANT)
+                    .payers(Collections.emptyList())
+                    .build();
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    put("/api/v1/trip/{tripId}/settlements/{settlementId}", tripId, settlementId)
+                            .with(user(userDetails))
+                            .content(objectMapper.writeValueAsBytes(settlementDto))
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors.name").exists())
+                    .andExpect(jsonPath("$.errors.totalPrice").exists());
         }
     }
 }


### PR DESCRIPTION
## 배경
- 정산 내역 수정 기능 요구

## 작업 사항
- 정산 내역 수정 관련 도메인 로직 추가 | (9ca277f251a9738084d417894c371180727cf24e)
  - 정산 내역(Settlement), 분담 내역(PayInfo) 엔티티 내 갱신 메서드( `.update()` ) 추가 
- 정산 내역 수정 로직 구현 | (64abfa5486fbf6270633690bdac527074d4022cf)
- 정산 내역 수정 api 구현 | (13f23f766aa967f68e87fb92ca7234ba96de1df3)

## 추가 논의
#### 1. Settlement - PayInfo 연관 관계 설정 예정
&nbsp; 현재 분담 내역(PayInfo)를 갱신하는 과정에서, 기존에 존재하는 분담 내역(사용자 ID 기준 원래 존재하는 엔티티)은 JPA 더티체킹을 기반으로해서 업데이트가 되도록 구현하였습니다. 

&nbsp; 이 과정에서 Settlement - PayInfo를 각각 엔티티 형태로 가져와야 영속성 컨텍스트로 관리가 되기 때문에 현재는 각각을 조회하기 위한 조회 쿼리가 발생하기 때문에 총 2번의 조회 쿼리가 나갑니다. 따라서, 예전에 대영님께서 말씀해주신 것처럼 Settlement - PayInfo 사이에 연관 관계 설정 후 fetch join으로 엔티티를 조회하는 것이 더 좋을 것 같아 이후 PR에서 수정하도록 하겠습니다.

#### 2. PayInfoRepository.deleteByIds(List\<Long\>) 메서드 @Modifying 설정
```java
// PayInfoRepository
@Modifying
@Query(value = "DELETE FROM pay_info WHERE id in :ids")
void deleteByIds(@Param(value = "ids") List<Long> ids);
```
&nbsp; 정산 내역을 수정하는 과정에서 분담 내역(PayInfo)를 추가, 수정, 삭제하게 됩니다. 정산 내역 수정 로직 내에서 분담 내역 삭제 로직을 제일 마지막에 실행하도록 하여  영속성 컨텍스트 내 추가/수정된 PayInfo 엔티티를 삭제해야하는 등의 일이 없기 때문에 `@Modifying` 어노테이션 내 `clearAutomatically`, `flushAutomatically` 설정을 따로 진행하지 않았습니다.