### PR TITLE
Refactor: 정산 내역 엔티티 연관 관계 설정

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
@@ -76,11 +76,11 @@ public class SettlementRequest {
             @Min(value = 0, message = "최소 금액은 0원입니다.")
             Long price
     ) {
-        public PayInfo toEntity(Long settlementId) {
+        public PayInfo toEntity(Settlement settlement) {
             return PayInfo.builder()
                     .userId(userId)
                     .price(price)
-                    .settlementId(settlementId)
+                    .settlement(settlement)
                     .build();
         }
     }

--- a/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementCommandService.java
@@ -59,12 +59,10 @@ public class SettlementCommandService {
         }
         
         
-        Settlement settlement = dto.toEntity(tripId, userId);
-        
-        Long settlementId = settlementService.save(settlement);
+        Settlement settlement = settlementService.save(dto.toEntity(tripId, userId));
         
         List<PayInfo> payInfoList = payers.stream()
-                .map(payInfo -> payInfo.toEntity(settlementId))
+                .map(payInfo -> payInfo.toEntity(settlement))
                 .toList();
         
         payInfoService.saveAllInBatch(payInfoList);
@@ -107,7 +105,7 @@ public class SettlementCommandService {
             throw new CustomException(TripErrorType.TRIP_NOT_FOUND);
         }
         
-        Settlement settlement = settlementService.readById(settlementId)
+        Settlement settlement = settlementService.readByIdJoinFetch(settlementId)
                 .orElseThrow(() -> new CustomException(SettlementErrorType.NOT_FOUND));
         
         if (!settlement.isPayer(userId)) {
@@ -124,11 +122,10 @@ public class SettlementCommandService {
             throw new CustomException(SettlementErrorType.NOT_VALID_PRICE);
         }
      
-        // TODO: Settlement - PayInfo 연관관계 설정 후 수정 예정
-        List<PayInfo> payInfos = payInfoService.readAllBySettlementId(settlementId);
+        List<PayInfo> payInfos = settlement.getPayInfos();
         
         settlement.update(dto.name(), dto.totalPrice(), dto.date(), dto.type());
-        synchronizePayInfo(payInfos, payers, settlementId);
+        synchronizePayInfo(payInfos, payers, settlement);
     }
     
     /**
@@ -136,12 +133,12 @@ public class SettlementCommandService {
      *
      * @param oldPayInfos   기존의 인당 분담 내역 목록
      * @param newPayInfos   수정할 인당 분담 내역 목록
-     * @param settlementId  정산 내역 ID
+     * @param settlement    정산 내역
      */
     private void synchronizePayInfo(
             List<PayInfo> oldPayInfos,
             List<SettlementRequest.PayInfoDto> newPayInfos,
-            Long settlementId
+            Settlement settlement
     ) {
         Map<Long, SettlementRequest.PayInfoDto> newPayInfoMap = newPayInfos.stream()
                 .collect(Collectors.toMap(
@@ -149,7 +146,7 @@ public class SettlementCommandService {
                         Function.identity()
                 ));
         
-        addPayInfo(oldPayInfos, newPayInfos, settlementId);
+        addPayInfo(oldPayInfos, newPayInfos, settlement);
         updatePayInfo(oldPayInfos, newPayInfoMap);
         deletePayInfo(oldPayInfos, newPayInfoMap);
     }
@@ -192,16 +189,16 @@ public class SettlementCommandService {
      *
      * @param oldPayInfos   기존의 인당 분담 내역 목록
      * @param newPayInfos   새로운 인당 분담 내역 목록
-     * @param settlementId  정산 내역 ID
+     * @param settlement    정산 내역
      */
-    private void addPayInfo(List<PayInfo> oldPayInfos, List<SettlementRequest.PayInfoDto> newPayInfos, Long settlementId) {
+    private void addPayInfo(List<PayInfo> oldPayInfos, List<SettlementRequest.PayInfoDto> newPayInfos, Settlement settlement) {
         List<Long> oldPayers = oldPayInfos.stream()
                 .map(payInfo -> payInfo.getUserId())
                 .toList();
         
         List<PayInfo> addedPayInfos = newPayInfos.stream()
                 .filter(payInfoDto -> !oldPayers.contains(payInfoDto.userId()))
-                .map(payInfoDto -> payInfoDto.toEntity(settlementId))
+                .map(payInfoDto -> payInfoDto.toEntity(settlement))
                 .toList();
         
         if (!addedPayInfos.isEmpty()) {
@@ -224,15 +221,14 @@ public class SettlementCommandService {
      */
     @Transactional
     public void completeSettlement(Long settlementId, Long userId, List<SettlementRequest.PayInfoCompletionDto> dtos) {
-        Settlement settlement = settlementService.readById(settlementId)
+        Settlement settlement = settlementService.readByIdJoinFetch(settlementId)
                 .orElseThrow(() -> new CustomException(SettlementErrorType.NOT_FOUND));
         
         if (!settlement.isPayer(userId)) {
             throw new CustomException(SettlementErrorType.IS_NOT_PAYER);
         }
         
-        List<PayInfo> payInfos = payInfoService.readAllBySettlementId(settlementId);
-        Map<Long, PayInfo> payInfoMap = payInfos.stream()
+        Map<Long, PayInfo> payInfoMap = settlement.getPayInfos().stream()
                 .collect(Collectors.toMap(
                         payInfo -> payInfo.getId(),
                         Function.identity()

--- a/src/main/java/kr/co/yeogiga/domain/settlement/entity/PayInfo.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/entity/PayInfo.java
@@ -2,9 +2,12 @@ package kr.co.yeogiga.domain.settlement.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,15 +30,17 @@ public class PayInfo {
     @Column(name = "is_completed")
     private boolean isCompleted;
     
-    @Column(name = "settlement_id", nullable = false)
-    private Long settlementId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "settlement_id", nullable = false)
+    private Settlement settlement;
     
     @Builder
-    public PayInfo(Long userId, Long price, boolean isCompleted, Long settlementId) {
+    public PayInfo(Long userId, Long price, boolean isCompleted, Settlement settlement) {
         this.userId = userId;
         this.price = price;
         this.isCompleted = isCompleted;
-        this.settlementId = settlementId;
+        this.settlement = settlement;
+        settlement.addPayInfo(this);
     }
     
     public void update(Long price) {

--- a/src/main/java/kr/co/yeogiga/domain/settlement/entity/Settlement.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/entity/Settlement.java
@@ -4,9 +4,11 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import kr.co.yeogiga.domain.settlement.type.SettlementType;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -14,6 +16,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -44,8 +48,12 @@ public class Settlement {
     @Column(name = "is_completed")
     private boolean isCompleted;
     
+    @OneToMany(mappedBy = "settlement", fetch = FetchType.LAZY)
+    private List<PayInfo> payInfos = new ArrayList<>();
+    
     @Builder
     public Settlement(
+            Long id,
             Long tripId,
             String name,
             Long totalPrice,
@@ -54,6 +62,7 @@ public class Settlement {
             Long payerId,
             boolean isCompleted
     ) {
+        this.id = id;
         this.tripId = tripId;
         this.name = name;
         this.totalPrice = totalPrice;
@@ -80,5 +89,9 @@ public class Settlement {
     
     public void uncomplete() {
         this.isCompleted = false;
+    }
+    
+    public void addPayInfo(PayInfo payInfo) {
+        this.payInfos.add(payInfo);
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomPayInfoRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomPayInfoRepositoryImpl.java
@@ -26,7 +26,7 @@ public class CustomPayInfoRepositoryImpl implements CustomPayInfoRepository {
                         ps.setLong(1, payInfo.getUserId());
                         ps.setLong(2, payInfo.getPrice());
                         ps.setBoolean(3, payInfo.isCompleted());
-                        ps.setLong(4, payInfo.getSettlementId());
+                        ps.setLong(4, payInfo.getSettlement().getId());
                     }
                     
                     @Override

--- a/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomSettlementRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomSettlementRepository.java
@@ -1,11 +1,13 @@
 package kr.co.yeogiga.domain.settlement.repository;
 
 import kr.co.yeogiga.domain.settlement.dto.SettlementDto;
+import kr.co.yeogiga.domain.settlement.entity.Settlement;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface CustomSettlementRepository {
+    Optional<Settlement> findByIdJoinFetch(Long id);
     Optional<Long> findPayerIdById(Long id);
     Optional<SettlementDto> findSettlementDtoById(Long id);
     List<SettlementDto> findAllSettlementDtoByTripId(Long tripId);

--- a/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomSettlementRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/repository/CustomSettlementRepositoryImpl.java
@@ -7,6 +7,7 @@ import kr.co.yeogiga.domain.settlement.dto.PayInfoDto;
 import kr.co.yeogiga.domain.settlement.dto.SettlementDto;
 import kr.co.yeogiga.domain.settlement.entity.QPayInfo;
 import kr.co.yeogiga.domain.settlement.entity.QSettlement;
+import kr.co.yeogiga.domain.settlement.entity.Settlement;
 import kr.co.yeogiga.domain.user.entity.QUser;
 import lombok.RequiredArgsConstructor;
 
@@ -24,6 +25,19 @@ public class CustomSettlementRepositoryImpl implements CustomSettlementRepositor
     private final QUser user = QUser.user;
     
     @Override
+    public Optional<Settlement> findByIdJoinFetch(Long id) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .selectFrom(settlement)
+                        .join(settlement.payInfos, payInfo)
+                        .fetchJoin()
+                        .where(settlement.id.eq(id))
+                        .distinct()
+                        .fetchOne()
+        );
+    }
+    
+    @Override
     public Optional<Long> findPayerIdById(Long id) {
         return Optional.ofNullable(
                 jpaQueryFactory
@@ -39,7 +53,7 @@ public class CustomSettlementRepositoryImpl implements CustomSettlementRepositor
         return Optional.ofNullable(
                 jpaQueryFactory
                         .from(settlement)
-                        .join(payInfo).on(settlement.id.eq(payInfo.settlementId))
+                        .join(payInfo).on(settlement.id.eq(payInfo.settlement.id))
                         .join(user).on(payInfo.userId.eq(user.id))
                         .where(settlement.id.eq(id))
                         .transform(
@@ -75,7 +89,7 @@ public class CustomSettlementRepositoryImpl implements CustomSettlementRepositor
         Collection<SettlementDto> result = jpaQueryFactory
                 .from(settlement)
                 .where(settlement.tripId.eq(tripId))
-                .join(payInfo).on(settlement.id.eq(payInfo.settlementId))
+                .join(payInfo).on(settlement.id.eq(payInfo.settlement.id))
                 .join(user).on(payInfo.userId.eq(user.id))
                 .transform(
                         GroupBy.groupBy(settlement.id).as(

--- a/src/main/java/kr/co/yeogiga/domain/settlement/service/SettlementService.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/service/SettlementService.java
@@ -14,12 +14,16 @@ import java.util.Optional;
 public class SettlementService {
     private final SettlementRepository settlementRepository;
     
-    public Long save(Settlement settlement) {
-        return settlementRepository.save(settlement).getId();
+    public Settlement save(Settlement settlement) {
+        return settlementRepository.save(settlement);
     }
     
     public Optional<Settlement> readById(Long id) {
         return settlementRepository.findById(id);
+    }
+    
+    public Optional<Settlement> readByIdJoinFetch(Long id) {
+        return settlementRepository.findByIdJoinFetch(id);
     }
     
     public Optional<Long> readPayerIdById(Long id) {

--- a/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementCommandServiceTest.java
@@ -60,6 +60,7 @@ public class SettlementCommandServiceTest {
     class CreateSettlement {
         private final Long tripId = 10L;
         private final Long userId = 1L;
+        private final Long settlementId = 100L;
         
         private List<User> members = List.of(
                 User.builder().id(1L).build(),
@@ -94,7 +95,7 @@ public class SettlementCommandServiceTest {
         void success() {
             // given
             when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(members);
-            when(settlementService.save(any(Settlement.class))).thenReturn(100L);
+            when(settlementService.save(any(Settlement.class))).thenReturn(Settlement.builder().id(settlementId).build());
             doNothing().when(payInfoService).saveAllInBatch(anyList());
             
             // when
@@ -104,8 +105,8 @@ public class SettlementCommandServiceTest {
             verify(settlementService, times(1)).save(settlementCaptor.capture());
             verify(payInfoService, times(1)).saveAllInBatch(payInfosCaptor.capture());
             
-            assertEquals(false, settlementCaptor.getValue().isCompleted());
-            payInfosCaptor.getValue().forEach(payInfo -> assertEquals(100L, payInfo.getSettlementId()));
+            assertFalse(settlementCaptor.getValue().isCompleted());
+            payInfosCaptor.getValue().forEach(payInfo -> assertEquals(settlementId, payInfo.getSettlement().getId()));
         }
         
         @Test
@@ -130,7 +131,7 @@ public class SettlementCommandServiceTest {
                     .build();
             
             when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(members);
-            when(settlementService.save(any(Settlement.class))).thenReturn(100L);
+            when(settlementService.save(any(Settlement.class))).thenReturn(Settlement.builder().build());
             doNothing().when(payInfoService).saveAllInBatch(anyList());
             
             // when
@@ -328,14 +329,14 @@ public class SettlementCommandServiceTest {
                     .userId(userId)
                     .price(20000L)
                     .isCompleted(true)
-                    .settlementId(settlement.getId())
+                    .settlement(settlement)
                     .build();
             
             payInfo2 = PayInfo.builder()
                     .userId(2L)
                     .price(30000L)
                     .isCompleted(false)
-                    .settlementId(settlement.getId())
+                    .settlement(settlement)
                     .build();
             
             ReflectionTestUtils.setField(payInfo1, "id", 1L);
@@ -362,8 +363,7 @@ public class SettlementCommandServiceTest {
         void success() {
             // given
             when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(List.of(member1, member2, member3));
-            when(settlementService.readById(settlementId)).thenReturn(Optional.of(settlement));
-            when(payInfoService.readAllBySettlementId(settlementId)).thenReturn(List.of(payInfo1, payInfo2));
+            when(settlementService.readByIdJoinFetch(settlementId)).thenReturn(Optional.of(settlement));
             
             List<SettlementRequest.PayInfoDto> payInfoDtos = List.of(
                     SettlementRequest.PayInfoDto.builder()
@@ -407,8 +407,7 @@ public class SettlementCommandServiceTest {
         void successIfOnlySettlementChanged() {
             // given
             when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(List.of(member1, member2, member3));
-            when(settlementService.readById(settlementId)).thenReturn(Optional.of(settlement));
-            when(payInfoService.readAllBySettlementId(settlementId)).thenReturn(List.of(payInfo1, payInfo2));
+            when(settlementService.readByIdJoinFetch(settlementId)).thenReturn(Optional.of(settlement));
             
             List<SettlementRequest.PayInfoDto> payInfoDtos = List.of(
                     SettlementRequest.PayInfoDto.builder()
@@ -477,7 +476,7 @@ public class SettlementCommandServiceTest {
         void failIfNotPayer() {
             // given
             when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(List.of(member1, member2, member3));
-            when(settlementService.readById(settlementId)).thenReturn(Optional.of(settlement));
+            when(settlementService.readByIdJoinFetch(settlementId)).thenReturn(Optional.of(settlement));
             
             List<SettlementRequest.PayInfoDto> payInfoDtos = List.of(
                     SettlementRequest.PayInfoDto.builder()
@@ -511,7 +510,7 @@ public class SettlementCommandServiceTest {
         void failIfExistsNotMember() {
             // given
             when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(List.of(member1, member2, member3));
-            when(settlementService.readById(settlementId)).thenReturn(Optional.of(settlement));
+            when(settlementService.readByIdJoinFetch(settlementId)).thenReturn(Optional.of(settlement));
             
             List<SettlementRequest.PayInfoDto> payInfoDtos = List.of(
                     SettlementRequest.PayInfoDto.builder()
@@ -545,7 +544,7 @@ public class SettlementCommandServiceTest {
         void failIfNotValidPrice() {
             // given
             when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(List.of(member1, member2, member3));
-            when(settlementService.readById(settlementId)).thenReturn(Optional.of(settlement));
+            when(settlementService.readByIdJoinFetch(settlementId)).thenReturn(Optional.of(settlement));
             
             List<SettlementRequest.PayInfoDto> payInfoDtos = List.of(
                     SettlementRequest.PayInfoDto.builder()
@@ -601,14 +600,14 @@ public class SettlementCommandServiceTest {
                     .userId(userId)
                     .price(5000L)
                     .isCompleted(true)
-                    .settlementId(settlementId)
+                    .settlement(settlement)
                     .build();
             
             payInfo2 = PayInfo.builder()
                     .userId(2L)
                     .price(5000L)
                     .isCompleted(false)
-                    .settlementId(settlementId)
+                    .settlement(settlement)
                     .build();
             
             ReflectionTestUtils.setField(payInfo1, "id", 1L);
@@ -619,8 +618,7 @@ public class SettlementCommandServiceTest {
         @DisplayName("성공 - 모든 정산자가 정산을 완료한 경우")
         void success() {
             // given
-            when(settlementService.readById(settlementId)).thenReturn(Optional.of(settlement));
-            when(payInfoService.readAllBySettlementId(settlementId)).thenReturn(List.of(payInfo1, payInfo2));
+            when(settlementService.readByIdJoinFetch(settlementId)).thenReturn(Optional.of(settlement));
             
             List<SettlementRequest.PayInfoCompletionDto> dtos = List.of(
                     new SettlementRequest.PayInfoCompletionDto(1L, true),
@@ -649,8 +647,7 @@ public class SettlementCommandServiceTest {
                     new SettlementRequest.PayInfoCompletionDto(2L, false)
             );
             
-            when(settlementService.readById(settlementId)).thenReturn(Optional.of(settlement));
-            when(payInfoService.readAllBySettlementId(settlementId)).thenReturn(List.of(payInfo1, payInfo2));
+            when(settlementService.readByIdJoinFetch(settlementId)).thenReturn(Optional.of(settlement));
             
             // when
             settlementCommandService.completeSettlement(settlementId, userId, dtos);
@@ -673,7 +670,7 @@ public class SettlementCommandServiceTest {
                     new SettlementRequest.PayInfoCompletionDto(2L, false)
             );
             
-            when(settlementService.readById(settlementId)).thenReturn(Optional.empty());
+            when(settlementService.readByIdJoinFetch(settlementId)).thenReturn(Optional.empty());
             
             // when
             CustomException exception = assertThrows(CustomException.class, ()
@@ -692,7 +689,7 @@ public class SettlementCommandServiceTest {
                     new SettlementRequest.PayInfoCompletionDto(2L, false)
             );
             
-            when(settlementService.readById(settlementId)).thenReturn(Optional.of(settlement));
+            when(settlementService.readByIdJoinFetch(settlementId)).thenReturn(Optional.of(settlement));
             
             // when
             CustomException exception = assertThrows(CustomException.class, ()
@@ -711,8 +708,7 @@ public class SettlementCommandServiceTest {
                     new SettlementRequest.PayInfoCompletionDto(5L, false)
             );
             
-            when(settlementService.readById(settlementId)).thenReturn(Optional.of(settlement));
-            when(payInfoService.readAllBySettlementId(settlementId)).thenReturn(List.of(payInfo1, payInfo2));
+            when(settlementService.readByIdJoinFetch(settlementId)).thenReturn(Optional.of(settlement));
             
             // when
             CustomException exception = assertThrows(CustomException.class, ()


### PR DESCRIPTION
## 배경
- 정산 내역(Settlement) - 분담 내역(PayInfo) 사이 연관 관계 설정을 통한 불필요 조회 쿼리 삭제 가능성 인식

## 작업 사항
- 정산 - 분담 내역 엔티티 연관 관계 설정 | (67adfd206fc8a4b0f7fdf413d42869f539311f21)
  - 객체 간 데이터 정합성 유지를 위한 `PayInfo` 생성자 내에서 `Settlement.addPayInfo(PayInfo)` 메서드 호출
  - 엔티티에 따로 `cascade` 설정은 주지 않았습니다. 따라서, 삭제 등 관리할 때 연관 관계를 고려하여야 합니다.
- 정산 - 분담 내역 연관 관계 설정으로 인한 도메인 로직 변경 | (59266e473d618a23e07a93fd43a8009df1ad4909)
  - 연관 관계 필드 설정으로 인한 QueryDSL 코드 내 QEntity 필드 변경
  - fetch join을 통한 정산 내역 조회 도메인 메서드 추가
- SettlementCommandService 로직 리팩토링 | (e7c9fca0ad40e6ff0b86b5f779cdcfabef0cd06f)
  - `PayInfo` 생성 시, 연관 관계 필드인 `settlement` 할당
  - 정산 내역 수정 시, Settlement와 PayInfo를 나누어서 조회하던 로직을 fetch join을 통한 한 번의 조회 로직으로 변경
  - 정산 완료 여부 수정 시, Settlement와 PayInfo를 나누어서 조회하던 로직을 fetch join을 통한 한 번의 조회 로직으로 변경