### PR TITLE
Feature(IL-409): 임시 인기 급상승 여행지 조회 기능 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/place/PlaceSearchService.java
+++ b/src/main/java/kr/co/yeogiga/application/place/PlaceSearchService.java
@@ -1,4 +1,4 @@
-package kr.co.yeogiga.application.place.application;
+package kr.co.yeogiga.application.place;
 
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.PlaceErrorType;

--- a/src/main/java/kr/co/yeogiga/application/uprisingplace/dto/UprisingPlaceDto.java
+++ b/src/main/java/kr/co/yeogiga/application/uprisingplace/dto/UprisingPlaceDto.java
@@ -14,7 +14,7 @@ public class UprisingPlaceDto {
             PlaceCategory placeCategory,
             String url
     ) {
-        public static Response fromEntity(UprisingPlace uprisingPlace) {
+        public static Response from(UprisingPlace uprisingPlace) {
             return Response.builder()
                     .id(uprisingPlace.getId())
                     .name(uprisingPlace.getName())

--- a/src/main/java/kr/co/yeogiga/application/uprisingplace/dto/UprisingPlaceDto.java
+++ b/src/main/java/kr/co/yeogiga/application/uprisingplace/dto/UprisingPlaceDto.java
@@ -1,0 +1,27 @@
+package kr.co.yeogiga.application.uprisingplace.dto;
+
+import kr.co.yeogiga.domain.trip.type.PlaceCategory;
+import kr.co.yeogiga.domain.uprisingplace.entity.UprisingPlace;
+import lombok.Builder;
+
+public class UprisingPlaceDto {
+    
+    @Builder
+    public record Response(
+            Long id,
+            String name,
+            String address,
+            PlaceCategory placeCategory,
+            String url
+    ) {
+        public static Response fromEntity(UprisingPlace uprisingPlace) {
+            return Response.builder()
+                    .id(uprisingPlace.getId())
+                    .name(uprisingPlace.getName())
+                    .address(uprisingPlace.getAddress())
+                    .placeCategory(uprisingPlace.getPlaceCategory())
+                    .url(uprisingPlace.getUrl())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/uprisingplace/service/UprisingPlaceQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/uprisingplace/service/UprisingPlaceQueryService.java
@@ -19,6 +19,6 @@ public class UprisingPlaceQueryService {
      */
     public List<UprisingPlaceDto.Response> getAllUprisingPlaces() {
         return uprisingPlaceService.readAll().stream()
-                .map(UprisingPlaceDto.Response::fromEntity).toList();
+                .map(UprisingPlaceDto.Response::from).toList();
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/uprisingplace/service/UprisingPlaceQueryService.java
+++ b/src/main/java/kr/co/yeogiga/application/uprisingplace/service/UprisingPlaceQueryService.java
@@ -1,0 +1,24 @@
+package kr.co.yeogiga.application.uprisingplace.service;
+
+import kr.co.yeogiga.application.uprisingplace.dto.UprisingPlaceDto;
+import kr.co.yeogiga.domain.uprisingplace.service.UprisingPlaceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UprisingPlaceQueryService {
+    private final UprisingPlaceService uprisingPlaceService;
+    
+    /**
+     * 인기 급상승 여행지 목록을 조회하는 메서드
+     *
+     * @return  인기 급상승 여행지 목록
+     */
+    public List<UprisingPlaceDto.Response> getAllUprisingPlaces() {
+        return uprisingPlaceService.readAll().stream()
+                .map(UprisingPlaceDto.Response::fromEntity).toList();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/uprisingplace/entity/UprisingPlace.java
+++ b/src/main/java/kr/co/yeogiga/domain/uprisingplace/entity/UprisingPlace.java
@@ -1,0 +1,33 @@
+package kr.co.yeogiga.domain.uprisingplace.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import kr.co.yeogiga.domain.trip.type.PlaceCategory;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "uprising_place")
+public class UprisingPlace {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    private String name;
+    
+    private String address;
+    
+    @Column(name = "place_category")
+    @Enumerated(EnumType.STRING)
+    private PlaceCategory placeCategory;
+    
+    private String url;
+}

--- a/src/main/java/kr/co/yeogiga/domain/uprisingplace/repository/UprisingPlaceRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/uprisingplace/repository/UprisingPlaceRepository.java
@@ -1,0 +1,7 @@
+package kr.co.yeogiga.domain.uprisingplace.repository;
+
+import kr.co.yeogiga.domain.uprisingplace.entity.UprisingPlace;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UprisingPlaceRepository extends JpaRepository<UprisingPlace, Long> {
+}

--- a/src/main/java/kr/co/yeogiga/domain/uprisingplace/service/UprisingPlaceService.java
+++ b/src/main/java/kr/co/yeogiga/domain/uprisingplace/service/UprisingPlaceService.java
@@ -1,0 +1,18 @@
+package kr.co.yeogiga.domain.uprisingplace.service;
+
+import kr.co.yeogiga.domain.uprisingplace.entity.UprisingPlace;
+import kr.co.yeogiga.domain.uprisingplace.repository.UprisingPlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UprisingPlaceService {
+    private final UprisingPlaceRepository uprisingPlaceRepository;
+    
+    public List<UprisingPlace> readAll() {
+        return uprisingPlaceRepository.findAll();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/security/constant/EndpointConstants.java
@@ -6,7 +6,7 @@ public final class EndpointConstants {
     public static final String[] PUBLIC_ENDPOINTS = {
             "/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**",
             "/webjars/**", "/error", "/api-checker/**", "/v1/api/link/checker/**",
-            "/api/v1/auth/**", "/api/v1/oauth/sign-in/**", "/api/v1/weather"
+            "/api/v1/auth/**", "/api/v1/oauth/sign-in/**", "/api/v1/weather", "/api/v1/uprising-places"
     };
 
     public static final String[] USER_ENDPOINTS = {

--- a/src/main/java/kr/co/yeogiga/presentation/auth/uprisingplace/api/UprisingPlaceApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/uprisingplace/api/UprisingPlaceApi.java
@@ -1,0 +1,103 @@
+package kr.co.yeogiga.presentation.auth.uprisingplace.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@ApiGroup(value = "[급상승 여행지 API]")
+@Tag(name = "[급상승 여행지 API]", description = "급상승 여행지 관련 API")
+public interface UprisingPlaceApi {
+    
+    @TrackApi(description = "급상승 여행지 전체 조회")
+    @Operation(summary = "급상승 여행지 전체 조회", description = "급상승 여행지 전체 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "급상승 여행지 전체 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(description = "급상승 인기 여행지 10곳 정보를 반환", value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": [
+                                                {
+                                                    "id": 1,
+                                                    "name": "말티재",
+                                                    "address": "충청북도 보인군 속리산면 갈목리 산19-6",
+                                                    "placeCategory": "TOURISM",
+                                                    "url": "https://image.com/1"
+                                                },
+                                                {
+                                                    "id": 2,
+                                                    "name": "관방제림",
+                                                    "address": "전라남도 담양군 담양읍 객사7길 37",
+                                                    "placeCategory": "TOURISM",
+                                                    "url": "https://image.com/2"
+                                                },
+                                                {
+                                                    "id": 3,
+                                                    "name": "불국사",
+                                                    "address": "경상북도 경주시 불국로 385",
+                                                    "placeCategory": "TOURISM",
+                                                    "url": "https://image.com/3"
+                                                },
+                                                {
+                                                    "id": 4,
+                                                    "name": "부석사",
+                                                    "address": "경상북도 영주시 부석면 부석사로 345",
+                                                    "placeCategory": "TOURISM",
+                                                    "url": "https://image.com/4"
+                                                },
+                                                {
+                                                    "id": 5,
+                                                    "name": "반계리 은행나무",
+                                                    "address": "강원특별자치도원주시 문막음 반계리 1496-1",
+                                                    "placeCategory": "TOURISM",
+                                                    "url": "https://image.com/5"
+                                                },
+                                                {
+                                                    "id": 6,
+                                                    "name": "팔공산 분수대광장",
+                                                    "address": "대구광역시 동구 용수동 27-5",
+                                                    "placeCategory": "TOURISM",
+                                                    "url": "https://image.com/6"
+                                                },
+                                                {
+                                                    "id": 7,
+                                                    "name": "삼성궁",
+                                                    "address": "경상남도 하동군 청암면 삼성궁길 13",
+                                                    "placeCategory": "TOURISM",
+                                                    "url": "https://image.com/7"
+                                                },
+                                                {
+                                                    "id": 8,
+                                                    "name": "다대포 해수욕장",
+                                                    "address": "부산광역시 사하구 몰운대1길 14",
+                                                    "placeCategory": "TOURISM",
+                                                    "url": "https://image.com/8"
+                                                },
+                                                {
+                                                    "id": 9,
+                                                    "name": "월정리 해수욕장",
+                                                    "address": "제주특별자치도 제주시 조천읍 월정1길 35",
+                                                    "placeCategory": "TOURISM",
+                                                    "url": "https://image.com/9"
+                                                },
+                                                {
+                                                    "id": 10,
+                                                    "name": "호국의병의숲 친수공원",
+                                                    "address": "경남 의령군 지정면 성산리 672",
+                                                    "placeCategory": "TOURISM",
+                                                    "url": "https://image.com/10"
+                                                }
+                                            ]
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getAllUprisingPlaces();
+}

--- a/src/main/java/kr/co/yeogiga/presentation/auth/uprisingplace/controller/UprisingPlaceController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/uprisingplace/controller/UprisingPlaceController.java
@@ -2,6 +2,7 @@ package kr.co.yeogiga.presentation.auth.uprisingplace.controller;
 
 import kr.co.yeogiga.application.uprisingplace.service.UprisingPlaceQueryService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.presentation.auth.uprisingplace.api.UprisingPlaceApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,9 +12,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/uprising-places")
 @RequiredArgsConstructor
-public class UprisingPlaceController {
+public class UprisingPlaceController implements UprisingPlaceApi {
     private final UprisingPlaceQueryService uprisingPlaceQueryService;
     
+    @Override
     @GetMapping
     public ResponseEntity<?> getAllUprisingPlaces() {
         return ResponseEntity.ok(SuccessResponse.from(uprisingPlaceQueryService.getAllUprisingPlaces()));

--- a/src/main/java/kr/co/yeogiga/presentation/auth/uprisingplace/controller/UprisingPlaceController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/uprisingplace/controller/UprisingPlaceController.java
@@ -1,0 +1,21 @@
+package kr.co.yeogiga.presentation.auth.uprisingplace.controller;
+
+import kr.co.yeogiga.application.uprisingplace.service.UprisingPlaceQueryService;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/uprising-places")
+@RequiredArgsConstructor
+public class UprisingPlaceController {
+    private final UprisingPlaceQueryService uprisingPlaceQueryService;
+    
+    @GetMapping
+    public ResponseEntity<?> getAllUprisingPlaces() {
+        return ResponseEntity.ok(SuccessResponse.from(uprisingPlaceQueryService.getAllUprisingPlaces()));
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/place/controller/PlaceController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/place/controller/PlaceController.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.presentation.place.controller;
 
-import kr.co.yeogiga.application.place.application.PlaceSearchService;
+import kr.co.yeogiga.application.place.PlaceSearchService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.presentation.place.api.PlaceApi;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/kr/co/yeogiga/application/place/PlaceSearchServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/place/PlaceSearchServiceTest.java
@@ -1,6 +1,5 @@
 package kr.co.yeogiga.application.place;
 
-import kr.co.yeogiga.application.place.application.PlaceSearchService;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.trip.exception.PlaceErrorType;
 import kr.co.yeogiga.infrastructure.place.PlaceSearchClient;

--- a/src/test/java/kr/co/yeogiga/presentation/place/controller/PlaceControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/place/controller/PlaceControllerTest.java
@@ -1,6 +1,6 @@
 package kr.co.yeogiga.presentation.place.controller;
 
-import kr.co.yeogiga.application.place.application.PlaceSearchService;
+import kr.co.yeogiga.application.place.PlaceSearchService;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.security.auth.CustomUserDetails;
 import kr.co.yeogiga.common.security.auth.CustomUserDetailsImpl;


### PR DESCRIPTION
## 배경
- 인기 급상승 여행지 조회 기능 필요
  - 공공데이터포털 장애로 인한 임시 조회 로직

## 작업 사항
- 급상승 여행지 엔티티 정의 및 조회 도메인 로직 구현 | (5e1f8144b01171c566f2d9118516585b35e6d3b2)
- 급상승 여행지 전체 조회 로직 구현 | (c196ce18cee33c1081474afa1d66fabb5b30cbb5)
- 급상승 여행지 전체 조회 api 구현 | (c1bed5d2e6f75564037634c3bf93f81a644cdbd3)

## 추가 논의
- 차후, 공공데이터포털 장애 복구 시 OpenAPI 적용 및 서비스 운영 기간 내 축척 데이터를 활용한 추천 여행지 시스템 도입 예정