### PR TITLE
Feature: 여행 일차 조회 중, 이미지 내역 목적지로 그룹화

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/TripPlaceImageRes.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/dto/TripPlaceImageRes.java
@@ -2,6 +2,7 @@ package kr.co.yeogiga.application.tripplace.image.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import kr.co.yeogiga.domain.placeimage.entity.Image;
+import kr.co.yeogiga.domain.tripplace.dto.ImagesPlaceDto;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import lombok.Builder;
 
@@ -43,6 +44,37 @@ public class TripPlaceImageRes {
                     unmatchedImages.stream()
                             .map(ImageDto::from)
                             .collect(Collectors.toList())
+            );
+        }
+    }
+
+    @Builder
+    public record GroupedResponse(
+            List<PlaceImages> byPlace,
+            List<ImageDto> unmatched
+    ) {
+        public static GroupedResponse from(ImagesPlaceDto.Response response) {
+            List<PlaceImages> byPlace = response.byPlace().stream()
+                    .map(PlaceImages::from)
+                    .toList();
+
+            List<ImageDto> unmatched = response.unmatched().stream()
+                    .map(ImageDto::from)
+                    .toList();
+
+            return new GroupedResponse(byPlace, unmatched);
+        }
+    }
+
+    @Builder
+    public record PlaceImages(
+            String placeId,
+            List<ImageDto> images
+    ) {
+        public static PlaceImages from(ImagesPlaceDto.PlaceImages placeImages) {
+            return new PlaceImages(
+                    placeImages.placeId(),
+                    placeImages.images().stream().map(ImageDto::from).toList()
             );
         }
     }

--- a/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageQueryServiceLegacy.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageQueryServiceLegacy.java
@@ -3,8 +3,8 @@ package kr.co.yeogiga.application.tripplace.image.service;
 import kr.co.yeogiga.application.tripplace.image.dto.FavoriteImageRes;
 import kr.co.yeogiga.application.tripplace.image.dto.TripPlaceImageRes;
 import kr.co.yeogiga.common.exception.CustomException;
