### PR TITLE
Feature(IL-356): 정산 완료 여부 갱신 로직 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
@@ -64,7 +64,7 @@ public class SettlementRequest {
         }
     }
     
-    @Schema(name = "SettlementRequest.PayInfoDto", description = "인원 별 정산 금액 및 여부")
+    @Schema(name = "SettlementRequest.PayInfoDto", description = "인원 별 정산 금액 및 여부 DTO")
     @Builder
     public record PayInfoDto(
             @Schema(description = "사용자 ID", example = "1")
@@ -85,14 +85,23 @@ public class SettlementRequest {
         }
     }
     
+    @Schema(name = "SettlementRequest.PayInfoCompletionListDto", description = "분담 내역 완료 여부 리스트 DTO")
     public record PayInfoCompletionListDto(
+        @Schema(
+                description = "분담 내역 완료 여부 리스트",
+                example = "[{\"payInfoId\": 1, \"isCompleted\": true}, {\"payInfoId\": 2, \"isCompleted\": false}]"
+        )
         @Size(min = 1, message = "정산 완료 목록은 최소 1개 이상이어야 합니다.")
         List<PayInfoCompletionDto> payInfos
     ) { }
     
+    @Schema(name = "SettlementRequest.PayInfoCompletionDto", description = "분담 내역 완료 여부 DTO")
     public record PayInfoCompletionDto(
+            @Schema(description = "분담 내역 ID", examples = "1")
             @NotNull(message = "분담자 id는 필수 입력값입니다.")
             Long payInfoId,
+            
+            @Schema(description = "정산 완료 여부", examples = "true")
             boolean isCompleted
     ) { }
 }

--- a/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import kr.co.yeogiga.common.validation.EnumValidation;
 import kr.co.yeogiga.domain.settlement.entity.PayInfo;
 import kr.co.yeogiga.domain.settlement.entity.Settlement;
