### PR TITLE
Refactor: 장소 카테고리 응답값 필드명 수정

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceRes.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/dto/TripPlaceRes.java
@@ -56,7 +56,7 @@ public class TripPlaceRes {
             String name,
             double latitude,
             double longitude,
-            String placeCategory
+            String placeType
     ) {
         public static TempPlaceInfo from(TripPlaceReqLegacy.StoredFormat place) {
             return new TempPlaceInfo(

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/api/TripPlaceEditingApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/api/TripPlaceEditingApi.java
@@ -65,14 +65,14 @@ public interface TripPlaceEditingApi {
                                                     "name": "목적지1",
                                                     "latitude": 32.33,
                                                     "longitude": 87.123,
-                                                    "placeCategory": "관광지"
+                                                    "placeType": "관광지"
                                                 },
                                                 {
                                                     "id": "place-id2",
                                                     "name": "목적지2",
                                                     "latitude": 132.33,
                                                     "longitude": 287.123,
-                                                    "placeCategory": "식당"
+                                                    "placeType": "식당"
                                                 }
                                             ]
                                         }

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceEditingServiceTest.java
@@ -168,6 +168,6 @@ public class TripPlaceEditingServiceTest {
         // then
         assertEquals(1, result.size());
         assertEquals("목적지1", result.get(0).name());
-        assertEquals(PlaceCategory.RESTAURANT.getLabel(), result.get(0).placeCategory());
+        assertEquals(PlaceCategory.RESTAURANT.getLabel(), result.get(0).placeType());
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/controller/TripPlaceEditingControllerTest.java
@@ -187,7 +187,7 @@ public class TripPlaceEditingControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data[0].name").value("목적지1"))
-                .andExpect(jsonPath("$.data[0].placeCategory").value(PlaceCategory.RESTAURANT.getLabel()));
+                .andExpect(jsonPath("$.data[0].placeType").value(PlaceCategory.RESTAURANT.getLabel()));
     }
 
     @Test


### PR DESCRIPTION
## 배경
- 일차에 지정한 목적지 조회하는 API(`/api/v1/trip/{tripId}/days/{day}/places`) 응답값 내 장소 카테코리 필드명 변경 요청
  - `placeCategory` → `placeType`

## 작업 사항
- `TripPlaceRes.TempPlaceInfo` dto 내 장소 카테고리 필드명 수정 | (737630fe4eff8aa1118c0a0a17a3ac3dbdf6f2a8)