### PR TITLE
Feature(IL-390): 아이디 찾기 기능 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/auth/dto/IdInquiryDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/IdInquiryDto.java
@@ -1,0 +1,11 @@
+package kr.co.yeogiga.application.auth.dto;
+
+public class IdInquiryDto {
+    public record Request(
+            String email
+    ) { }
+    
+    public record Response(
+            String username
+    ) { }
+}

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/IdInquiryDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/IdInquiryDto.java
@@ -1,7 +1,14 @@
 package kr.co.yeogiga.application.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 public class IdInquiryDto {
     public record Request(
+            @Schema(description = "이메일", example = "test@test.com")
+            @NotBlank(message = "이메일은 필수 입력값입니다.")
+            @Pattern(regexp = "^[\\w!#$%&'*+/=?`{|}~^.-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$", message = "잘못된 이메일 형식입니다.")
             String email
     ) { }
     

--- a/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.application.auth.service;
 
+import kr.co.yeogiga.application.auth.dto.IdInquiryDto;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
 import kr.co.yeogiga.application.auth.dto.SignUpDto;
 import kr.co.yeogiga.application.auth.dto.TokenDto;
@@ -148,5 +149,18 @@ public class AuthService {
         }
         
         user.revertWithdrawal();
+    }
+    
+    /**
+     * 사용자 로그인 아이디 찾기 메서드
+     *
+     * @param email     이메일
+     * @return          사용자 로그인 아이디
+     */
+    public IdInquiryDto.Response inquireUsername(String email) {
+        User user = userService.readByEmail(email)
+                .orElseThrow(() -> new CustomException(UserErrorType.EMAIL_NOT_FOUND));
+        
+        return new IdInquiryDto.Response(user.getUsername());
     }
 }

--- a/src/main/java/kr/co/yeogiga/domain/user/exception/UserErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/exception/UserErrorType.java
@@ -14,8 +14,8 @@ public enum UserErrorType implements BaseErrorType {
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "U002", "비밀번호가 불일치합니다."),
     ALREADY_WITHDRAW(HttpStatus.BAD_REQUEST, "U003", "이미 회원탈퇴한 사용자입니다."),
     ALREADY_USED_NICKNAME(HttpStatus.CONFLICT, "U004", "이미 사용 중인 닉네임입니다."),
-    SAME_NICKNAME(HttpStatus.CONFLICT, "U005", "기존과 동일한 닉네임 입니다.");
-
+    SAME_NICKNAME(HttpStatus.CONFLICT, "U005", "기존과 동일한 닉네임 입니다."),
+    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "U006", "존재하지 않는 이메일입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepository.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface CustomUserRepository {
+    Optional<User> findUserIncludeDeletedByEmail(String email);
     Optional<User> findUserIncludeDeletedByPlatformAndPlatformId(String platform, String platformId);
     Optional<User> findUserIncludeDeletedById(Long id);
     Optional<User> findUserIncludeDeletedByNickname(String nickname);

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepositoryImpl.java
@@ -50,6 +50,19 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
     }
     
     @Override
+    public Optional<User> findUserIncludeDeletedByEmail(String email) {
+        JPASQLQuery<Tuple> jpaSqlQuery = new JPASQLQuery<>(entityManager, sqlTemplates);
+        
+        return Optional.ofNullable(
+                jpaSqlQuery
+                        .select(USER_ENTITY_PATH)
+                        .from(USER_ENTITY_PATH)
+                        .where(Expressions.stringPath(USER_ENTITY_PATH, USER_COLUMN.EMAIL).eq(email))
+                        .fetchFirst()
+        );
+    }
+    
+    @Override
     public Optional<User> findUserIncludeDeletedByPlatformAndPlatformId(String platform, String platformId) {
         JPASQLQuery<Tuple> jpaSqlQuery = new JPASQLQuery<>(entityManager, sqlTemplates);
         

--- a/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
@@ -51,6 +51,9 @@ public class UserService {
         return userRepository.findByFcmToken(fcmToken);
     }
 
+    public Optional<User> readByEmail(String email) {
+        return userRepository.findUserIncludeDeletedByEmail(email);
+    }
     public boolean existsIncludeDeletedByUsername(String username) {
         return userRepository.existsIncludeDeletedByUsername(username);
     }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/AuthApi.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import kr.co.yeogiga.application.auth.dto.IdInquiryDto;
 import kr.co.yeogiga.application.auth.dto.RestoreDto;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
 import kr.co.yeogiga.application.auth.dto.SignUpDto;
@@ -303,4 +304,42 @@ public interface AuthApi {
                     }))
     })
     ResponseEntity<?> restoreUser(@Valid @RequestBody RestoreDto.Request request);
