### PR TITLE
Feature: 정산 내역 생성 시 정산자의 정산 여부 기본값 설정

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/dto/SettlementRequest.java
@@ -83,6 +83,15 @@ public class SettlementRequest {
                     .settlement(settlement)
                     .build();
         }
+        
+        public PayInfo toEntity(Settlement settlement, boolean isCompleted) {
+            return PayInfo.builder()
+                    .userId(userId)
+                    .price(price)
+                    .settlement(settlement)
+                    .isCompleted(isCompleted)
+                    .build();
+        }
     }
     
     @Schema(name = "SettlementRequest.PayInfoCompletionListDto", description = "분담 내역 완료 여부 리스트 DTO")

--- a/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementCommandService.java
+++ b/src/main/java/kr/co/yeogiga/application/settlement/service/SettlementCommandService.java
@@ -58,11 +58,10 @@ public class SettlementCommandService {
             throw new CustomException(SettlementErrorType.NOT_VALID_PRICE);
         }
         
-        
         Settlement settlement = settlementService.save(dto.toEntity(tripId, userId));
         
         List<PayInfo> payInfoList = payers.stream()
-                .map(payInfo -> payInfo.toEntity(settlement))
+                .map(payInfo -> payInfo.toEntity(settlement, settlement.isPayer(payInfo.userId())))
                 .toList();
         
         payInfoService.saveAllInBatch(payInfoList);

--- a/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementCommandServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/settlement/service/SettlementCommandServiceTest.java
@@ -36,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -74,7 +75,7 @@ public class SettlementCommandServiceTest {
                 .type(SettlementType.RESTAURANT)
                 .payers(List.of(
                         SettlementRequest.PayInfoDto.builder()
-                                .userId(1L)
+                                .userId(userId)
                                 .price(10000L)
                                 .build(),
                         SettlementRequest.PayInfoDto.builder()
@@ -94,8 +95,11 @@ public class SettlementCommandServiceTest {
         @DisplayName("성공")
         void success() {
             // given
+            Settlement settlement = mock(Settlement.class);
+            when(settlement.getId()).thenReturn(settlementId);
+            when(settlement.isPayer(userId)).thenReturn(true);
             when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(members);
-            when(settlementService.save(any(Settlement.class))).thenReturn(Settlement.builder().id(settlementId).build());
+            when(settlementService.save(any(Settlement.class))).thenReturn(settlement);
             doNothing().when(payInfoService).saveAllInBatch(anyList());
             
             // when
@@ -107,6 +111,16 @@ public class SettlementCommandServiceTest {
             
             assertFalse(settlementCaptor.getValue().isCompleted());
             payInfosCaptor.getValue().forEach(payInfo -> assertEquals(settlementId, payInfo.getSettlement().getId()));
+            List<PayInfo> payInfos = payInfosCaptor.getValue();
+            
+            for (PayInfo payInfo : payInfos) {
+                assertEquals(settlementId, payInfo.getSettlement().getId());
+                if (payInfo.getUserId().equals(userId)) {
+                    assertTrue(payInfo.isCompleted());
+                } else {
+                    assertFalse(payInfo.isCompleted());
+                }
+            }
         }
         
         @Test
@@ -131,7 +145,7 @@ public class SettlementCommandServiceTest {
                     .build();
             
             when(tripMemberService.readAllUserByTripId(tripId)).thenReturn(members);
-            when(settlementService.save(any(Settlement.class))).thenReturn(Settlement.builder().build());
+            when(settlementService.save(any(Settlement.class))).thenReturn(Settlement.builder().payerId(userId).build());
             doNothing().when(payInfoService).saveAllInBatch(anyList());
             
             // when


### PR DESCRIPTION
## 배경
- 정산 내역 생성 시 정산자(payer)는 정산 완료 상태가 `true` 설정되도록 기능 수정 사항 발생

## 작업 사항
- 정산 내역 생성 시 정산자는 정산 완료 상태로 설정 | (1e6ec380edd1bb6b08c88cdd61058ed17bb479d8)