### PR TITLE
Feature: 여행 주 목적 지역 할당 로직 수정

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingServiceLegacy.java
+++ b/src/main/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingServiceLegacy.java
@@ -18,7 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -63,17 +64,28 @@ public class TripPlaceSavingServiceLegacy {
     }
     
     /**
-     * 여행 주 목적지(city) 값을 설정하는 메서드
+     * 여행 주 목적 지역(city) 값을 설정하는 메서드
+     *
+     * <p> 여러 목직 지역이 존재하는 경우 가장 빈도 수가 높은 2곳을 선택해 저장
      *
      * @param trip      여행 엔티티
      * @param addresses 목적지들의 주소 목록
      */
     public void updateTripCity(Trip trip, List<String> addresses) {
-        Set<String> regionSet = addresses.stream()
-                .map(address -> RegionUtil.extractRegion(address))
-                .collect(Collectors.toSet());
+        Map<String, Long> regionCounts = addresses.stream()
+                .map(RegionUtil::extractRegion)
+                .collect(Collectors.groupingBy(
+                        Function.identity(),
+                        Collectors.counting()
+                ));
         
-        trip.updateCity(regionSet.stream().toList());
+        List<String> top2Regions = regionCounts.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .limit(2)
+                .map(Map.Entry::getKey)
+                .toList();
+        
+        trip.updateCity(top2Regions);
     }
 
     /**

--- a/src/main/java/kr/co/yeogiga/domain/settlement/exception/SettlementErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/settlement/exception/SettlementErrorType.java
@@ -11,7 +11,7 @@ import org.springframework.http.HttpStatus;
 public enum SettlementErrorType implements BaseErrorType {
     NOT_VALID_PRICE(HttpStatus.BAD_REQUEST, "S000", "정산 내역 금액 총합이 일치하지 않습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "존재하지 않는 정산 내역 입니다."),
-    IS_NOT_PAYER(HttpStatus.FORBIDDEN, "S002", "정산자가 아닙니다."),
+    IS_NOT_PAYER(HttpStatus.FORBIDDEN, "S002", "정산 생성자가 아닙니다."),
     PAY_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "S003", "존재하지 않는 분담 내역입니다.");
     
     private final HttpStatus status;

--- a/src/main/java/kr/co/yeogiga/presentation/settlement/api/SettlementApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/settlement/api/SettlementApi.java
@@ -350,7 +350,7 @@ public interface SettlementApi {
                             @ExampleObject(name = "요청자가 정산자가 아닌 경우",value = """
                                              {
                                                   "code": "S002",
-                                                  "message": "정산자가 아닙니다."
+                                                  "message": "정산자 생성자가 아닙니다."
                                               }
                                     """)
                     })),
@@ -410,7 +410,7 @@ public interface SettlementApi {
                             @ExampleObject(name = "요청자가 정산자가 아닌 경우",value = """
                                              {
                                                   "code": "S002",
-                                                  "message": "정산자가 아닙니다."
+                                                  "message": "정산 생성자가 아닙니다."
                                               }
                                     """)
                     })),
@@ -464,7 +464,7 @@ public interface SettlementApi {
                             @ExampleObject(name = "요청자가 정산 생성자가 아닌 경우", value = """
                                              {
                                                  "code": "S002",
-                                                 "message": "정산자가 아닙니다."
+                                                 "message": "정산 생성자가 아닙니다."
                                              }
                                     """)
                     })),

--- a/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingServiceLegacyTest.java
+++ b/src/test/java/kr/co/yeogiga/application/tripplace/service/TripPlaceSavingServiceLegacyTest.java
@@ -222,9 +222,46 @@ public class TripPlaceSavingServiceLegacyTest {
             // when
             tripPlaceSavingServiceLegacy.completeTrip(tripId, 2);
             
-            // then: 여행 목적지(지역)은 중복인 목적지로 인하여 총 3곳이며, "대구광역시", "포항시", "제주특별자치도"이다.
-            assertThat(trip.getCity()).hasSize(3);
-            assertThat(trip.getCity()).containsAll(List.of("대구광역시", "포항시", "제주특별자치도"));
+            // then: 여행 목적지(지역)은 여러 목적지 중 빈도 수가 높은 2곳이 할당되며, "포항시", "대구광역시" 이다. 삽입 순서에 따라 대구광역시가 우선 할당 된다.
+            assertThat(trip.getCity()).hasSize(2);
+            assertThat(trip.getCity()).containsAll(List.of("대구광역시", "포항시"));
+        }
+    }
+    
+    @Test
+    @DisplayName("여행 목적지 확정 성공 - 여행 주 목적지(지역)이 한 곳만 존재하는 경우")
+    void successAssignTripCityWhenCityIsOnlyOne() {
+        // given
+        TripPlaceReqLegacy.StoredFormat place1 = new TripPlaceReqLegacy.StoredFormat(
+                "id2", "포함시청", "경상북도 포항시 남구 대잠동 1001 포항시청", 33.789, 126.987, PlaceCategory.TOURISM
+        );
+        TripPlaceReqLegacy.StoredFormat place2 = new TripPlaceReqLegacy.StoredFormat(
+                "id3", "포항역 고속철", "경상북도 포항시 북구 흥해읍 이인리 137-1", 33.789, 126.987, PlaceCategory.TRANSPORT
+        );
+        when(redisRepository.getList(PlaceConstant.dayPlacesKey(tripId, 1), TripPlaceReqLegacy.StoredFormat.class))
+                .thenReturn(List.of(place1));
+        
+        
+        when(redisRepository.getList(PlaceConstant.dayPlacesKey(tripId, 2), TripPlaceReqLegacy.StoredFormat.class))
+                .thenReturn(List.of(place2));
+        
+        ReflectionTestUtils.setField(trip, "startedAt", LocalDateTime.of(2025, 5, 20, 12, 0));
+        ReflectionTestUtils.setField(trip, "endedAt", LocalDateTime.of(2025, 5, 21, 12, 0));
+        
+        when(tripService.readById(tripId)).thenReturn(Optional.of(trip));
+        
+        try (MockedStatic<LocalDateTime> mockedLocalDateTime = Mockito.mockStatic(LocalDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+            String date = "2025-05-24T12:00:00Z";
+            Clock clock = Clock.fixed(Instant.parse(date), ZoneId.of("UTC"));
+            LocalDateTime mockNow = LocalDateTime.now(clock);
+            mockedLocalDateTime.when(LocalDateTime::now).thenReturn(mockNow);
+            
+            // when
+            tripPlaceSavingServiceLegacy.completeTrip(tripId, 2);
+            
+            // then: 여행 주 목적 지역이 단 1곳일 경우는, 해당 지역만 할당된다.
+            assertThat(trip.getCity()).hasSize(1);
+            assertThat(trip.getCity()).containsAll(List.of("포항시"));
         }
     }
 }


### PR DESCRIPTION
## 배경
- 여행 주 목적 지역 할당 시 가장 빈도수가 높은 2곳만 할당하도록 로직 변경 요청

## 작업 사항
- 여행 주 목적 지역 저장 시 빈도 수에 따른 저장 도시 수 변경 | (3ceef3c94809e3f12def71eeba69a266929a1010)
  - 주소 추출 시, 가장 빈도 수가 높은 2곳만 선택해 리스트 형태로 저장
- 정산 생성자가 아닌 경우 예외 응답 메시지 변경 | (e02b600ff6aa02429b67a13a13987c04a903d197)
  - 작업 도중 해당 요청사항이 있어 이번 작업 도중 변경하였습니다.