### PR TITLE
Feature(IL-360): 일차별 이미지 조회 로직 추가 (이미지 전체 조회 임시 로직)

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageQueryServiceLegacy.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageQueryServiceLegacy.java
@@ -21,6 +21,20 @@ public class TripPlaceImageQueryServiceLegacy {
     private final TripDayPlaceService tripDayPlaceService;
 
     /**
+     * ## 임시 처리 로직
+     * <p>
+     * 특정 TripDayPlace 내에서 일차(day)별 이미지 조회 메섣,
+     *
+     * @param tripId 여행 ID
+     * @param day    일차
+     * @return 여행 일차에 대한 이미지 반환
+     */
+    public List<TripPlaceImageRes.ImageDto> getTripDayImageInfo(Long tripId, int day) {
+        return tripDayPlaceService.readAllImagesByTripIdAndDay(tripId, day)
+                .stream().map(TripPlaceImageRes.ImageDto::from).toList();
+    }
+
+    /**
      * 특정 TripDayPlace 내에서 지정된 Place의 정보와 해당 장소에 속한 이미지 목록을 조회 메서드
      *
      * @param tripDayPlaceId TripDayPlace(여행 일차) ID

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
@@ -14,6 +14,7 @@ public interface CustomTripDayPlaceRepository {
     Double findMaxOrderById(String id);
     Optional<TripDayPlace> findByIdSorted(String id);
     List<TripDayPlace> findByTripIdSorted(Long tripId);
+    List<Image> findAllImagesByTripIdAndDay(Long tripId, int day);
     Optional<Place> findPlaceByIdAndPlaceId(String id, String placeId);
     List<Image> findUnmatchedImagesById(String id);
     List<TripDayPlace> findTripDayPlaceSummariesByTripId(Long tripId);

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
@@ -14,6 +14,8 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -120,6 +122,33 @@ public class CustomTripDayPlaceRepositoryImpl implements CustomTripDayPlaceRepos
                 mongoTemplate.aggregate(aggregation, "trip_day_place", TripDayPlace.class);
 
         return results.getMappedResults();
+    }
+
+    @Override
+    public List<Image> findAllImagesByTripIdAndDay(Long tripId, int day) {
+        Criteria criteria = Criteria.where("tripId").is(tripId)
+                .and("day").is(day);
+
+        Query query = new Query(criteria);
+        query.fields().include("unmatchedImages").include("places.images");
+
+        TripDayPlace doc = mongoTemplate.findOne(query, TripDayPlace.class);
+        if (doc == null) return Collections.emptyList();
+
+        List<Image> images = new ArrayList<>();
+
+        if (doc.getUnmatchedImages() != null) {
+            images.addAll(doc.getUnmatchedImages());
+        }
+
+        if (doc.getPlaces() != null) {
+            for (Place p : doc.getPlaces()) {
+                if (p.getImages() != null) {
+                    images.addAll(p.getImages());
+                }
+            }
+        }
+        return images;
     }
 
     @Override

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
@@ -137,17 +137,12 @@ public class CustomTripDayPlaceRepositoryImpl implements CustomTripDayPlaceRepos
 
         List<Image> images = new ArrayList<>();
 
-        if (doc.getUnmatchedImages() != null) {
-            images.addAll(doc.getUnmatchedImages());
+        images.addAll(doc.getUnmatchedImages());
+
+        for (Place p : doc.getPlaces()) {
+            images.addAll(p.getImages());
         }
 
-        if (doc.getPlaces() != null) {
-            for (Place p : doc.getPlaces()) {
-                if (p.getImages() != null) {
-                    images.addAll(p.getImages());
-                }
-            }
-        }
         return images;
     }
 

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
@@ -51,6 +51,10 @@ public class TripDayPlaceService {
         return tripDayPlaceRepository.findMaxOrderById(id);
     }
 
+    public List<Image> readAllImagesByTripIdAndDay(Long tripId, int day) {
+        return tripDayPlaceRepository.findAllImagesByTripIdAndDay(tripId, day);
+    }
+
     public Optional<Place> readPlaceByIdAndPlaceId(String id, String placeId) {
         return tripDayPlaceRepository.findPlaceByIdAndPlaceId(id, placeId);
     }

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/api/TripPlaceImageApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/api/TripPlaceImageApi.java
@@ -20,6 +20,45 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "[이미지 매칭 후 이미지 API]", description = "이미지 매칭 후 이미지 관련 API")
 public interface TripPlaceImageApi {
 
+    @TrackApi(description = "여행 일차별 이미지 조회 (임시 처리 REST API)")
+    @Operation(summary = "여행 일차별 이미지 조회 (임시 처리 REST API)", description = "여행 일차별 이미지 조회하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "일차에 맞는 이미지 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": [
+                                                {
+                                                    "id": "image1-id",
+                                                    "url": "https://image1.com",
+                                                    "latitude": 11.11,
+                                                    "longitude": 22.22,
+                                                    "date": "2025-04-13T21:53:57.445",
+                                                    "favorite": true
+                                                },
+                                                {
+                                                    "id": "image2-id",
+                                                    "url": "https://image2.com",
+                                                    "latitude": 33.33,
+                                                    "longitude": 44.44,
+                                                    "date": "2025-04-13T21:53:57.445",
+                                                    "favorite": false
+                                                }
+                                            ]
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getTripDayImageInfo(
+            @Parameter(description = "여행 ID")
+            @PathVariable Long tripId,
+
+            @Parameter(description = "여행 일차")
+            @PathVariable int day
+    );
+
     @TrackApi(description = "일차별 목적지에 매칭되어 있는 이미지 조회")
     @Operation(summary = "일차별 목적지에 매칭되어 있는 이미지 조회", description = "일차별 목적지에 매칭되어 있는 이미지 조회하는 API입니다.")
     @ApiResponses({

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
@@ -28,6 +28,18 @@ public class TripPlaceImageController implements TripPlaceImageApi {
     private final TripPlaceImageQueryServiceLegacy tripPlaceImageQueryServiceLegacy;
     private final TripPlaceImageReassignmentServiceLegacy tripPlaceImageReassignmentServiceLegacy;
 
+    @GetMapping("/{tripId}/day-place/images/day/{day}")
+    public ResponseEntity<?> getTripDayImageInfo(
+            @PathVariable Long tripId,
+            @PathVariable int day
+    ) {
+        return ResponseEntity.ok(
+                SuccessResponse.from(
+                        tripPlaceImageQueryServiceLegacy.getTripDayImageInfo(tripId, day)
+                )
+        );
+    }
+
     @Override
     @GetMapping("/{tripId}/day-place/{tripDayPlaceId}/places/{placeId}/images")
     public ResponseEntity<?> getPlaceInfo(

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
@@ -28,6 +28,7 @@ public class TripPlaceImageController implements TripPlaceImageApi {
     private final TripPlaceImageQueryServiceLegacy tripPlaceImageQueryServiceLegacy;
     private final TripPlaceImageReassignmentServiceLegacy tripPlaceImageReassignmentServiceLegacy;
 
+    @Override
     @GetMapping("/{tripId}/day-place/images/day/{day}")
     public ResponseEntity<?> getTripDayImageInfo(
             @PathVariable Long tripId,

--- a/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageQueryServiceLegacyTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageQueryServiceLegacyTest.java
@@ -3,11 +3,11 @@ package kr.co.yeogiga.application.tripplace.image.service;
 import kr.co.yeogiga.application.tripplace.image.dto.FavoriteImageRes;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageRes;
 import kr.co.yeogiga.common.exception.CustomException;
-import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.placeimage.entity.Image;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
+import kr.co.yeogiga.domain.trip.type.PlaceCategory;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
-import kr.co.yeogiga.domain.trip.type.PlaceCategory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -53,6 +53,25 @@ public class TripPlaceImageQueryServiceLegacyTest {
             .placeType(PlaceCategory.RESTAURANT)
             .order(10.0)
             .build();
+
+    @Test
+    @DisplayName("여행 일차에 대한 이미지 조회 테스트")
+    void getTripDayImageInfoTest() {
+        // given
+        List<Image> images = List.of(image);
+        Long tripId = 1L;
+        int day = 1;
+
+        when(tripDayPlaceService.readAllImagesByTripIdAndDay(tripId, day))
+                .thenReturn(images);
+
+        // when
+        List<TripPlaceImageRes.ImageDto> result =
+                tripPlaceImageQueryServiceLegacy.getTripDayImageInfo(tripId, day);
+
+        // then
+        assertThat(result).hasSize(1);
+    }
 
     @Nested
     @DisplayName("특정 여행 일차 및 목적지의 이미지 목록 조회 테스트")

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
@@ -84,6 +84,38 @@ public class TripPlaceImageControllerTest {
                 .build();
     }
 
+    @Test
+    @DisplayName("여행 일차 이미지 조회 테스트")
+    void getTripDayImageInfoTest() throws Exception {
+        // given
+        TripPlaceImageRes.ImageDto image1 = TripPlaceImageRes.ImageDto.builder()
+                .url("https://image1.com")
+                .build();
+
+        TripPlaceImageRes.ImageDto image2 = TripPlaceImageRes.ImageDto.builder()
+                .url("https://image2.com")
+                .build();
+
+        List<TripPlaceImageRes.ImageDto> imageDtos = List.of(image1, image2);
+        int day = 1;
+
+        when(tripPlaceImageQueryServiceLegacy.getTripDayImageInfo(tripId, day))
+                .thenReturn(imageDtos);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/trip/{tripId}/day-place/images/day/{day}", tripId, day)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."))
+                .andExpect(jsonPath("$.data", hasSize(2)));
+    }
+
     @Nested
     @DisplayName("이미지 조회 테스트")
     class GetImageInfoTest {


### PR DESCRIPTION
## 배경
이미지 전체 조회가 필요.
전체 이미지를 조회하면, 이미지 처리 크기 때문에 속도 저하 문제 → 일차별로 이미지 조회 로직 구현

** 현재 이미지 페이징 처리 조회가 어려운 구조 + 현재는 일차별로 이미지가 적은 상태 = 일차별로 이미지 조회
추후에 이미지 저장 구조를 개선한 후, 페이징 처리로 변경 예정

## 작업 사항
- 여행 일차별 이미지 조회 로직 구현 (c1ed729a847074972e86fe0638dd36e1895a392b)
- 여행 일차별 이미지 조회 rest api 연결(9732682f404fe198891a315be20d80f4516fb835)

## 추가 논의
위 배경에서 말한 것처럼 이후 이미지 구조를 개선한 후 `전체 이미지 조회 페이징 처리`할 예정입니다!