-import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.placeimage.entity.Image;
+import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +23,7 @@ public class TripPlaceImageQueryServiceLegacy {
     /**
      * ## 임시 처리 로직
      * <p>
-     * 특정 TripDayPlace 내에서 일차(day)별 이미지 조회 메섣,
+     * 특정 여행 내에서 일차(day)별 이미지 조회 메서드
      *
      * @param tripId 여행 ID
      * @param day    일차
@@ -32,6 +32,21 @@ public class TripPlaceImageQueryServiceLegacy {
     public List<TripPlaceImageRes.ImageDto> getTripDayImageInfo(Long tripId, int day) {
         return tripDayPlaceService.readAllImagesByTripIdAndDay(tripId, day)
                 .stream().map(TripPlaceImageRes.ImageDto::from).toList();
+    }
+
+    /**
+     * ## 임시 처리 로직 v2 (placeId별 그룹화)
+     * <p>
+     * 특정 여행 내에서 일차(day)별 이미지 조회 메서드
+     *
+     * @param tripId 여행 ID
+     * @param day    일차
+     * @return 여행 일차에 대한 이미지 반환
+     */
+    public TripPlaceImageRes.GroupedResponse getTripDayImageInfoWithPlaceId(Long tripId, int day) {
+        return TripPlaceImageRes.GroupedResponse.from(
+                tripDayPlaceService.readImagesGroupedByPlace(tripId, day)
+        );
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/dto/ImagesPlaceDto.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/dto/ImagesPlaceDto.java
@@ -1,0 +1,18 @@
+package kr.co.yeogiga.domain.tripplace.dto;
+
+import kr.co.yeogiga.domain.placeimage.entity.Image;
+
+import java.util.List;
+
+public class ImagesPlaceDto {
+
+    public record Response(
+            List<PlaceImages> byPlace,
+            List<Image> unmatched
+    ) { }
+
+    public record PlaceImages(
+            String placeId,
+            List<Image> images
+    ) { }
+}

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepository.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.domain.tripplace.repository;
 
 import kr.co.yeogiga.domain.placeimage.entity.Image;
+import kr.co.yeogiga.domain.tripplace.dto.ImagesPlaceDto;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 
@@ -15,6 +16,7 @@ public interface CustomTripDayPlaceRepository {
     Optional<TripDayPlace> findByIdSorted(String id);
     List<TripDayPlace> findByTripIdSorted(Long tripId);
     List<Image> findAllImagesByTripIdAndDay(Long tripId, int day);
+    ImagesPlaceDto.Response findImagesGroupedByPlace(Long tripId, int day);
     Optional<Place> findPlaceByIdAndPlaceId(String id, String placeId);
     List<Image> findUnmatchedImagesById(String id);
     List<TripDayPlace> findTripDayPlaceSummariesByTripId(Long tripId);

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/repository/CustomTripDayPlaceRepositoryImpl.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.domain.tripplace.repository;
 
 import kr.co.yeogiga.domain.placeimage.entity.Image;
+import kr.co.yeogiga.domain.tripplace.dto.ImagesPlaceDto;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import lombok.RequiredArgsConstructor;
@@ -144,6 +145,40 @@ public class CustomTripDayPlaceRepositoryImpl implements CustomTripDayPlaceRepos
         }
 
         return images;
+    }
+
+    @Override
+    public ImagesPlaceDto.Response findImagesGroupedByPlace(Long tripId, int day) {
+        Criteria criteria = Criteria.where("tripId").is(tripId)
+                .and("day").is(day);
+
+        Query query = new Query(criteria);
+        query.fields()
+                .include("unmatchedImages")
+                .include("places.images")
+                .include("places.id");
+
+        TripDayPlace doc = mongoTemplate.findOne(query, TripDayPlace.class);
+        if (doc == null) {
+            return new ImagesPlaceDto.Response(List.of(), List.of());
+        }
+
+        List<Image> unmatched = Optional.ofNullable(doc.getUnmatchedImages())
+                .map(List::copyOf)
+                .orElseGet(List::of);
+
+        List<ImagesPlaceDto.PlaceImages> byPlace = new ArrayList<>();
+        List<Place> places = Optional.ofNullable(doc.getPlaces()).orElseGet(List::of);
+
+        for (Place p : places) {
+            if (p.getId() == null) continue;
+            List<Image> imgs = Optional.ofNullable(p.getImages())
+                    .map(List::copyOf)
+                    .orElseGet(List::of);
+            byPlace.add(new ImagesPlaceDto.PlaceImages(p.getId(), imgs));
+        }
+
+        return new ImagesPlaceDto.Response(byPlace, unmatched);
     }
 
     @Override

--- a/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
+++ b/src/main/java/kr/co/yeogiga/domain/tripplace/service/TripDayPlaceService.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.domain.tripplace.service;
 
 import kr.co.yeogiga.domain.placeimage.entity.Image;
+import kr.co.yeogiga.domain.tripplace.dto.ImagesPlaceDto;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.entity.TripDayPlace;
 import kr.co.yeogiga.domain.tripplace.repository.TripDayPlaceRepository;
@@ -53,6 +54,10 @@ public class TripDayPlaceService {
 
     public List<Image> readAllImagesByTripIdAndDay(Long tripId, int day) {
         return tripDayPlaceRepository.findAllImagesByTripIdAndDay(tripId, day);
+    }
+
+    public ImagesPlaceDto.Response readImagesGroupedByPlace(Long tripId, int day) {
+        return tripDayPlaceRepository.findImagesGroupedByPlace(tripId, day);
     }
 
     public Optional<Place> readPlaceByIdAndPlaceId(String id, String placeId) {

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/api/TripPlaceImageApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/api/TripPlaceImageApi.java
@@ -59,6 +59,85 @@ public interface TripPlaceImageApi {
             @PathVariable int day
     );
 
+    @TrackApi(description = "여행 일차별 이미지 조회 - 목적지 id로 그룹화 (임시 처리 REST API)")
+    @Operation(summary = "여행 일차별 이미지 조회 - 목적지 id로 그룹화 (임시 처리 REST API)", description = "여행 일차별 이미지 조회하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "일차에 맞는 이미지 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": {
+                                                 "byPlace": [
+                                                     {
+                                                         "placeId": "place1-id",
+                                                         "images": [
+                                                            {
+                                                                 "id": "image1-id",
+                                                                 "url": "https://image1.com",
+                                                                 "latitude": 11.11,
+                                                                 "longitude": 22.22,
+                                                                 "date": "2025-04-13T21:53:57.445",
+                                                                 "favorite": true
+                                                             },
+                                                             {
+                                                                 "id": "image2-id",
+                                                                 "url": "https://image2.com",
+                                                                 "latitude": 33.33,
+                                                                 "longitude": 44.44,
+                                                                 "date": "2025-04-13T21:53:57.445",
+                                                                 "favorite": false
+                                                             }
+                                                         ]
+                                                     },
+                                                     {
+                                                         "placeId": "place2-id",
+                                                         "images": [
+                                                             {
+                                                                 "id": "image3-id",
+                                                                 "url": "https://image3.com",
+                                                                 "latitude": 55.55,
+                                                                 "longitude": 66.66,
+                                                                 "date": "2025-04-13T21:53:57.445",
+                                                                 "favorite": true
+                                                             },
+                                                             {
+                                                                 "id": "image4-id",
+                                                                 "url": "https://image4.com",
+                                                                 "latitude": 77.77,
+                                                                 "longitude": 88.88,
+                                                                 "date": "2025-04-13T21:53:57.445",
+                                                                 "favorite": false
+                                                             }
+                                                         ]
+                                                     }
+                                                 ],
+                                                 "unmatched": [
+                                                     {
+                                                         "id": "image5-id",
+                                                         "url": "https://image5.com",
+                                                         "favorite": false
+                                                     },
+                                                     {
+                                                         "id": "image6-id",
+                                                         "url": "https://image6.com",
+                                                         "favorite": false
+                                                     }
+                                                 ]
+                                             }
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getTripDayImageInfoWithPlaceId(
+            @Parameter(description = "여행 ID")
+            @PathVariable Long tripId,
+
+            @Parameter(description = "여행 일차")
+            @PathVariable int day
+    );
+
     @TrackApi(description = "일차별 목적지에 매칭되어 있는 이미지 조회")
     @Operation(summary = "일차별 목적지에 매칭되어 있는 이미지 조회", description = "일차별 목적지에 매칭되어 있는 이미지 조회하는 API입니다.")
     @ApiResponses({

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
@@ -41,6 +41,18 @@ public class TripPlaceImageController implements TripPlaceImageApi {
         );
     }
 
+    @GetMapping("/{tripId}/day-place/images/day/{day}/with-place")
+    public ResponseEntity<?> getTripDayImageInfoWithPlaceId(
+            @PathVariable Long tripId,
+            @PathVariable int day
+    ) {
+        return ResponseEntity.ok(
+                SuccessResponse.from(
+                        tripPlaceImageQueryServiceLegacy.getTripDayImageInfoWithPlaceId(tripId, day)
+                )
+        );
+    }
+
     @Override
     @GetMapping("/{tripId}/day-place/{tripDayPlaceId}/places/{placeId}/images")
     public ResponseEntity<?> getPlaceInfo(

--- a/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageController.java
@@ -41,6 +41,7 @@ public class TripPlaceImageController implements TripPlaceImageApi {
         );
     }
 
+    @Override
     @GetMapping("/{tripId}/day-place/images/day/{day}/with-place")
     public ResponseEntity<?> getTripDayImageInfoWithPlaceId(
             @PathVariable Long tripId,

--- a/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageQueryServiceLegacyTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/image/service/TripPlaceImageQueryServiceLegacyTest.java
@@ -6,6 +6,7 @@ import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.placeimage.entity.Image;
 import kr.co.yeogiga.domain.trip.exception.TripErrorType;
 import kr.co.yeogiga.domain.trip.type.PlaceCategory;
+import kr.co.yeogiga.domain.tripplace.dto.ImagesPlaceDto;
 import kr.co.yeogiga.domain.tripplace.entity.Place;
 import kr.co.yeogiga.domain.tripplace.service.TripDayPlaceService;
 import org.junit.jupiter.api.DisplayName;
@@ -71,6 +72,61 @@ public class TripPlaceImageQueryServiceLegacyTest {
 
         // then
         assertThat(result).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("여행 일차에 대한 이미지 조회 테스트 (목적지 id로 그룹화)")
+    void getTripDayImageInfoWithPlaceIdTest() {
+        // given
+        Image image1 = Image.builder()
+                .url("https://image-1.com")
+                .latitude(37.0)
+                .longitude(127.0)
+                .date(LocalDateTime.of(2024, 5, 14, 12, 0))
+                .build();
+
+        Image image2 = Image.builder()
+                .url("https://image-2.com")
+                .latitude(37.1)
+                .longitude(127.1)
+                .date(LocalDateTime.of(2024, 5, 15, 8, 30))
+                .build();
+
+        Image unmatched = Image.builder()
+                .url("https://image-3.com")
+                .latitude(36.9)
+                .longitude(126.9)
+                .date(LocalDateTime.of(2024, 5, 16, 9, 0))
+                .build();
+
+        Long tripId = 1L;
+        int day = 1;
+
+        ImagesPlaceDto.PlaceImages placeGroup = new ImagesPlaceDto.PlaceImages(
+                "place-1",
+                List.of(image1, image2)
+        );
+
+        ImagesPlaceDto.Response response = new ImagesPlaceDto.Response(
+                List.of(placeGroup),
+                List.of(unmatched)
+        );
+
+        given(tripDayPlaceService.readImagesGroupedByPlace(tripId, day))
+                .willReturn(response);
+
+        // when
+        TripPlaceImageRes.GroupedResponse result =
+                tripPlaceImageQueryServiceLegacy.getTripDayImageInfoWithPlaceId(tripId, day);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.byPlace()).hasSize(1);
+        assertThat(result.unmatched()).hasSize(1);
+
+        TripPlaceImageRes.PlaceImages byPlace0 = result.byPlace().get(0);
+        assertThat(byPlace0.placeId()).isEqualTo("place-1");
+        assertThat(byPlace0.images()).hasSize(2);
     }
 
     @Nested

--- a/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/tripplace/image/controller/TripPlaceImageControllerTest.java
@@ -116,6 +116,69 @@ public class TripPlaceImageControllerTest {
                 .andExpect(jsonPath("$.data", hasSize(2)));
     }
 
+    @Test
+    @DisplayName("여행 일차에 대한 이미지 조회 테스트 (목적지 id로 그룹화)")
+    void getTripDayImageInfoWithPlaceIdTest() throws Exception {
+        // given
+        long tripId = 1L;
+        int day = 1;
+
+        TripPlaceImageRes.ImageDto img1 = TripPlaceImageRes.ImageDto.builder()
+                .id("image1-id")
+                .url("https://image1.com")
+                .latitude(37.0).longitude(127.0)
+                .favorite(false)
+                .build();
+
+        TripPlaceImageRes.ImageDto img2 = TripPlaceImageRes.ImageDto.builder()
+                .id("image2-id")
+                .url("https://image2.com")
+                .latitude(37.1).longitude(127.1)
+                .favorite(true)
+                .build();
+
+        TripPlaceImageRes.ImageDto unmatched = TripPlaceImageRes.ImageDto.builder()
+                .id("image3-id")
+                .url("https://unmatched.com")
+                .latitude(36.9).longitude(126.9)
+                .favorite(false)
+                .build();
+
+        TripPlaceImageRes.PlaceImages byPlace0 = TripPlaceImageRes.PlaceImages.builder()
+                .placeId("place-1")
+                .images(List.of(img1, img2))
+                .build();
+
+        TripPlaceImageRes.GroupedResponse grouped =
+                TripPlaceImageRes.GroupedResponse.builder()
+                        .byPlace(List.of(byPlace0))
+                        .unmatched(List.of(unmatched))
+                        .build();
+
+        when(tripPlaceImageQueryServiceLegacy.getTripDayImageInfoWithPlaceId(tripId, day))
+                .thenReturn(grouped);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/trip/{tripId}/day-place/images/day/{day}/with-place", tripId, day)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."))
+                .andExpect(jsonPath("$.data.byPlace", hasSize(1)))
+                .andExpect(jsonPath("$.data.byPlace[0].placeId").value("place-1"))
+                .andExpect(jsonPath("$.data.byPlace[0].images", hasSize(2)))
+                .andExpect(jsonPath("$.data.byPlace[0].images[0].id").value("image1-id"))
+                .andExpect(jsonPath("$.data.byPlace[0].images[1].id").value("image2-id"))
+                .andExpect(jsonPath("$.data.unmatched", hasSize(1)))
+                .andExpect(jsonPath("$.data.unmatched[0].id").value("image3-id"));
+
+    }
+
     @Nested
     @DisplayName("이미지 조회 테스트")
     class GetImageInfoTest {


### PR DESCRIPTION
## 배경
- 이미지에 대한 접근 (즐겨찾기 추가)를 위해 목적지 정보가 필요함.
- 그래서, 목적지 정보 (`place-id`)를 통해 그룹화하여 이미지 정보를 조회하는 로직 추가.

## 작업 사항
 - 여행 일차 내 목적지 이미지 그룹화 조회 로직 구현 (64fc621b6f34da1816552c0668415ffca6bffcfb)
 - 목적지 그룹화한 이미지 조회 구현 (42ca3cf171365b18c5058e33a15b663f94672dcf) 및 rest api 연결 (b9e28e433f768aff93a6ea5b3490190a02df17b6)

## 전달 사항
 - 기존에 조회하던 일차별 이미지 조회 (`/{tripId}/day-place/images/day/{day}`)는 그대로 두고, 위 로직을 구현했습니다.
    프론트단에서 해당 로직으로 모두 변경한다면, 제거하겠습니다