### PR TITLE
Fix: 여행 멤버 위치 저장 및 조회 시 사용자 아이디 null 값 전달 문제 해결

### DIFF
--- a/src/main/java/kr/co/yeogiga/presentation/trip/api/TripMemberLocationApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/api/TripMemberLocationApi.java
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.co.yeogiga.application.trip.dto.TripMemberLocationDto;
-import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -62,7 +62,7 @@ public interface TripMemberLocationApi {
                     }))
     })
     ResponseEntity<?> saveLocation(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             
             @Parameter(description = "여행 ID")
             @PathVariable Long tripId,
@@ -116,7 +116,7 @@ public interface TripMemberLocationApi {
                     }))
     })
     ResponseEntity<?> getLocations(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             
             @Parameter(description = "여행 ID")
             @PathVariable Long tripId

--- a/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripMemberLocationController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/trip/controller/TripMemberLocationController.java
@@ -5,7 +5,7 @@ import kr.co.yeogiga.application.trip.dto.TripMemberLocationDto;
 import kr.co.yeogiga.application.trip.service.TripMemberLocationCommandService;
 import kr.co.yeogiga.application.trip.service.TripMemberLocationQueryService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
-import kr.co.yeogiga.common.security.auth.CustomUserDetails;
+import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;
 import kr.co.yeogiga.presentation.trip.api.TripMemberLocationApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -28,7 +28,7 @@ public class TripMemberLocationController implements TripMemberLocationApi {
     @Override
     @PostMapping("/{tripId}/members/location")
     public ResponseEntity<?> saveLocation(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @PathVariable Long tripId,
             @Valid @RequestBody TripMemberLocationDto.Request request
     ) {
@@ -39,7 +39,7 @@ public class TripMemberLocationController implements TripMemberLocationApi {
     @Override
     @GetMapping("/{tripId}/members/location")
     public ResponseEntity<?> getLocations(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal CustomUserDetailsImpl userDetails,
             @PathVariable Long tripId
     ) {
         return ResponseEntity.ok()

--- a/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripMemberLocationControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/trip/controller/TripMemberLocationControllerTest.java
@@ -37,7 +37,9 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -64,12 +66,14 @@ public class TripMemberLocationControllerTest {
     @MockBean
     private TripMemberLocationQueryService tripMemberLocationQueryService;
     
-    private CustomUserDetails userDetails;
+    private CustomUserDetailsImpl userDetails;
     
     @BeforeEach
     void setUp(WebApplicationContext webApplicationContext) {
         this.mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .defaultRequest(post("/**").with(csrf()))
                 .alwaysDo(print())
                 .build();
         


### PR DESCRIPTION
## 배경
- 여행 멤버 위치 저장 및 조회 시 에러 발생

## 작업 사항
- `TripMemberLocationController` 내 여행 멤버 위치 저장 및 조회 메서드 사용 인자 타입 변경 | (62199294af435a3f7c40250263840660ffa1b73f)
  - `CustomUserDetails` 인터페이스 → `CustomUserDetailsImpl` 구현체