### PR TITLE
Fix: 비밀번호 초기화 링크 오류 수정

### DIFF
--- a/src/main/resources/templates/password-reset-template.html
+++ b/src/main/resources/templates/password-reset-template.html
@@ -22,7 +22,7 @@
 
         <div style="margin-bottom: 50px;">
             <a
-                    th:href="@{{password_reset_url}(password_reset_url=${password_reset_url})}"
+                    th:href="${password_reset_url}"
                     th:text="${password_reset_url}"
             >
             </a>


### PR DESCRIPTION
## 배경
- 비밀번호 초기화 링크 내 쿼리 스트링 시작부 오류 발견
  - `?` 구분자가 `%3f`로 인코딩 되어 출력

## 작업 사항
- 비밀번호 초기화 링크 매핑 방식 변경 | (fbda90f2f52360a19ae5b4cec082714803177212)