@@ -19,7 +20,7 @@ public class SettlementRequest {
     
     @Schema(name = "SettlementRequest.SettlementDto", description = "정산 내역 생성 요청 DTO")
     @Builder
-    public record SettlementDto (
+    public record SettlementDto(
             @Schema(description = "정산 내역 이름", example = "점심 식사")
             @NotBlank(message = "이름은 필수 입력값입니다.")
             String name,
@@ -62,10 +63,10 @@ public class SettlementRequest {
                     .sum();
         }
     }
-   
+    
     @Schema(name = "SettlementRequest.PayInfoDto", description = "인원 별 정산 금액 및 여부")
     @Builder
-    public record PayInfoDto (
+    public record PayInfoDto(
             @Schema(description = "사용자 ID", example = "1")
             @NotNull(message = "사용자 id는 필수 입력값입니다.")
             Long userId,
@@ -83,4 +84,15 @@ public class SettlementRequest {
                     .build();
         }
     }
+    
+    public record PayInfoCompletionListDto(
+        @Size(min = 1, message = "정산 완료 목록은 최소 1개 이상이어야 합니다.")
+        List<PayInfoCompletionDto> payInfos
+    ) { }
+    
+    public record PayInfoCompletionDto(
+            @NotNull(message = "분담자 id는 필수 입력값입니다.")
+            Long payInfoId,
+            boolean isCompleted
+    ) { }
 }

--- a/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementCommandService.java
@@ -210,6 +210,60 @@ public class SettlementCommandService {
     }
     
     /**
+     * 정산 여부를 갱신하는 메서드
+     *
+     * <p> 모든 분담 내역이 정산 완료된 경우, 해당 분담 내역을 포함하는 정산 내역도 정산 완료 처리
+     *
+     * @param settlementId  정산 내역 ID
+     * @param userId        사용자 ID
+     * @param dtos          정산 여부 갱신 DTO 리스트
+     *
+     * @throws CustomException SettlementErrorType.NOT_FOUND - 정산 내역이 존재하지 않는 경우
+     * @throws CustomException SettlementErrorType.IS_NOT_PAYER - 요청자가 정산 내역의 생성자가 아닌 경우
+     * @throws CustomException SettlementErrorTYpe.PAY_INFO_NOT_FOUND - 분담 내역이 존재하지 않는 경우
+     */
+    @Transactional
+    public void completeSettlement(Long settlementId, Long userId, List<SettlementRequest.PayInfoCompletionDto> dtos) {
+        Settlement settlement = settlementService.readById(settlementId)
+                .orElseThrow(() -> new CustomException(SettlementErrorType.NOT_FOUND));
+        
+        if (!settlement.isPayer(userId)) {
+            throw new CustomException(SettlementErrorType.IS_NOT_PAYER);
+        }
+        
+        List<PayInfo> payInfos = payInfoService.readAllBySettlementId(settlementId);
+        Map<Long, PayInfo> payInfoMap = payInfos.stream()
+                .collect(Collectors.toMap(
+                        payInfo -> payInfo.getId(),
+                        Function.identity()
+                ));
+        
+        boolean isAllCompleted = true;
+        
+        for (SettlementRequest.PayInfoCompletionDto dto : dtos) {
+            PayInfo payInfo = payInfoMap.get(dto.payInfoId());
+            
+            if (payInfo == null) {
+                throw new CustomException(SettlementErrorType.PAY_INFO_NOT_FOUND);
+            }
+            
+            if (dto.isCompleted()) {
+                payInfo.complete();
+            } else {
+                payInfo.uncomplete();
+            }
+            
+            isAllCompleted = isAllCompleted && dto.isCompleted();
+        }
+        
+        if (isAllCompleted) {
+            settlement.complete();
+        } else {
+            settlement.uncomplete();
+        }
+    }
+    
+    /**
      * 정산 내역을 삭제하는 메서드
      *
      * @param tripId        여행 ID

--- a/src/main/java/kr/co/yeogiga/domain/settlement/entity/PayInfo.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/entity/PayInfo.java
@@ -41,4 +41,12 @@ public class PayInfo {
     public void update(Long price) {
         this.price = price;
     }
+    
+    public void complete() {
+        this.isCompleted = true;
+    }
+    
+    public void uncomplete() {
+        this.isCompleted = false;
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/settlement/entity/Settlement.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/entity/Settlement.java
@@ -73,4 +73,12 @@ public class Settlement {
     public boolean isPayer(Long id) {
         return payerId.equals(id);
     }
+    
+    public void complete() {
+        this.isCompleted = true;
+    }
+    
+    public void uncomplete() {
+        this.isCompleted = false;
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/settlement/exception/SettlementErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/exception/SettlementErrorType.java
@@ -11,7 +11,8 @@ import org.springframework.http.HttpStatus;
 public enum SettlementErrorType implements BaseErrorType {
     NOT_VALID_PRICE(HttpStatus.BAD_REQUEST, "S000", "정산 내역 금액 총합이 일치하지 않습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "존재하지 않는 정산 내역 입니다."),
-    IS_NOT_PAYER(HttpStatus.FORBIDDEN, "S002", "정산자가 아닙니다.");
+    IS_NOT_PAYER(HttpStatus.FORBIDDEN, "S002", "정산자가 아닙니다."),
+    PAY_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "S003", "존재하지 않는 분담 내역입니다.");
     
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/api/SettlementApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/api/SettlementApi.java
@@ -382,6 +382,62 @@ public interface SettlementApi {
             @Valid @RequestBody SettlementRequest.SettlementDto settlement
     );
     
+    @TrackApi(description = "정산 완료 여부 갱신")
+    @Operation(summary = "정산 완료 여부 갱신", description = "정산 완료 여부 갱신 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "정산 완료 여부 갱신 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                             {
+                                                     "code": 200,
+                                                     "message": "요청이 성공하였습니다."
+                                             }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "정산 완료 여부 갱신 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "유효성 검사 실패", value = """
+                                             {
+                                                 "code": "G002",
+                                                 "errors": {
+                                                     "payInfos": "정산 완료 목록은 최소 1개 이상이어야 합니다."
+                                                 }
+                                             }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "정산 완료 여부 갱신 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "요청자가 정산자가 아닌 경우",value = """
+                                             {
+                                                  "code": "S002",
+                                                  "message": "정산자가 아닙니다."
+                                              }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "정산 완료 여부 갱신 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "존재하지 않는 정산 내역",value = """
+                                             {
+                                                  "code": "S001",
+                                                  "message": "존재하지 않는 정산 내역 입니다."
+                                              }
+                                    """),
+                            @ExampleObject(name = "존재하지 않는 분담 내역",value = """
+                                             {
+                                                 "code": "S003",
+                                                 "message": "존재하지 않는 분담 내역입니다."
+                                             }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> completeSettlement(
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            
+            @Parameter(description = "정산 내역 ID")
+            @PathVariable(name = "settlementId") Long settlementId,
+            @Valid @RequestBody SettlementRequest.PayInfoCompletionListDto request
+    );
+    
     @TrackApi(description = "정산 내역 삭제")
     @Operation(summary = "정산 내역 삭제", description = "정산 내역 삭제 API")
     @ApiResponses({

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
@@ -74,6 +74,7 @@ public class SettlementController implements SettlementApi {
         return ResponseEntity.ok(SuccessResponse.ok());
     }
     
+    @Override
     @PatchMapping("/{tripId}/settlements/{settlementId}")
     public ResponseEntity<?> completeSettlement(
             @AuthenticationPrincipal CustomUserDetailsImpl userDetails,

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/controller/SettlementController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -70,6 +71,16 @@ public class SettlementController implements SettlementApi {
     ) {
         settlementCommandService.updateSettlement(tripId, userDetails.getUserId(), settlementId, settlement);
         
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+    
+    @PatchMapping("/{tripId}/settlements/{settlementId}")
+    public ResponseEntity<?> completeSettlement(
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
+            @PathVariable(name = "settlementId") Long settlementId,
+            @Valid @RequestBody SettlementRequest.PayInfoCompletionListDto request
+    ) {
+        settlementCommandService.completeSettlement(settlementId, userDetails.getUserId(), request.payInfos());
         return ResponseEntity.ok(SuccessResponse.ok());
     }
     

--- a/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementCommandServiceTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -571,6 +572,154 @@ public class SettlementCommandServiceTest {
             
             // then
             assertEquals(SettlementErrorType.NOT_VALID_PRICE, exception.getErrorType());
+        }
+    }
+    
+    @Nested
+    @DisplayName("정산 완료 여부 갱신")
+    class CompleteSettlement {
+        private final Long settlementId = 1L;
+        private final Long userId = 1L;
+        
+        private Settlement settlement;
+        private PayInfo payInfo1;
+        private PayInfo payInfo2;
+        
+        @BeforeEach
+        void setUp() {
+            settlement = Settlement.builder()
+                    .tripId(1L)
+                    .name("점심 식사")
+                    .totalPrice(10000L)
+                    .date(LocalDate.of(2025, 10, 16))
+                    .type(SettlementType.RESTAURANT)
+                    .payerId(userId)
+                    .isCompleted(false)
+                    .build();
+            
+            payInfo1 = PayInfo.builder()
+                    .userId(userId)
+                    .price(5000L)
+                    .isCompleted(true)
+                    .settlementId(settlementId)
+                    .build();
+            
+            payInfo2 = PayInfo.builder()
+                    .userId(2L)
+                    .price(5000L)
+                    .isCompleted(false)
+                    .settlementId(settlementId)
+                    .build();
+            
+            ReflectionTestUtils.setField(payInfo1, "id", 1L);
+            ReflectionTestUtils.setField(payInfo2, "id", 2L);
+        }
+        
+        @Test
+        @DisplayName("성공 - 모든 정산자가 정산을 완료한 경우")
+        void success() {
+            // given
+            when(settlementService.readById(settlementId)).thenReturn(Optional.of(settlement));
+            when(payInfoService.readAllBySettlementId(settlementId)).thenReturn(List.of(payInfo1, payInfo2));
+            
+            List<SettlementRequest.PayInfoCompletionDto> dtos = List.of(
+                    new SettlementRequest.PayInfoCompletionDto(1L, true),
+                    new SettlementRequest.PayInfoCompletionDto(2L, true)
+            );
+            
+            // when
+            settlementCommandService.completeSettlement(settlementId, userId, dtos);
+            
+            // then
+            // 1. 분담 내역의 완료 여부가 DTO의 완료 여부와 동일하다.
+            assertEquals(dtos.get(0).isCompleted(), payInfo1.isCompleted());
+            assertEquals(dtos.get(1).isCompleted(), payInfo2.isCompleted());
+            
+            // 2. 분담 내역이 모두 정산 완료 된 경우, 해당 정산 내역도 정산 완료 처리 된다.
+            assertTrue(settlement.isCompleted());
+        }
+        
+        
+        @Test
+        @DisplayName("성공 - 정산을 완료하지 않은 분담자가 존재하는 경우")
+        void successIfNotSettledUserExists() {
+            // given
+            List<SettlementRequest.PayInfoCompletionDto> dtos = List.of(
+                    new SettlementRequest.PayInfoCompletionDto(1L, true),
+                    new SettlementRequest.PayInfoCompletionDto(2L, false)
+            );
+            
+            when(settlementService.readById(settlementId)).thenReturn(Optional.of(settlement));
+            when(payInfoService.readAllBySettlementId(settlementId)).thenReturn(List.of(payInfo1, payInfo2));
+            
+            // when
+            settlementCommandService.completeSettlement(settlementId, userId, dtos);
+            
+            // then
+            // 1. 분담 내역의 완료 여부가 DTO의 완료 여부와 동일하다.
+            assertEquals(dtos.get(0).isCompleted(), payInfo1.isCompleted());
+            assertEquals(dtos.get(1).isCompleted(), payInfo2.isCompleted());
+            
+            // 2. 정산 완료 되지 않은 분담 내역이 존재하는 경우, 해당 정산 내역도 정산 미완료 처리가 된다.
+            assertFalse(settlement.isCompleted());
+        }
+        
+        @Test
+        @DisplayName("실패 - 정산 내역이 존재하지 않는 경우")
+        void failIfSettlementNotFound() {
+            // given
+            List<SettlementRequest.PayInfoCompletionDto> dtos = List.of(
+                    new SettlementRequest.PayInfoCompletionDto(1L, true),
+                    new SettlementRequest.PayInfoCompletionDto(2L, false)
+            );
+            
+            when(settlementService.readById(settlementId)).thenReturn(Optional.empty());
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> settlementCommandService.completeSettlement(settlementId, userId, dtos));
+            
+            // then
+            assertEquals(SettlementErrorType.NOT_FOUND, exception.getErrorType());
+        }
+        
+        @Test
+        @DisplayName("실패 - 요청자가 정산 내역 생성자가 아닌 경우")
+        void failIfUserisNotPayer() {
+            // given
+            List<SettlementRequest.PayInfoCompletionDto> dtos = List.of(
+                    new SettlementRequest.PayInfoCompletionDto(1L, true),
+                    new SettlementRequest.PayInfoCompletionDto(2L, false)
+            );
+            
+            when(settlementService.readById(settlementId)).thenReturn(Optional.of(settlement));
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> settlementCommandService.completeSettlement(settlementId, 2L, dtos));
+            
+            // then
+            assertEquals(SettlementErrorType.IS_NOT_PAYER, exception.getErrorType());
+        }
+        
+        @Test
+        @DisplayName("실패 - 존재하지 않는 분담 내역이 존재하는 경우")
+        void failIfPayInfoNotFound() {
+            // given
+            List<SettlementRequest.PayInfoCompletionDto> dtos = List.of(
+                    new SettlementRequest.PayInfoCompletionDto(1L, true),
+                    new SettlementRequest.PayInfoCompletionDto(5L, false)
+            );
+            
+            when(settlementService.readById(settlementId)).thenReturn(Optional.of(settlement));
+            when(payInfoService.readAllBySettlementId(settlementId)).thenReturn(List.of(payInfo1, payInfo2));
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> settlementCommandService.completeSettlement(settlementId, userId, dtos));
+            
+            // then
+            assertEquals(SettlementErrorType.PAY_INFO_NOT_FOUND, exception.getErrorType());
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/settlement/controller/SettlementControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/settlement/controller/SettlementControllerTest.java
@@ -48,6 +48,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -548,6 +549,69 @@ public class SettlementControllerTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.errors.name").exists())
                     .andExpect(jsonPath("$.errors.totalPrice").exists());
+        }
+    }
+    
+    @Nested
+    @DisplayName("정산 완료")
+    class CompleteSettlement {
+        private final Long settlementId = 1L;
+        private final Long tripId = 1L;
+        
+        private SettlementRequest.PayInfoCompletionListDto dto;
+        
+        @BeforeEach
+        void setUp() {
+            SettlementRequest.PayInfoCompletionDto payInfoCompletion1
+                    = new SettlementRequest.PayInfoCompletionDto(userDetails.getUserId(), true);
+            SettlementRequest.PayInfoCompletionDto payInfoCompletion2
+                    = new SettlementRequest.PayInfoCompletionDto(2L, false);
+            
+            dto = new SettlementRequest.PayInfoCompletionListDto(List.of(payInfoCompletion1, payInfoCompletion2));
+        }
+        
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            doNothing().when(settlementCommandService).completeSettlement(
+                    settlementId,
+                    userDetails.getUserId(),
+                    dto.payInfos()
+            );
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    patch("/api/v1/trip/{tripId}/settlements/{settlementId}", tripId, settlementId)
+                            .with(user(userDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(dto))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
+        
+        @Test
+        @DisplayName("실패 - 분담 내역 리스트의 크기가 1보다 작은 경우 유효성 검증 실패")
+        void failValidation() throws Exception {
+            // given
+            dto = new SettlementRequest.PayInfoCompletionListDto(Collections.emptyList());
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    patch("/api/v1/trip/{tripId}/settlements/{settlementId}", tripId, settlementId)
+                            .with(user(userDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(dto))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors.payInfos").exists());
         }
     }
 }


### PR DESCRIPTION
## 배경
- 정산 내역 및 분담 내역 완료(isCompleted) 여부 갱신 기능 필요

## 작업 사항
- 정산, 분담 내역 엔티티 내 정산 완료 여부 갱신 메서드 추가 | (40017591e9be0831462c6292eb80a881db108891)
  - `uncomplete()`가 문법에는 맞지 않지만, `complete()`와 대조되는 직관적인 이름으로 설정하였습니다. 다른 의견 있으시면 조언 부탁드립니다!
- 정산 완료 여부 갱신 로직 구현 | (475f127516481dedc1ca3ba20e48085ef5864950)
- 정산 완료 여부 갱신 api 구현 | (5673418fbc19a3b8696165adf1642659a7b2f626)