### PR TITLE
Chore: Dockerfile 이미지 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17 AS builder
+FROM eclipse-temurin:17-jdk AS builder
 COPY gradlew .
 COPY gradle gradle
 COPY build.gradle .

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN microdnf install findutils
 RUN ./gradlew build -x test
 
 
-FROM openjdk:17
+FROM eclipse-temurin:17-jre
 RUN mkdir /opt/app
 COPY --from=builder build/libs/*.jar /opt/app/spring-boot-application.jar
 EXPOSE 8080


### PR DESCRIPTION
## 배경
기존에 사용하던 openjdk 베이스 이미지가 Docker Hub에서 deprecated됨 ([openjdk docker](https://hub.docker.com/_/openjdk))
그래서,  eclipse-temurin로 변경

## 작업 사항
- Dockerfile 이미지 eclipse-temurin로 변경

## 추가 논의
x