### PR TITLE
Feature(IL-396): 비밀번호 찾기(초기화) 기능 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/auth/dto/PasswordResetDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/PasswordResetDto.java
@@ -15,4 +15,11 @@ public class PasswordResetDto {
             @NotBlank(message = "아이디는 필수 입력값입니다.")
             String username
     ) { }
+    
+    public record Reset(
+            String email,
+            String username,
+            String code,
+            String password
+    ) { }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/PasswordResetDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/PasswordResetDto.java
@@ -1,8 +1,15 @@
 package kr.co.yeogiga.application.auth.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 public class PasswordResetDto {
     public record Request(
+            @NotBlank(message = "이메일은 필수 입력값입니다.")
+            @Pattern(regexp = "^[\\w!#$%&'*+/=?`{|}~^.-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$", message = "잘못된 이메일 형식입니다.")
             String email,
+            
+            @NotBlank(message = "아이디는 필수 입력값입니다.")
             String username
     ) { }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/PasswordResetDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/PasswordResetDto.java
@@ -17,16 +17,20 @@ public class PasswordResetDto {
     ) { }
     
     public record Reset(
+            @Schema(description = "이메일", example = "test@test.com")
             @NotBlank(message = "이메일은 필수 입력값입니다.")
             @Pattern(regexp = "^[\\w!#$%&'*+/=?`{|}~^.-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$", message = "잘못된 이메일 형식입니다.")
             String email,
             
+            @Schema(description = "아이디", example = "testid")
             @NotBlank(message = "아이디는 필수 입력값입니다.")
             String username,
             
+            @Schema(description = "비밀번호 초기화 확인용 코드", example = "33322338-80e8-418f-a2aa-19d50241dd0c")
             @NotBlank(message = "비밀번호 초기화 확인용 코드는 필수 입력값입니다.")
             String code,
             
+            @Schema(description = "새 비밀번호", example = "newpassword")
             @NotBlank(message = "새 비밀번호는 필수 입력값입니다.")
             String password
     ) { }

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/PasswordResetDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/PasswordResetDto.java
@@ -1,14 +1,17 @@
 package kr.co.yeogiga.application.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public class PasswordResetDto {
     public record Request(
+            @Schema(description = "이메일", example = "test@test.com")
             @NotBlank(message = "이메일은 필수 입력값입니다.")
             @Pattern(regexp = "^[\\w!#$%&'*+/=?`{|}~^.-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$", message = "잘못된 이메일 형식입니다.")
             String email,
             
+            @Schema(description = "아이디", example = "testid")
             @NotBlank(message = "아이디는 필수 입력값입니다.")
             String username
     ) { }

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/PasswordResetDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/PasswordResetDto.java
@@ -17,9 +17,17 @@ public class PasswordResetDto {
     ) { }
     
     public record Reset(
+            @NotBlank(message = "이메일은 필수 입력값입니다.")
+            @Pattern(regexp = "^[\\w!#$%&'*+/=?`{|}~^.-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$", message = "잘못된 이메일 형식입니다.")
             String email,
+            
+            @NotBlank(message = "아이디는 필수 입력값입니다.")
             String username,
+            
+            @NotBlank(message = "비밀번호 초기화 확인용 코드는 필수 입력값입니다.")
             String code,
+            
+            @NotBlank(message = "새 비밀번호는 필수 입력값입니다.")
             String password
     ) { }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/dto/PasswordResetDto.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/dto/PasswordResetDto.java
@@ -1,0 +1,8 @@
+package kr.co.yeogiga.application.auth.dto;
+
+public class PasswordResetDto {
+    public record Request(
+            String email,
+            String username
+    ) { }
+}

--- a/src/main/java/kr/co/yeogiga/application/auth/service/PasswordManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/PasswordManagementService.java
@@ -1,0 +1,40 @@
+package kr.co.yeogiga.application.auth.service;
+
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.common.util.PasswordCodeGenerator;
+import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
+import kr.co.yeogiga.domain.auth.service.PasswordCodeService;
+import kr.co.yeogiga.domain.user.service.UserService;
+import kr.co.yeogiga.infrastructure.mail.PasswordResetEmailSender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PasswordManagementService {
+    private final UserService userService;
+    private final PasswordCodeService passwordCodeService;
+    private final PasswordResetEmailSender passwordResetEmailSender;
+    
+    /**
+     * 비밀번호 초기화 요청 메서드
+     *
+     * <p> 사용자 확인을 위한 확인용 코드 생성 및 저장
+     *
+     * <p> 해당 사용자에게 비밀번호 초기화 링크 메일 전송
+     *
+     * @param email     사용자 이메일
+     * @param username  사용자 아이디
+     * @throws CustomException AuthErrorType.MISMATCHED_EMAIL_OR_USERNAME - 이메일 또는 아이디가 불일치하는 경우
+     */
+    public void requestPasswordReset(String email, String username) {
+        if (!userService.existsIncludeDeletedByEmailAndUsername(email, username)) {
+            throw new CustomException(AuthErrorType.MISMATCHED_EMAIL_OR_USERNAME);
+        }
+        
+        String code = PasswordCodeGenerator.generate();
+        
+        passwordCodeService.save(email, code);
+        passwordResetEmailSender.send(email, code);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/auth/service/PasswordManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/PasswordManagementService.java
@@ -4,10 +4,13 @@ import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.util.PasswordCodeGenerator;
 import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
 import kr.co.yeogiga.domain.auth.service.PasswordCodeService;
+import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.service.UserService;
 import kr.co.yeogiga.infrastructure.mail.PasswordResetEmailSender;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +18,7 @@ public class PasswordManagementService {
     private final UserService userService;
     private final PasswordCodeService passwordCodeService;
     private final PasswordResetEmailSender passwordResetEmailSender;
+    private final PasswordEncoder passwordEncoder;
     
     /**
      * 비밀번호 초기화 요청 메서드
@@ -36,5 +40,32 @@ public class PasswordManagementService {
         
         passwordCodeService.save(email, code);
         passwordResetEmailSender.send(email, code);
+    }
+    
+    /**
+     * 비밀번호 초기화 메서드
+     *
+     * @param email         사용자 이메일
+     * @param username      사용자 아이디
+     * @param code          초기화 확인용 코드
+     * @param newPassword   새 비밀번호
+     */
+    @Transactional
+    public void resetPassword(String email, String username, String code, String newPassword) {
+        User user = userService.readIncludeDeletedUserByEmailAndUsername(email, username)
+                .orElseThrow(() -> new CustomException(AuthErrorType.MISMATCHED_EMAIL_OR_USERNAME));
+        
+        String savedCode = passwordCodeService.getCode(email);
+        
+        if (savedCode == null) {
+            throw new CustomException(AuthErrorType.PASSWORD_RESET_TIMEOUT);
+        }
+        
+        if (!savedCode.equals(code)) {
+            throw new CustomException(AuthErrorType.PASSWORD_CODE_MISMATCH);
+        }
+        
+        user.updatePassword(passwordEncoder.encode(newPassword));
+        passwordCodeService.del(email);
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/service/PasswordManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/PasswordManagementService.java
@@ -36,6 +36,10 @@ public class PasswordManagementService {
             throw new CustomException(AuthErrorType.MISMATCHED_EMAIL_OR_USERNAME);
         }
         
+        if (passwordCodeService.existsCode(email)) {
+            throw new CustomException(AuthErrorType.PASSWORD_RESET_TIME_LIMIT);
+        }
+        
         String code = PasswordCodeGenerator.generate();
         
         passwordCodeService.save(email, code);

--- a/src/main/java/kr/co/yeogiga/common/util/PasswordCodeGenerator.java
+++ b/src/main/java/kr/co/yeogiga/common/util/PasswordCodeGenerator.java
@@ -1,0 +1,9 @@
+package kr.co.yeogiga.common.util;
+
+import java.util.UUID;
+
+public class PasswordCodeGenerator {
+    public static String generate() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
@@ -30,7 +30,9 @@ public enum AuthErrorType implements BaseErrorType {
     EMAIL_VERIFICATION_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "A015", "이메일 인증 번호가 일치하지 않습니다."),
     EMAIL_VERIFICATION_TIME_LIMIT(HttpStatus.BAD_REQUEST, "A016", "이메일 인증 시도 횟수를 초과하였습니다. 잠시 후 시도해주세요."),
     
-    NOT_WITHDRAWN(HttpStatus.BAD_REQUEST, "A017", "탈퇴한 사용자가 아닙니다.");
+    NOT_WITHDRAWN(HttpStatus.BAD_REQUEST, "A017", "탈퇴한 사용자가 아닙니다."),
+    
+    MISMATCHED_EMAIL_OR_USERNAME(HttpStatus.BAD_REQUEST, "A018", "이메일 또는 아이디가 일치하지 않습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
@@ -34,7 +34,8 @@ public enum AuthErrorType implements BaseErrorType {
     
     MISMATCHED_EMAIL_OR_USERNAME(HttpStatus.BAD_REQUEST, "A018", "이메일 또는 아이디가 일치하지 않습니다."),
     PASSWORD_RESET_TIMEOUT(HttpStatus.BAD_REQUEST, "A019", "비밀번호 초기화 요청 시간이 초과하였습니다. 다시 시도해주세요."),
-    PASSWORD_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "A020", "비밀번호 초기화 인증 코드가 일치하지 않습니다.");
+    PASSWORD_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "A020", "비밀번호 초기화 인증 코드가 일치하지 않습니다."),
+    PASSWORD_RESET_TIME_LIMIT(HttpStatus.BAD_REQUEST, "A021", "비밀번호 초기화 요청 후 3분 이내 재요청은 불가능합니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/exception/AuthErrorType.java
@@ -32,7 +32,9 @@ public enum AuthErrorType implements BaseErrorType {
     
     NOT_WITHDRAWN(HttpStatus.BAD_REQUEST, "A017", "탈퇴한 사용자가 아닙니다."),
     
-    MISMATCHED_EMAIL_OR_USERNAME(HttpStatus.BAD_REQUEST, "A018", "이메일 또는 아이디가 일치하지 않습니다.");
+    MISMATCHED_EMAIL_OR_USERNAME(HttpStatus.BAD_REQUEST, "A018", "이메일 또는 아이디가 일치하지 않습니다."),
+    PASSWORD_RESET_TIMEOUT(HttpStatus.BAD_REQUEST, "A019", "비밀번호 초기화 요청 시간이 초과하였습니다. 다시 시도해주세요."),
+    PASSWORD_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "A020", "비밀번호 초기화 인증 코드가 일치하지 않습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/kr/co/yeogiga/domain/auth/repository/PasswordCodeCache.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/repository/PasswordCodeCache.java
@@ -24,6 +24,11 @@ public class PasswordCodeCache implements PasswordCodeRepository {
     }
     
     @Override
+    public boolean existsCode(String email) {
+        return redisRepository.existed(getPasswordCodeKey(email));
+    }
+    
+    @Override
     public void del(String email) {
         redisRepository.del(getPasswordCodeKey(email));
     }

--- a/src/main/java/kr/co/yeogiga/domain/auth/repository/PasswordCodeCache.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/repository/PasswordCodeCache.java
@@ -23,6 +23,11 @@ public class PasswordCodeCache implements PasswordCodeRepository {
         return (String) redisRepository.get(getPasswordCodeKey(email));
     }
     
+    @Override
+    public void del(String email) {
+        redisRepository.del(getPasswordCodeKey(email));
+    }
+    
     private String getPasswordCodeKey(String email) {
         return PASSWORD_CODE_KEY_FORMAT.formatted(email);
     }

--- a/src/main/java/kr/co/yeogiga/domain/auth/repository/PasswordCodeCache.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/repository/PasswordCodeCache.java
@@ -1,0 +1,29 @@
+package kr.co.yeogiga.domain.auth.repository;
+
+import kr.co.yeogiga.infrastructure.redis.RedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class PasswordCodeCache implements PasswordCodeRepository {
+    private final RedisRepository redisRepository;
+    private final Duration DURATION = Duration.ofMinutes(3);
+    private final String PASSWORD_CODE_KEY_FORMAT = "password-code:%s";
+    
+    @Override
+    public void save(String email, String code) {
+        redisRepository.set(getPasswordCodeKey(email), code, DURATION);
+    }
+    
+    @Override
+    public String getCode(String email) {
+        return (String) redisRepository.get(getPasswordCodeKey(email));
+    }
+    
+    private String getPasswordCodeKey(String email) {
+        return PASSWORD_CODE_KEY_FORMAT.formatted(email);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/auth/repository/PasswordCodeRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/repository/PasswordCodeRepository.java
@@ -2,8 +2,7 @@ package kr.co.yeogiga.domain.auth.repository;
 
 public interface PasswordCodeRepository {
     void save(String email, String code);
-    
     String getCode(String email);
-    
+    boolean existsCode(String email);
     void del(String email);
 }

--- a/src/main/java/kr/co/yeogiga/domain/auth/repository/PasswordCodeRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/repository/PasswordCodeRepository.java
@@ -1,0 +1,7 @@
+package kr.co.yeogiga.domain.auth.repository;
+
+public interface PasswordCodeRepository {
+    void save(String email, String code);
+    
+    String getCode(String email);
+}

--- a/src/main/java/kr/co/yeogiga/domain/auth/repository/PasswordCodeRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/repository/PasswordCodeRepository.java
@@ -4,4 +4,6 @@ public interface PasswordCodeRepository {
     void save(String email, String code);
     
     String getCode(String email);
+    
+    void del(String email);
 }

--- a/src/main/java/kr/co/yeogiga/domain/auth/service/PasswordCodeService.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/service/PasswordCodeService.java
@@ -16,4 +16,8 @@ public class PasswordCodeService {
     public String getCode(String email) {
         return passwordCodeRepository.getCode(email);
     }
+    
+    public void del(String email) {
+        passwordCodeRepository.del(email);
+    }
 }

--- a/src/main/java/kr/co/yeogiga/domain/auth/service/PasswordCodeService.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/service/PasswordCodeService.java
@@ -1,0 +1,19 @@
+package kr.co.yeogiga.domain.auth.service;
+
+import kr.co.yeogiga.domain.auth.repository.PasswordCodeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PasswordCodeService {
+    private final PasswordCodeRepository passwordCodeRepository;
+    
+    public void save(String email, String code) {
+        passwordCodeRepository.save(email, code);
+    }
+    
+    public String getCode(String email) {
+        return passwordCodeRepository.getCode(email);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/auth/service/PasswordCodeService.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/service/PasswordCodeService.java
@@ -17,6 +17,10 @@ public class PasswordCodeService {
         return passwordCodeRepository.getCode(email);
     }
     
+    public boolean existsCode(String email) {
+        return passwordCodeRepository.existsCode(email);
+    }
+    
     public void del(String email) {
         passwordCodeRepository.del(email);
     }

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepository.java
@@ -16,5 +16,6 @@ public interface CustomUserRepository {
     boolean existsIncludeDeletedByUsername(String username);
     boolean existsIncludeDeletedByNickname(String nickname);
     boolean existsIdIncludeDeletedByEmail(String email);
+    boolean existsIncludeDeletedByEmailAndUsername(String email, String username);
     void deleteHardAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepository.java
@@ -12,6 +12,7 @@ public interface CustomUserRepository {
     Optional<User> findUserIncludeDeletedById(Long id);
     Optional<User> findUserIncludeDeletedByNickname(String nickname);
     Optional<User> findUserIncludeDeletedByUsername(String username);
+    Optional<User> findUserIncludeDeletedByEmailAndUsername(String email, String username);
     List<Long> findDeletedUserIdBefore(LocalDate date);
     boolean existsIncludeDeletedByUsername(String username);
     boolean existsIncludeDeletedByNickname(String nickname);

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepositoryImpl.java
@@ -132,6 +132,22 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
     }
     
     @Override
+    public Optional<User> findUserIncludeDeletedByEmailAndUsername(String email, String username) {
+        JPASQLQuery<Tuple> jpaSqlQuery = new JPASQLQuery<>(entityManager, sqlTemplates);
+        
+        return Optional.ofNullable(
+                jpaSqlQuery
+                        .select(USER_ENTITY_PATH)
+                        .from(USER_ENTITY_PATH)
+                        .where(
+                                Expressions.stringPath(USER_ENTITY_PATH, USER_COLUMN.EMAIL).eq(email),
+                                Expressions.stringPath(USER_ENTITY_PATH, USER_COLUMN.USERNAME).eq(username)
+                        )
+                        .fetchOne()
+        );
+    }
+    
+    @Override
     public List<Long> findDeletedUserIdBefore(LocalDate date) {
         JPASQLQuery<Tuple> jpaSqlQuery = new JPASQLQuery<>(entityManager, sqlTemplates);
         

--- a/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/repository/CustomUserRepositoryImpl.java
@@ -197,6 +197,22 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
     }
     
     @Override
+    public boolean existsIncludeDeletedByEmailAndUsername(String email, String username) {
+        JPASQLQuery<Tuple> jpaSqlQuery = new JPASQLQuery<>(entityManager, sqlTemplates);
+        
+        Integer fetchOne = jpaSqlQuery
+                .select(Expressions.ONE)
+                .from(USER_ENTITY_PATH)
+                .where(
+                        Expressions.stringPath(USER_ENTITY_PATH, USER_COLUMN.EMAIL).eq(email),
+                        Expressions.stringPath(USER_ENTITY_PATH, USER_COLUMN.USERNAME).eq(username)
+                )
+                .fetchFirst();
+        
+        return fetchOne != null;
+    }
+    
+    @Override
     public void deleteHardAllByIdIn(List<Long> ids) {
         jpaQueryFactory
                 .delete(user)

--- a/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
@@ -65,6 +65,10 @@ public class UserService {
     public boolean existsIncludeDeletedByEmail(String email) {
         return userRepository.existsIdIncludeDeletedByEmail(email);
     }
+    
+    public boolean existsIncludeDeletedByEmailAndUsername(String email, String username) {
+        return userRepository.existsIncludeDeletedByEmailAndUsername(email, username);
+    }
 
     public void deleteById(Long userId) {
         userRepository.deleteById(userId);

--- a/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/yeogiga/domain/user/service/UserService.java
@@ -42,6 +42,10 @@ public class UserService {
     public Optional<User> readIncludeDeletedUserByPlatformAndPlatformId(OAuthPlatform platform, String platformId) {
         return userRepository.findUserIncludeDeletedByPlatformAndPlatformId(platform.name(), platformId);
     }
+    
+    public Optional<User> readIncludeDeletedUserByEmailAndUsername(String email, String username) {
+        return userRepository.findUserIncludeDeletedByEmailAndUsername(email, username);
+    }
 
     public List<Long> readDeletedUserIdBefore(LocalDate date) {
         return userRepository.findDeletedUserIdBefore(date);

--- a/src/main/java/kr/co/yeogiga/infrastructure/mail/AbstractEmailSender.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/mail/AbstractEmailSender.java
@@ -1,0 +1,22 @@
+package kr.co.yeogiga.infrastructure.mail;
+
+import lombok.RequiredArgsConstructor;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@RequiredArgsConstructor
+public abstract class AbstractEmailSender {
+    private final JavaEmailSender javaEmailSender;
+    private final TemplateEngine templateEngine;
+    
+    private final String LOGO_NAME = "logo";
+    private final String LOGO_LOCATION = "static/images/logo.png";
+    
+    protected void send(String email, String subject, String template, Context context) {
+        String html = templateEngine.process(template, context);
+        
+        Content content = new Content(LOGO_NAME, LOGO_LOCATION);
+        
+        javaEmailSender.send(email, subject, html, content);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/mail/PasswordResetEmailSender.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/mail/PasswordResetEmailSender.java
@@ -1,0 +1,37 @@
+package kr.co.yeogiga.infrastructure.mail;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@Component
+@RequiredArgsConstructor
+public class PasswordResetEmailSender {
+    @Value("${mail.password-reset-url}")
+    private String passwordResetUrl;
+    
+    private final JavaEmailSender javaEmailSender;
+    private final TemplateEngine templateEngine;
+    
+    private final String SUBJECT = "[여기가] 비밀번호 초기화";
+    private final String PASSWORD_RESET_URL_VARIABLE_NAME = "password_reset_url";
+    private final String PASSWORD_RESET_TEMPLATE_NAME = "password-reset-template";
+    private final String LOGO_NAME = "logo";
+    private final String LOGO_LOCATION = "static/images/logo.png";
+    
+    public void send(String email, String code) {
+        Context context = new Context();
+        context.setVariable(PASSWORD_RESET_URL_VARIABLE_NAME, generateUrl(code));
+        
+        String html = templateEngine.process(PASSWORD_RESET_TEMPLATE_NAME, context);
+        Content content = new Content(LOGO_NAME, LOGO_LOCATION);
+        
+        javaEmailSender.send(email, SUBJECT, html, content);
+    }
+    
+    private String generateUrl(String code) {
+        return passwordResetUrl + "?code=" + code;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/mail/PasswordResetEmailSender.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/mail/PasswordResetEmailSender.java
@@ -1,34 +1,34 @@
 package kr.co.yeogiga.infrastructure.mail;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
 @Component
-@RequiredArgsConstructor
-public class PasswordResetEmailSender {
+public class PasswordResetEmailSender extends AbstractEmailSender {
     @Value("${mail.password-reset-url}")
     private String passwordResetUrl;
     
-    private final JavaEmailSender javaEmailSender;
-    private final TemplateEngine templateEngine;
+    public PasswordResetEmailSender(
+            JavaEmailSender javaEmailSender,
+            TemplateEngine templateEngine,
+            @Value("${mail.password-reset-url}")
+            String passwordResetUrl
+    ) {
+        super(javaEmailSender, templateEngine);
+        this.passwordResetUrl = passwordResetUrl;
+    }
     
     private final String SUBJECT = "[여기가] 비밀번호 초기화";
     private final String PASSWORD_RESET_URL_VARIABLE_NAME = "password_reset_url";
     private final String PASSWORD_RESET_TEMPLATE_NAME = "password-reset-template";
-    private final String LOGO_NAME = "logo";
-    private final String LOGO_LOCATION = "static/images/logo.png";
     
     public void send(String email, String code) {
         Context context = new Context();
         context.setVariable(PASSWORD_RESET_URL_VARIABLE_NAME, generateUrl(code));
         
-        String html = templateEngine.process(PASSWORD_RESET_TEMPLATE_NAME, context);
-        Content content = new Content(LOGO_NAME, LOGO_LOCATION);
-        
-        javaEmailSender.send(email, SUBJECT, html, content);
+        super.send(email, SUBJECT, PASSWORD_RESET_TEMPLATE_NAME, context);
     }
     
     private String generateUrl(String code) {

--- a/src/main/java/kr/co/yeogiga/infrastructure/mail/VerificationCodeEmailSender.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/mail/VerificationCodeEmailSender.java
@@ -1,29 +1,23 @@
 package kr.co.yeogiga.infrastructure.mail;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
 @Component
-@RequiredArgsConstructor
-public class VerificationCodeEmailSender {
-    private final JavaEmailSender javaEmailSender;
-    private final TemplateEngine templateEngine;
+public class VerificationCodeEmailSender extends AbstractEmailSender {
+    public VerificationCodeEmailSender(JavaEmailSender javaEmailSender, TemplateEngine templateEngine) {
+        super(javaEmailSender, templateEngine);
+    }
     
     private final String SUBJECT = "[여기가] 이메일 인증 코드";
     private final String CODE_VARIABLE_NAME = "code";
     private final String EMAIL_VERIFICATION_CODE_TEMPLATE_NAME = "email-verification-code-template";
-    private final String LOGO_NAME = "logo";
-    private final String LOGO_LOCATION = "static/images/logo.png";
     
     public void send(String email, String code) {
         Context context = new Context();
         context.setVariable(CODE_VARIABLE_NAME, code);
         
-        String html = templateEngine.process(EMAIL_VERIFICATION_CODE_TEMPLATE_NAME, context);
-        Content content = new Content(LOGO_NAME, LOGO_LOCATION);
-        
-        javaEmailSender.send(email, SUBJECT, html, content);
+        super.send(email, SUBJECT, EMAIL_VERIFICATION_CODE_TEMPLATE_NAME, context);
     }
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/PasswordApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/PasswordApi.java
@@ -1,0 +1,46 @@
+package kr.co.yeogiga.presentation.auth.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.co.yeogiga.application.auth.dto.PasswordResetDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@ApiGroup(value = "[비밀번호 API]")
+@Tag(name = "[비밀번호 API]", description = "비밀번호 관련 API")
+public interface PasswordApi {
+    
+    @TrackApi(description = "비밀번호 초기화 요청")
+    @Operation(summary = "비밀번호 초기화 요청", description = "비밀번호 초기화 요청 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "비밀번호 초기화 요청 성공, 성공 후 해당 이메일로 비밀번호 초기화 메일 발송",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "비밀번호 초기화 요청 성공", value = """
+                                        {
+                                             "code": 200,
+                                             "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "비밀번호 초기화 요청 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "유효성 검증 실패", value = """
+                                        {
+                                            "code": "G002",
+                                            "errors": {
+                                                "email": "잘못된 이메일 형식입니다.",
+                                                "username": "아이디는 필수 입력값입니다."
+                                            }
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> requestPasswordReset(@Valid @RequestBody PasswordResetDto.Request request);
+}

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/PasswordApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/PasswordApi.java
@@ -39,6 +39,12 @@ public interface PasswordApi {
                                                 "username": "아이디는 필수 입력값입니다."
                                             }
                                         }
+                                    """),
+                            @ExampleObject(name = "시간 내 비밀번호 초기화 요청 횟수 초과", value = """
+                                        {
+                                            "code": "A021",
+                                            "message": "비밀번호 초기화 요청 후 3분 이내 재요청은 불가능합니다."
+                                        }
                                     """)
                     }))
     })

--- a/src/main/java/kr/co/yeogiga/presentation/auth/api/PasswordApi.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/api/PasswordApi.java
@@ -43,4 +43,43 @@ public interface PasswordApi {
                     }))
     })
     ResponseEntity<?> requestPasswordReset(@Valid @RequestBody PasswordResetDto.Request request);
+    
+    @TrackApi(description = "비밀번호 초기화")
+    @Operation(summary = "비밀번호 초기화", description = "비밀번호 초기화 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "비밀번호 초기화 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "비밀번호 초기화 성공", value = """
+                                        {
+                                             "code": 200,
+                                             "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "비밀번호 초기화 요청 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "유효성 검증 실패", value = """
+                                        {
+                                            "code": "G002",
+                                            "errors": {
+                                                "email": "잘못된 이메일 형식입니다.",
+                                                "username": "아이디는 필수 입력값입니다."
+                                            }
+                                        }
+                                    """),
+                            @ExampleObject(name = "비밀번호 초기화 시간 초과", value = """
+                                        {
+                                             "code": "A019",
+                                             "message": "비밀번호 초기화 요청 시간이 초과하였습니다. 다시 시도해주세요."
+                                         }
+                                    """),
+                            @ExampleObject(name = "비밀번호 확인용 코드 불일치", value = """
+                                        {
+                                             "code": "A020",
+                                             "message": "비밀번호 초기화 인증 코드가 일치하지 않습니다."
+                                         }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> resetPassword(@Valid @RequestBody PasswordResetDto.Reset request);
 }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/PasswordController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/PasswordController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import kr.co.yeogiga.application.auth.dto.PasswordResetDto;
 import kr.co.yeogiga.application.auth.service.PasswordManagementService;
 import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.presentation.auth.api.PasswordApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,9 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
-public class PasswordController {
+public class PasswordController implements PasswordApi {
     private final PasswordManagementService passwordManagementService;
     
+    @Override
     @PostMapping("/password/reset")
     public ResponseEntity<?> requestPasswordReset(@Valid @RequestBody PasswordResetDto.Request request) {
         passwordManagementService.requestPasswordReset(request.email(), request.username());

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/PasswordController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/PasswordController.java
@@ -7,6 +7,7 @@ import kr.co.yeogiga.common.response.success.SuccessResponse;
 import kr.co.yeogiga.presentation.auth.api.PasswordApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +23,13 @@ public class PasswordController implements PasswordApi {
     @PostMapping("/password/reset")
     public ResponseEntity<?> requestPasswordReset(@Valid @RequestBody PasswordResetDto.Request request) {
         passwordManagementService.requestPasswordReset(request.email(), request.username());
+        
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+    
+    @PatchMapping("/password/reset")
+    public ResponseEntity<?> resetPassword(@Valid @RequestBody PasswordResetDto.Reset request) {
+        passwordManagementService.resetPassword(request.email(), request.username(), request.code(), request.password());
         
         return ResponseEntity.ok(SuccessResponse.ok());
     }

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/PasswordController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/PasswordController.java
@@ -1,0 +1,26 @@
+package kr.co.yeogiga.presentation.auth.controller;
+
+import jakarta.validation.Valid;
+import kr.co.yeogiga.application.auth.dto.PasswordResetDto;
+import kr.co.yeogiga.application.auth.service.PasswordManagementService;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class PasswordController {
+    private final PasswordManagementService passwordManagementService;
+    
+    @PostMapping("/password/reset")
+    public ResponseEntity<?> requestPasswordReset(@Valid @RequestBody PasswordResetDto.Request request) {
+        passwordManagementService.requestPasswordReset(request.email(), request.username());
+        
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+}

--- a/src/main/java/kr/co/yeogiga/presentation/auth/controller/PasswordController.java
+++ b/src/main/java/kr/co/yeogiga/presentation/auth/controller/PasswordController.java
@@ -27,6 +27,7 @@ public class PasswordController implements PasswordApi {
         return ResponseEntity.ok(SuccessResponse.ok());
     }
     
+    @Override
     @PatchMapping("/password/reset")
     public ResponseEntity<?> resetPassword(@Valid @RequestBody PasswordResetDto.Reset request) {
         passwordManagementService.resetPassword(request.email(), request.username(), request.code(), request.password());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,6 +68,8 @@ spring:
         auth: true
         starttls:
           enable: true
+mail:
+  password-reset-url: ${PASSWORD_RESET_URL}
 
 --- # map
 map:

--- a/src/main/resources/templates/password-reset-template.html
+++ b/src/main/resources/templates/password-reset-template.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body style="margin: 0; padding: 0; display: flex; justify-content: center; align-content: center;">
+<div style="display: flex; justify-content: center">
+    <div style="border-radius: 6px; border: 1px solid #F0F0F0; padding: 40px 30px; max-width: 420px;">
+        <div style="margin-bottom: 30px;">
+            <img src="cid:logo" alt="yeogiga-logo">
+        </div>
+
+        <div style="font-weight: bold; font-size: 32px; margin-bottom: 30px;">
+            비밀번호 재설정을<br/>
+            진행해주세요.
+        </div>
+
+        <div style="margin-bottom: 50px; line-height: 1.5em;">
+            아래 링크를 통해 접속한 뒤, 새로운 비밀번호를 설정해주세요.
+        </div>
+
+        <div style="margin-bottom: 50px;">
+            <a
+                    th:href="@{password_reset_url}"
+                    th:text="${password_reset_url}"
+            >
+            </a>
+        </div>
+
+        <div style="line-height: 1.5em; color: #888888">
+            • 해당 링크를 통한 변경은 3분 동안 유효합니다.<br/>
+            • 본 메일은 발신 전용입니다.
+        </div>
+
+        <div style="text-align: right; color: #444444">
+            일로만난사이
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/test/java/kr/co/yeogiga/application/auth/service/PasswordManagementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/PasswordManagementServiceTest.java
@@ -1,0 +1,75 @@
+package kr.co.yeogiga.application.auth.service;
+
+import kr.co.yeogiga.common.exception.CustomException;
+import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
+import kr.co.yeogiga.domain.auth.service.PasswordCodeService;
+import kr.co.yeogiga.domain.user.service.UserService;
+import kr.co.yeogiga.infrastructure.mail.PasswordResetEmailSender;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class PasswordManagementServiceTest {
+    @Mock
+    private UserService userService;
+    
+    @Mock
+    private PasswordCodeService passwordCodeService;
+    
+    @Mock
+    private PasswordResetEmailSender passwordResetEmailSender;
+    
+    @InjectMocks
+    private PasswordManagementService passwordManagementService;
+    
+    @Nested
+    @DisplayName("패스워드 초기화 요청")
+    class RequestPasswordReset {
+        private final String email = "test@test.com";
+        private final String username = "test";
+        
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            when(userService.existsIncludeDeletedByEmailAndUsername(email, username)).thenReturn(true);
+            doNothing().when(passwordCodeService).save(eq(email), anyString());
+            doNothing().when(passwordResetEmailSender).send(eq(email), anyString());
+            
+            // when
+            passwordManagementService.requestPasswordReset(email, username);
+            
+            // then
+            verify(passwordCodeService, times(1)).save(eq(email), anyString());
+            verify(passwordResetEmailSender, times(1)).send(eq(email), anyString());
+        }
+        
+        @Test
+        @DisplayName("실패 - 이메일 또는 아이디가 불일치하는 경우")
+        void failIfEmailOrPasswordMismatch() {
+            // given
+            when(userService.existsIncludeDeletedByEmailAndUsername(email, username)).thenReturn(false);
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> passwordManagementService.requestPasswordReset(email, username));
+            
+            // then
+            assertEquals(AuthErrorType.MISMATCHED_EMAIL_OR_USERNAME, exception.getErrorType());
+        }
+    }
+}

--- a/src/test/java/kr/co/yeogiga/application/auth/service/PasswordManagementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/PasswordManagementServiceTest.java
@@ -45,7 +45,7 @@ public class PasswordManagementServiceTest {
     private PasswordManagementService passwordManagementService;
     
     @Nested
-    @DisplayName("패스워드 초기화 요청")
+    @DisplayName("비밀번호 초기화 요청")
     class RequestPasswordReset {
         private final String email = "test@test.com";
         private final String username = "test";
@@ -55,6 +55,7 @@ public class PasswordManagementServiceTest {
         void success() {
             // given
             when(userService.existsIncludeDeletedByEmailAndUsername(email, username)).thenReturn(true);
+            when(passwordCodeService.existsCode(email)).thenReturn(false);
             doNothing().when(passwordCodeService).save(eq(email), anyString());
             doNothing().when(passwordResetEmailSender).send(eq(email), anyString());
             
@@ -64,6 +65,21 @@ public class PasswordManagementServiceTest {
             // then
             verify(passwordCodeService, times(1)).save(eq(email), anyString());
             verify(passwordResetEmailSender, times(1)).send(eq(email), anyString());
+        }
+        
+        @Test
+        @DisplayName("실패 - 최초 요청 후 시간 내 재요청한 경우")
+        void failBecausePasswordResetTimeLimit() {
+            // given
+            when(userService.existsIncludeDeletedByEmailAndUsername(email, username)).thenReturn(true);
+            when(passwordCodeService.existsCode(email)).thenReturn(true);
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> passwordManagementService.requestPasswordReset(email, username));
+            
+            // then
+            assertEquals(AuthErrorType.PASSWORD_RESET_TIME_LIMIT, exception.getErrorType());
         }
         
         @Test

--- a/src/test/java/kr/co/yeogiga/application/auth/service/PasswordManagementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/PasswordManagementServiceTest.java
@@ -3,6 +3,7 @@ package kr.co.yeogiga.application.auth.service;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
 import kr.co.yeogiga.domain.auth.service.PasswordCodeService;
+import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.service.UserService;
 import kr.co.yeogiga.infrastructure.mail.PasswordResetEmailSender;
 import org.junit.jupiter.api.DisplayName;
@@ -12,6 +13,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -32,6 +37,9 @@ public class PasswordManagementServiceTest {
     
     @Mock
     private PasswordResetEmailSender passwordResetEmailSender;
+    
+    @Mock
+    private PasswordEncoder passwordEncoder;
     
     @InjectMocks
     private PasswordManagementService passwordManagementService;
@@ -70,6 +78,79 @@ public class PasswordManagementServiceTest {
             
             // then
             assertEquals(AuthErrorType.MISMATCHED_EMAIL_OR_USERNAME, exception.getErrorType());
+        }
+    }
+    
+    @Nested
+    @DisplayName("비밀번호 초기화")
+    class ResetPassword {
+        private final String email = "test@test.com";
+        private final String username = "username";
+        private final String code = UUID.randomUUID().toString();
+        private final String newPassword = "newPassword";
+        
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            User user = User.builder().build();
+            String encryptedPassword = "encrypted-newPassword";
+            when(userService.readIncludeDeletedUserByEmailAndUsername(email, username)).thenReturn(Optional.of(user));
+            when(passwordCodeService.getCode(email)).thenReturn(code);
+            when(passwordEncoder.encode(newPassword)).thenReturn(encryptedPassword);
+            doNothing().when(passwordCodeService).del(email);
+            
+            // then
+            passwordManagementService.resetPassword(email, username, code, newPassword);
+            
+            // then
+            assertEquals(encryptedPassword, user.getPassword());
+        }
+        
+        @Test
+        @DisplayName("실패 - 이메일 또는 아이디 불일치")
+        void failIfEmailAndUsernameMismatch() {
+            // given
+            when(userService.readIncludeDeletedUserByEmailAndUsername(email, username)).thenReturn(Optional.empty());
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> passwordManagementService.resetPassword(email, username, code, newPassword));
+            
+            // then
+            assertEquals(AuthErrorType.MISMATCHED_EMAIL_OR_USERNAME, exception.getErrorType());
+        }
+        
+        @Test
+        @DisplayName("실패 - 비밀번호 초기화 인증 시간 초과")
+        void failIfPasswordResetTimeout() {
+            // given
+            User user = User.builder().build();
+            when(userService.readIncludeDeletedUserByEmailAndUsername(email, username)).thenReturn(Optional.of(user));
+            when(passwordCodeService.getCode(email)).thenReturn(null);
+            
+            // when
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> passwordManagementService.resetPassword(email, username, code, newPassword));
+            
+            // then
+            assertEquals(AuthErrorType.PASSWORD_RESET_TIMEOUT, exception.getErrorType());
+        }
+        
+        @Test
+        @DisplayName("실패 - 비밀번호 초기화 확인용 코드 불일치")
+        void failIfPasswordCodeMismatch() {
+            // given
+            User user = User.builder().build();
+            when(userService.readIncludeDeletedUserByEmailAndUsername(email, username)).thenReturn(Optional.of(user));
+            when(passwordCodeService.getCode(email)).thenReturn("mismatch-password");
+            
+            // then
+            CustomException exception = assertThrows(CustomException.class, ()
+                    -> passwordManagementService.resetPassword(email, username, code, newPassword));
+            
+            // then
+            assertEquals(AuthErrorType.PASSWORD_CODE_MISMATCH, exception.getErrorType());
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/auth/controller/PasswordControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/auth/controller/PasswordControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -96,6 +97,59 @@ public class PasswordControllerTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.errors.email").exists())
                     .andExpect(jsonPath("$.errors.username").doesNotExist());
+        }
+    }
+    
+    @Nested
+    @DisplayName("비밀번호 초기화")
+    class ResetPassword {
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            String email = "test@test.com";
+            String username = "test";
+            String code = "code";
+            String password = "password";
+            PasswordResetDto.Reset request = new PasswordResetDto.Reset(email, username, code, password);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    patch("/api/v1/auth/password/reset")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
+        
+        @Test
+        @DisplayName("실패 - 유효성 검증 실패")
+        void failValidation() throws Exception {
+            // given
+            String email = "test@testcom";
+            String username = "";
+            String code = "code";
+            String password = "password";
+            PasswordResetDto.Reset request = new PasswordResetDto.Reset(email, username, code, password);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    patch("/api/v1/auth/password/reset")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors.email").exists())
+                    .andExpect(jsonPath("$.errors.username").exists())
+                    .andExpect(jsonPath("$.errors.code").doesNotExist())
+                    .andExpect(jsonPath("$.errors.password").doesNotExist());
         }
     }
 }

--- a/src/test/java/kr/co/yeogiga/presentation/auth/controller/PasswordControllerTest.java
+++ b/src/test/java/kr/co/yeogiga/presentation/auth/controller/PasswordControllerTest.java
@@ -1,0 +1,101 @@
+package kr.co.yeogiga.presentation.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.application.auth.dto.PasswordResetDto;
+import kr.co.yeogiga.application.auth.service.PasswordManagementService;
+import kr.co.yeogiga.common.response.success.SuccessResponse;
+import kr.co.yeogiga.common.security.filter.JwtAuthenticationFilter;
+import kr.co.yeogiga.infrastructure.config.security.SecurityConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = PasswordController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, JwtAuthenticationFilter.class})
+        }
+)
+public class PasswordControllerTest {
+    private MockMvc mockMvc;
+    
+    @MockBean
+    private PasswordManagementService passwordManagementService;
+    
+    @Autowired
+    private ObjectMapper objectMapper;
+    
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .alwaysDo(print())
+                .build();
+    }
+    
+    @Nested
+    @DisplayName("비밀번호 초기화 요청")
+    class RequestPasswordReset {
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            String email = "test@test.com";
+            String username = "test";
+            
+            PasswordResetDto.Request request = new PasswordResetDto.Request(email, username);
+            doNothing().when(passwordManagementService).requestPasswordReset(email, username);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/password/reset")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value(SuccessResponse.ok().message()));
+        }
+        
+        @Test
+        @DisplayName("실패 - 유효성 검증")
+        void failValidation() throws Exception {
+            // given
+            String email = "";
+            String username = "test";
+            PasswordResetDto.Request request = new PasswordResetDto.Request(email, username);
+            
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/password/reset")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request))
+            );
+            
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors.email").exists())
+                    .andExpect(jsonPath("$.errors.username").doesNotExist());
+        }
+    }
+}


### PR DESCRIPTION
## 배경
- 비밀번호 찾기 기능 필요

## 작업 사항
1. 비밀번호 초기화 요청 메일 발송 기능
    - 비밀번호 초기화 url 프로퍼티 설정 | (d2c3a373f1d9350264341fd807a586f8dcc9c03e)
    - 비밀번호 초기화 요청 이메일 템플릿 작성 | (e40c18a160ad440ee81d33334dcde695f99df90d)
    - 비밀번호 초기화 확인용 코드 도메인 로직 작성 | (f4e0a5ff57b09aec7ef99098b7b1dabb07ee835f)
    - 비밀번호 초기화 코드 생성 유틸 클래스 작성 | (2397ed1e44769e0285fdd377596ef2c6509e89a9)
    - 이메일, 아이디를 통한 사용자 존재 여부 조회 도메인 로직 추가 | (b4cff56670778592ad8c7b772ee5804335f34370) (d1c79a081c8a945b598e5d1821438d79cb0f4468)
    - 비밀번호 초기화 요청 메일 발송 클래스 추가 | (b4dec6939b77edacd0aed71a6bfc7c597b15f794)
    - 비밀번호 초기화 요청 로직 구현 | (babe38caacee3580720a6c9bd590fe5082dff49c)
    - 비밀번호 초기화 요청 api 구현 | (fb2fd8acb39af589ebf4f62e889e5650b824f1ad)

2. 비밀번호 초기화 로직
    - 이메일, 아이디를 통한 사용자 조회 도메인 로직 추가 | (273b1eae2280907b883f7e2a721753963b8391b6)
    - 비밀번호 초기화 확인용 코드 삭제 도메인 로직 추가 | (727a3bcfba720c99c7bf738f47d8026d19323e2a)
    - 비밀번호 초기화 로직 구현 | (a4aa867b542c75b8eeebc8b37731339a58fe5362)
    - 비밀번호 초기화 api 구현 | (52d4420eefbdee938bd53be7da2457036f5aed4a)

3. `(1) 비밀번호 초기화 요청 메일 발송 기능`에 시간 내 초기화 요청 메일 발송 제한 로직 추가
    - 비밀번호 초기화 확인용 코드 존재 여부 확인 도메인 로직 추가 (72036aea5729206a1049e1081d9acb2eca2f59a8)
    - 비밀번호 초기화 요청 로직 내 시간 내 재요청 제한 로직 추가 | (8f06077cbe7dfd3d572e015b56c91b522cf95fc7)

4. 이메일 발송 클래스 내 공통 로직 분리
    - 이메일 발송 클래스 내 공통 로직 분리 | (a5114ac72cf5ddffb30022b53e0118c6d2c891aa)

## 예시
<img width="1655" height="743" alt="image" src="https://github.com/user-attachments/assets/9c560636-cd90-4ef3-a10e-897eca682d0a" />


## 추가 논의
- 현재는 간단하게 공통 로직 정도만 분리 해놓고 구조를 간단하게 해놓은 상태입니다. 차후, 더 나은 구조 및 적용할 추가 로직(아웃박스 패턴 등) 등 고려해보고 적용하도록 하겠습니다.