+    
+    @TrackApi(description = "아이디 찾기")
+    @Operation(summary = "아이디 찾기", description = "사용자 로그인 아이디를 찾는 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "아이디 찾기 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "아이디 찾기 성공", value = """
+                                        {
+                                             "code": 200,
+                                             "message": "요청이 성공하였습니다.",
+                                             "data": {
+                                                 "username": "testid13"
+                                             }
+                                         }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "아이디 찾기 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "유효성 검증 실패", value = """
+                                        {
+                                             "code": "G002",
+                                             "errors": {
+                                                 "email": "잘못된 이메일 형식입니다."
+                                             }
+                                         }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "아이디 찾기 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "존재하지 않는 이메일", value = """
+                                        {
+                                            "code": "U006",
+                                            "message": "존재하지 않는 이메일입니다."
+                                        }
+                                    """),
+                    }))
+    })
+    ResponseEntity<?> inquireUsername(@Valid @RequestBody IdInquiryDto.Request request);
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package kr.co.yeogiga.presentation.auth.controller;
 
 import jakarta.validation.Valid;
+import kr.co.yeogiga.application.auth.dto.IdInquiryDto;
 import kr.co.yeogiga.application.auth.dto.RestoreDto;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
 import kr.co.yeogiga.application.auth.dto.SignUpDto;
@@ -113,5 +114,11 @@ public class AuthController implements AuthApi {
     public ResponseEntity<?> restoreUser(@Valid @RequestBody RestoreDto.Request request) {
         authService.restoreUser(request.userId());
         return ResponseEntity.ok(SuccessResponse.ok());
+    }
+    
+    @PostMapping("/id-inquiry")
+    public ResponseEntity<?> inquireUsername(@Valid @RequestBody IdInquiryDto.Request request) {
+        return ResponseEntity
+                .ok(SuccessResponse.from(authService.inquireUsername(request.email())));
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/AuthController.java
@@ -116,6 +116,7 @@ public class AuthController implements AuthApi {
         return ResponseEntity.ok(SuccessResponse.ok());
     }
     
+    @Override
     @PostMapping("/id-inquiry")
     public ResponseEntity<?> inquireUsername(@Valid @RequestBody IdInquiryDto.Request request) {
         return ResponseEntity

--- a/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package kr.co.yeogiga.application.auth.service;
 
+import kr.co.yeogiga.application.auth.dto.IdInquiryDto;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
 import kr.co.yeogiga.application.auth.dto.SignUpDto;
 import kr.co.yeogiga.application.auth.dto.TokenDto;
@@ -406,6 +407,45 @@ public class AuthServiceTest {
             
             // then
             assertEquals(AuthErrorType.NOT_WITHDRAWN, exception.getErrorType());
+        }
+    }
+    
+    @Nested
+    @DisplayName("아이디 찾기")
+    class InquireUsername {
+        private final String email = "test@test.com";
+        private final String username = "test";
+        private final User user = User.builder()
+                .username(username)
+                .email(email)
+                .password("password")
+                .build();
+        
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            when(userService.readByEmail(email)).thenReturn(Optional.of(user));
+            
+            // when
+            IdInquiryDto.Response result = authService.inquireUsername(email);
+            
+            // then
+            assertEquals(username, result.username());
+        }
+        
+        @Test
+        @DisplayName("실패 - 해당 이메일을 사용하는 사용자가 존재하지 않는 경우")
+        void failIfEmailNotFound() {
+            // given
+            when(userService.readByEmail(email)).thenReturn(Optional.empty());
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> authService.inquireUsername(email));
+            
+            // then
+            assertEquals(UserErrorType.EMAIL_NOT_FOUND, exception.getErrorType());
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/auth/controller/AuthControllerTest.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.presentation.auth.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
 import kr.co.yeogiga.application.auth.constant.AuthConstants;
+import kr.co.yeogiga.application.auth.dto.IdInquiryDto;
 import kr.co.yeogiga.application.auth.dto.RestoreDto;
 import kr.co.yeogiga.application.auth.dto.SignInDto;
 import kr.co.yeogiga.application.auth.dto.SignUpDto;
@@ -37,6 +38,7 @@ import java.time.LocalDate;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -662,6 +664,53 @@ public class AuthControllerTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.errors.userId").exists());
         }
+    }
+    
+    @Nested
+    @DisplayName("아이디 찾기")
+    class InquireUsername {
+        private final String email = "test@test.com";
+        private final String username = "test";
+        private final IdInquiryDto.Request request = new IdInquiryDto.Request(email);
+        private final IdInquiryDto.Response response = new IdInquiryDto.Response(username);
         
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            when(authService.inquireUsername(email)).thenReturn(response);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/id-inquiry")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.username").value(username));
+        }
+        
+        @Test
+        @DisplayName("실패 - 유효성 검증 실패")
+        void failValidation() throws Exception {
+            // given
+            IdInquiryDto.Request request = new IdInquiryDto.Request("notvalidemail");
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/id-inquiry")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors.email").exists());
+            
+        }
     }
 }


### PR DESCRIPTION
## 배경
- 아이디 찾기 기능 필요

## 작업 사항
- 이메일을 통한 사용자 조회 도메인 로직 구현 | (63d9929099b30da9a2311705aef6c4281c973a15)
  - soft delete된 사용자 포함
- 아이디 찾기 로직 구현 | (79d3462ad54bc84b1d00c7b1133de7b87cd849e1)
- 아이디 찾기 api 구현 | (b73f1c0266a4a2f01517055d748f5ab4d5e46155)

## 추가 논의
- 시연 시 아이디 확인을 용이하게 하기 위하여 별도의 마스킹 처리 없이 단순히 아이디 값을 응답하도록 구현하였습니다.