### PR TITLE
Feature: 이메일 발송 로직 분리 및 Spring Event 기반 비동기 처리 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,9 @@ dependencies {
 
     /* Sentry */
     implementation 'io.sentry:sentry-spring-boot-starter-jakarta:8.21.0'
+
+    /* ULID */
+    implementation 'com.github.f4b6a3:ulid-creator:5.2.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/co/yeogiga/application/auth/event/EmailVerificationEvent.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/event/EmailVerificationEvent.java
@@ -1,0 +1,16 @@
+package kr.co.yeogiga.application.auth.event;
+
+import kr.co.yeogiga.domain.event.DomainEvent;
+import lombok.Getter;
+
+@Getter
+public class EmailVerificationEvent extends DomainEvent {
+    private final String email;
+    private final String code;
+    
+    public EmailVerificationEvent(String email, String code) {
+        super();
+        this.email = email;
+        this.code = code;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/auth/event/PasswordResetEvent.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/event/PasswordResetEvent.java
@@ -1,0 +1,16 @@
+package kr.co.yeogiga.application.auth.event;
+
+import kr.co.yeogiga.domain.event.DomainEvent;
+import lombok.Getter;
+
+@Getter
+public class PasswordResetEvent extends DomainEvent {
+    private final String email;
+    private final String code;
+    
+    public PasswordResetEvent(String email, String code) {
+        super();
+        this.email = email;
+        this.code = code;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/auth/event/listener/EmailVerificationEventEmailListener.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/event/listener/EmailVerificationEventEmailListener.java
@@ -1,0 +1,26 @@
+package kr.co.yeogiga.application.auth.event.listener;
+
+import kr.co.yeogiga.application.auth.event.EmailVerificationEvent;
+import kr.co.yeogiga.application.event.listener.DomainEventListener;
+import kr.co.yeogiga.infrastructure.mail.VerificationCodeEmailSender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static kr.co.yeogiga.infrastructure.config.AsyncConfig.EMAIL_TASK_EXECUTOR;
+
+@Component
+@RequiredArgsConstructor
+public class EmailVerificationEventEmailListener extends DomainEventListener<EmailVerificationEvent> {
+    private final VerificationCodeEmailSender verificationCodeEmailSender;
+    
+    @Override
+    @Async(value = EMAIL_TASK_EXECUTOR)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleEvent(EmailVerificationEvent event) {
+        verificationCodeEmailSender.send(event.getEmail(), event.getCode());
+        // TODO: Transactional Outbox Pattern 적용 시, 이벤트 상태 변경 로직 추가 필요
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/auth/event/listener/PasswordResetEventEmailListener.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/event/listener/PasswordResetEventEmailListener.java
@@ -1,0 +1,26 @@
+package kr.co.yeogiga.application.auth.event.listener;
+
+import kr.co.yeogiga.application.auth.event.PasswordResetEvent;
+import kr.co.yeogiga.application.event.listener.DomainEventListener;
+import kr.co.yeogiga.infrastructure.mail.PasswordResetEmailSender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static kr.co.yeogiga.infrastructure.config.AsyncConfig.EMAIL_TASK_EXECUTOR;
+
+@Component
+@RequiredArgsConstructor
+public class PasswordResetEventEmailListener extends DomainEventListener<PasswordResetEvent> {
+    private final PasswordResetEmailSender passwordResetEmailSender;
+    
+    @Override
+    @Async(value = EMAIL_TASK_EXECUTOR)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleEvent(PasswordResetEvent event) {
+        passwordResetEmailSender.send(event.getEmail(), event.getCode());
+        // TODO: Transactional Outbox Pattern 적용 시, 이벤트 상태 변경 로직 추가 필요
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/auth/service/PasswordManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/PasswordManagementService.java
@@ -1,12 +1,13 @@
 package kr.co.yeogiga.application.auth.service;
 
+import kr.co.yeogiga.application.auth.event.PasswordResetEvent;
+import kr.co.yeogiga.application.event.publisher.DomainEventPublisher;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.util.PasswordCodeGenerator;
 import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
 import kr.co.yeogiga.domain.auth.service.PasswordCodeService;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.service.UserService;
-import kr.co.yeogiga.infrastructure.mail.PasswordResetEmailSender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -17,8 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class PasswordManagementService {
     private final UserService userService;
     private final PasswordCodeService passwordCodeService;
-    private final PasswordResetEmailSender passwordResetEmailSender;
     private final PasswordEncoder passwordEncoder;
+    private final DomainEventPublisher eventPublisher;
     
     /**
      * 비밀번호 초기화 요청 메서드
@@ -27,23 +28,26 @@ public class PasswordManagementService {
      *
      * <p> 해당 사용자에게 비밀번호 초기화 링크 메일 전송
      *
+     * <p> 최종적으로 비밀번호 초기화 요청 이벤트 발행
+     *
      * @param email     사용자 이메일
      * @param username  사용자 아이디
      * @throws CustomException AuthErrorType.MISMATCHED_EMAIL_OR_USERNAME - 이메일 또는 아이디가 불일치하는 경우
      */
+    @Transactional
     public void requestPasswordReset(String email, String username) {
         if (!userService.existsIncludeDeletedByEmailAndUsername(email, username)) {
             throw new CustomException(AuthErrorType.MISMATCHED_EMAIL_OR_USERNAME);
         }
-        
+
         if (passwordCodeService.existsCode(email)) {
             throw new CustomException(AuthErrorType.PASSWORD_RESET_TIME_LIMIT);
         }
         
         String code = PasswordCodeGenerator.generate();
-        
         passwordCodeService.save(email, code);
-        passwordResetEmailSender.send(email, code);
+        
+        eventPublisher.publish(new PasswordResetEvent(email, code));
     }
     
     /**

--- a/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeService.java
@@ -1,30 +1,34 @@
 package kr.co.yeogiga.application.auth.service;
 
+import kr.co.yeogiga.application.auth.event.EmailVerificationEvent;
+import kr.co.yeogiga.application.event.publisher.DomainEventPublisher;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.common.util.VerificationCodeGenerator;
 import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
 import kr.co.yeogiga.domain.auth.repository.VerificationCodeRepository;
 import kr.co.yeogiga.domain.user.service.UserService;
-import kr.co.yeogiga.infrastructure.mail.VerificationCodeEmailSender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
 public class VerificationCodeService {
     private final VerificationCodeRepository verificationCodeRepository;
-    private final VerificationCodeEmailSender verificationCodeEmailSender;
     private final UserService userService;
+    private final DomainEventPublisher eventPublisher;
     
     private final Long VERIFICATION_CODE_SEND_TIME_LIMIT = 2 * 60L;
     
     /**
      * 사용자가 인증 요청한 이메일로 인증 번호를 발송하는 메서드
+     *
      * @throws CustomException AuthErrorType.ALREADY_USED_EMAIL - 이미 사용 중인 이메일일 경우
      * @throws CustomException AuthErrorType.EMAIL_VERIFICATION_TIME_LIMIT - 이메일 인증 시도 횟수 초과 (1분 이내 재요청)
      *
      * @param email 인증 요청 이메일
      */
+    @Transactional
     public void issueCode(String email) {
         if (userService.existsIncludeDeletedByEmail(email)) {
             throw new CustomException(AuthErrorType.ALREADY_USED_EMAIL);
@@ -38,7 +42,8 @@ public class VerificationCodeService {
         }
         
         verificationCodeRepository.save(email, code);
-        verificationCodeEmailSender.send(email, code);
+        
+        eventPublisher.publish(new EmailVerificationEvent(email, code));
     }
     
     /**

--- a/src/main/java/kr/co/yeogiga/application/event/listener/DomainEventListener.java
+++ b/src/main/java/kr/co/yeogiga/application/event/listener/DomainEventListener.java
@@ -1,0 +1,7 @@
+package kr.co.yeogiga.application.event.listener;
+
+import kr.co.yeogiga.domain.event.DomainEvent;
+
+public abstract class DomainEventListener <T extends DomainEvent> {
+    public abstract void handleEvent(T event);
+}

--- a/src/main/java/kr/co/yeogiga/application/event/publisher/DomainEventPublisher.java
+++ b/src/main/java/kr/co/yeogiga/application/event/publisher/DomainEventPublisher.java
@@ -1,0 +1,16 @@
+package kr.co.yeogiga.application.event.publisher;
+
+import kr.co.yeogiga.domain.event.DomainEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DomainEventPublisher {
+    private final ApplicationEventPublisher applicationEventPublisher;
+    
+    public void publish(DomainEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/event/DomainEvent.java
+++ b/src/main/java/kr/co/yeogiga/domain/event/DomainEvent.java
@@ -1,0 +1,17 @@
+package kr.co.yeogiga.domain.event;
+
+import com.github.f4b6a3.ulid.UlidCreator;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public abstract class DomainEvent {
+    private final LocalDateTime createdAt;
+    private final String eventId;
+    
+    public DomainEvent() {
+        this.createdAt = LocalDateTime.now();
+        this.eventId = UlidCreator.getUlid().toString();
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/AsyncConfig.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/AsyncConfig.java
@@ -1,9 +1,44 @@
 package kr.co.yeogiga.infrastructure.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
 
 @EnableAsync
 @Configuration
 public class AsyncConfig {
+    public final static String EMAIL_TASK_EXECUTOR = "emailTaskExecutor";
+    
+    /**
+     * 이메일 발송 작업 수행을 위한 ThreadPoolTaskExecutor 빈
+     *
+     * <p> 이메일 발송 로직 성능 측정 데이터 기반 corePoolSize 할당
+     * <p> 산정 공식: cores * (1 + wait_time / service_time)
+     *
+     * <p> 예기치 못한 프로세스 종료 시에도, 대기 작업 수행을 위한 graceful shutdown 적용
+     *
+     * @return 비동기 이메일 발송 작업 용 ThreadPoolTaskExecutor
+     */
+    @Bean(name = EMAIL_TASK_EXECUTOR)
+    public Executor emailTaskExecutor() {
+        int cores = Runtime.getRuntime().availableProcessors();
+        int corePoolSize = cores * 7;
+        int maxPoolSize = corePoolSize * 2;
+        
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(corePoolSize);
+        executor.setMaxPoolSize(maxPoolSize);
+        executor.setQueueCapacity(100);
+        
+        executor.setThreadNamePrefix("email-exec-");
+        
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.initialize();
+        
+        return executor;
+    }
 }

--- a/src/main/java/kr/co/yeogiga/infrastructure/mail/JavaEmailSender.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/mail/JavaEmailSender.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -16,7 +15,6 @@ import org.springframework.stereotype.Component;
 public class JavaEmailSender extends EmailSender {
     private final JavaMailSender javaMailSender;
     
-    @Async
     @Override
     public void send(String to, String subject, String html, Content... contents) {
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
@@ -32,7 +30,6 @@ public class JavaEmailSender extends EmailSender {
             for (Content content : contents) {
                 helper.addInline(content.contentId(), new ClassPathResource(content.contentLocation()));
             }
-            
             javaMailSender.send(mimeMessage);
         } catch (MessagingException e) {
             log.error("[ERROR] Failed to send mail - to: {} | subject: {} | message: {}", to, subject, e.getMessage());

--- a/src/test/java/kr/co/yeogiga/application/auth/service/PasswordManagementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/PasswordManagementServiceTest.java
@@ -1,11 +1,12 @@
 package kr.co.yeogiga.application.auth.service;
 
+import kr.co.yeogiga.application.auth.event.PasswordResetEvent;
+import kr.co.yeogiga.application.event.publisher.DomainEventPublisher;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
 import kr.co.yeogiga.domain.auth.service.PasswordCodeService;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.service.UserService;
-import kr.co.yeogiga.infrastructure.mail.PasswordResetEmailSender;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -36,7 +38,7 @@ public class PasswordManagementServiceTest {
     private PasswordCodeService passwordCodeService;
     
     @Mock
-    private PasswordResetEmailSender passwordResetEmailSender;
+    public DomainEventPublisher eventPublisher;
     
     @Mock
     private PasswordEncoder passwordEncoder;
@@ -57,14 +59,14 @@ public class PasswordManagementServiceTest {
             when(userService.existsIncludeDeletedByEmailAndUsername(email, username)).thenReturn(true);
             when(passwordCodeService.existsCode(email)).thenReturn(false);
             doNothing().when(passwordCodeService).save(eq(email), anyString());
-            doNothing().when(passwordResetEmailSender).send(eq(email), anyString());
+            doNothing().when(eventPublisher).publish(any(PasswordResetEvent.class));
             
             // when
             passwordManagementService.requestPasswordReset(email, username);
             
             // then
             verify(passwordCodeService, times(1)).save(eq(email), anyString());
-            verify(passwordResetEmailSender, times(1)).send(eq(email), anyString());
+            verify(eventPublisher, times(1)).publish(any(PasswordResetEvent.class));
         }
         
         @Test

--- a/src/test/java/kr/co/yeogiga/application/auth/service/VerificationCodeServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/VerificationCodeServiceTest.java
@@ -1,10 +1,11 @@
 package kr.co.yeogiga.application.auth.service;
 
+import kr.co.yeogiga.application.auth.event.EmailVerificationEvent;
+import kr.co.yeogiga.application.event.publisher.DomainEventPublisher;
 import kr.co.yeogiga.common.exception.CustomException;
 import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
 import kr.co.yeogiga.domain.auth.repository.VerificationCodeCache;
 import kr.co.yeogiga.domain.user.service.UserService;
-import kr.co.yeogiga.infrastructure.mail.VerificationCodeEmailSender;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -31,10 +33,10 @@ public class VerificationCodeServiceTest {
     private VerificationCodeCache verificationCodeCache;
     
     @Mock
-    private VerificationCodeEmailSender verificationCodeEmailSender;
+    private UserService userService;
     
     @Mock
-    private UserService userService;
+    private DomainEventPublisher eventPublisher;
     
     @InjectMocks
     private VerificationCodeService verificationCodeService;
@@ -52,14 +54,14 @@ public class VerificationCodeServiceTest {
             when(userService.existsIncludeDeletedByEmail(anyString())).thenReturn(false);
             doNothing().when(verificationCodeCache).save(anyString(), anyString());
             when(verificationCodeCache.getExpire(anyString())).thenReturn(-1L);
-            doNothing().when(verificationCodeEmailSender).send(anyString(), anyString());
+            doNothing().when(eventPublisher).publish(any(EmailVerificationEvent.class));
             
             // when
             verificationCodeService.issueCode(email);
             
             // then
             verify(verificationCodeCache, times(1)).save(eq(email), anyString());
-            verify(verificationCodeEmailSender, times(1)).send(eq(email), anyString());
+            verify(eventPublisher, times(1)).publish(any(EmailVerificationEvent.class));
         }
         
         @Test


### PR DESCRIPTION
## 배경
- 이메일 발송 기능 실행 보장을 위한 Transactional Outbox Pattern 적용 필요성
- Transactional Outbox Pattern 적용 전 Spring Event 기반 사전 작업(주 비즈니스 로직 내 이메일 발송 기능 분리) 수행

## 작업 사항
- 도메인 이벤트 공통 기반 추상 클래스 `DomainEvent` 정의 | (f7868650e03166ea579a7c7e48f7e578042e5aa0)
  - 차후 이벤트 아웃박스 식별을 위한 `eventId` 컬럼 용 ULID 라이브러리 추가 | (b7a5feaf3242878013aa08bad0b739ac1892c8bc)
    - 테이블 보조인덱스(논-클러스터링 인덱스) 사용 목적
    - 이벤트 아웃박스 삽입 시, 인덱스 재배치 최소화를 위한 타임 스탬프 기반 식별자 ULID 사용
- 도메인 이벤트 발행 클래스 `DomainEventPublisher` 정의 | (335ad67e876b1ca66729a7984f933f0d9e0a817c)
- 도메인 이벤트 리스너 공통 기반 추상 클래스 `DomainEventListener` 정의 | (93ba1abf71adec96d779029be255dc323d7ae086)
- 이메일 발송 비동기 작업 수행을 위한 ThreadPoolTaskExecutor 빈 등록 | (76900333212edb92ef2050eb5e947359e35b9779)
  - 쓰레드풀 크기 산정 공식: `cpu_cores * (1 + wait_time / service_time)`
    - 이메일 발송 네트워크 I/O 소요 시간 : 평균 약 2400ms
    - 그 외 비즈니스 로직 수행(CPU 연산) 소요 시간: 평균 약 400ms
    - 따라서, 쓰레드_수 = `cpu_cores * (1 + 2400 / 400)` = `cpu_corse * 7`
  - 예기치 못한 프로세스 종료 시에도 대기큐 내 작업 수행을 위한 graceful shutdown 적용
- 이메일 발송 로직 비동기 적용 위치 변경을 위한 JavaEmailSender 내 `@Async` 어노테이션 제거 | (432996fd9d16f3ff3e476616878358a71f70d310)
  - 예외 처리 등을 위한 상위 레벨에서 비동기 적용
- 비밀번호 초기화 요청 로직 이벤트 적용 & 리스너 정의 | (86bf6990af6e2a19d802b1d9dd48b92e33dc5910)
- 이메일 인증코드 발급 요청 로직 이벤트 적용 & 리스너 정의 | (343cf4dd938e3f2d3bb59fb1e2afcc4d7cd69d85)

## 추가 논의
- 이메일 전송이 예기치 못하게 실패하는 상황이 있어, 이메일 발송을 보장하고자 Transactional Outbox Pattern에 관해 찾아보게 되었습니다. 해당 방법은 MSA + Event Driven Architecture에서 주로 사용되지만 전송 보장을 목적으로 하는 것은 동일하기에 현재 프로젝트에도 약간 변형하여 적용할 예정입니다.
- EC2를 확인해보니, 운영 서버의 CPU core는 1개이기 때문에 가능한 쓰레드 풀을 더 낮게 잡을까 고민하였지만, 우선은 대체적으로 많이 사용하는 공식에 의거하여 사이즈를 정의해놓은 상태입니다. 다른 관점의 의견이 있거나 더 나은 방법이 있으면 변경하도록 하겠습니다.