### PR TITLE
Chore: RabbitMQ 디펜던시 추가 및 관련 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,9 @@ dependencies {
 
     /* ULID */
     implementation 'com.github.f4b6a3:ulid-creator:5.2.3'
+
+    /* RabbitMQ */
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/rabbitmq/EmailVerificationRabbitMQConfig.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/rabbitmq/EmailVerificationRabbitMQConfig.java
@@ -1,0 +1,84 @@
+package kr.co.yeogiga.infrastructure.config.rabbitmq;
+
+import kr.co.yeogiga.infrastructure.properties.RabbitMQProperties;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EmailVerificationRabbitMQConfig {
+    private final RabbitMQProperties.Attribute properties;
+    
+    public EmailVerificationRabbitMQConfig(RabbitMQProperties rabbitMQProperties) {
+        this.properties = rabbitMQProperties.getEmailVerification();
+    }
+    
+    @Bean
+    public DirectExchange emailVerificationExchange() {
+        return new DirectExchange(properties.getExchange());
+    }
+    
+    @Bean
+    public Queue emailVerificationEmailWorkQueue() {
+        return QueueBuilder.durable(properties.getQueue() + ".email")
+                .withArgument("x-dead-letter-exchange", properties.getExchange() + ".email.retry")
+                .withArgument("x-dead-letter-routing-key", properties.getRoutingKey() + ".email.retry")
+                .build();
+    }
+    
+    @Bean
+    public Binding emailVerificationEmailWorkBinding(Queue emailVerificationEmailWorkQueue, DirectExchange emailVerificationExchange) {
+        return BindingBuilder.bind(emailVerificationEmailWorkQueue)
+                .to(emailVerificationExchange)
+                .with(properties.getRoutingKey() + ".email");
+    }
+    
+    @Bean
+    public Binding emailVerificationCommonBinding(Queue emailVerificationEmailWorkQueue, DirectExchange emailVerificationExchange) {
+        return BindingBuilder.bind(emailVerificationEmailWorkQueue)
+                .to(emailVerificationExchange)
+                .with(properties.getRoutingKey() + ".requested");
+    }
+    
+    @Bean
+    public DirectExchange emailVerificationEmailRetryExchange() {
+        return new DirectExchange(properties.getExchange() + ".email.retry");
+    }
+    
+    @Bean
+    public Queue emailVerificationEmailRetryQueue() {
+        return QueueBuilder.durable(properties.getQueue() + ".email.retry")
+                .withArgument("x-message-ttl", properties.getTtl())
+                .withArgument("x-dead-letter-exchange", properties.getExchange())
+                .withArgument("x-dead-letter-routing-key", properties.getRoutingKey() + ".email")
+                .build();
+    }
+    
+    @Bean
+    public Binding emailVerificationRetryBinding(Queue emailVerificationEmailRetryQueue, DirectExchange emailVerificationEmailRetryExchange) {
+        return BindingBuilder.bind(emailVerificationEmailRetryQueue)
+                .to(emailVerificationEmailRetryExchange)
+                .with(properties.getRoutingKey() + ".email.retry");
+    }
+    
+    @Bean
+    public DirectExchange emailVerificationEmailDeadExchange() {
+        return new DirectExchange(properties.getExchange() + ".email.dead");
+    }
+    
+    @Bean
+    public Queue emailVerificationEmailDeadQueue() {
+        return new Queue(properties.getQueue() + ".email.dead");
+    }
+    
+    @Bean
+    public Binding emailVerificationDeadBinding(Queue emailVerificationEmailDeadQueue, DirectExchange emailVerificationEmailDeadExchange) {
+        return BindingBuilder.bind(emailVerificationEmailDeadQueue)
+                .to(emailVerificationEmailDeadExchange)
+                .with(properties.getRoutingKey() + ".email.dead");
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/rabbitmq/PasswordResetRabbitMQConfig.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/rabbitmq/PasswordResetRabbitMQConfig.java
@@ -1,0 +1,84 @@
+package kr.co.yeogiga.infrastructure.config.rabbitmq;
+
+import kr.co.yeogiga.infrastructure.properties.RabbitMQProperties;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PasswordResetRabbitMQConfig {
+    private final RabbitMQProperties.Attribute properties;
+    
+    public PasswordResetRabbitMQConfig(RabbitMQProperties rabbitMQProperties) {
+        this.properties = rabbitMQProperties.getPasswordReset();
+    }
+    
+    @Bean
+    public DirectExchange passwordResetExchange() {
+        return new DirectExchange(properties.getExchange());
+    }
+    
+    @Bean
+    public Queue passwordResetEmailWorkQueue() {
+        return QueueBuilder.durable(properties.getQueue() + ".email")
+                .withArgument("x-dead-letter-exchange", properties.getExchange() + ".email.retry")
+                .withArgument("x-dead-letter-routing-key", properties.getRoutingKey() + ".email.retry")
+                .build();
+    }
+    
+    @Bean
+    public Binding PasswordResetEmailWorkBinding(Queue passwordResetEmailWorkQueue, DirectExchange passwordResetExchange) {
+        return BindingBuilder.bind(passwordResetEmailWorkQueue)
+                .to(passwordResetExchange)
+                .with(properties.getRoutingKey() + ".email");
+    }
+    
+    @Bean
+    public Binding PasswordResetCommonBinding(Queue passwordResetEmailWorkQueue, DirectExchange passwordResetExchange) {
+        return BindingBuilder.bind(passwordResetEmailWorkQueue)
+                .to(passwordResetExchange)
+                .with(properties.getRoutingKey() + ".requested");
+    }
+    
+    @Bean
+    public DirectExchange passwordResetEmailRetryExchange() {
+        return new DirectExchange(properties.getExchange() + ".email.retry");
+    }
+    
+    @Bean
+    public Queue passwordResetEmailRetryQueue() {
+        return QueueBuilder.durable(properties.getQueue() + ".email.retry")
+                .withArgument("x-message-ttl", properties.getTtl())
+                .withArgument("x-dead-letter-exchange", properties.getExchange())
+                .withArgument("x-dead-letter-routing-key", properties.getRoutingKey() + ".email")
+                .build();
+    }
+    
+    @Bean
+    public Binding passwordResetEmailRetryBinding(Queue passwordResetEmailRetryQueue, DirectExchange passwordResetEmailRetryExchange) {
+        return BindingBuilder.bind(passwordResetEmailRetryQueue)
+                .to(passwordResetEmailRetryExchange)
+                .with(properties.getRoutingKey() + ".email.retry");
+    }
+    
+    @Bean
+    public DirectExchange passwordResetEmailDeadExchange() {
+        return new DirectExchange(properties.getExchange() + ".email.dead");
+    }
+    
+    @Bean
+    public Queue passwordResetEmailDeadQueue() {
+        return new Queue(properties.getQueue() + ".email.dead");
+    }
+    
+    @Bean
+    public Binding passwordResetEmailDeadBinding(Queue passwordResetEmailDeadQueue, DirectExchange passwordResetEmailDeadExchange) {
+        return BindingBuilder.bind(passwordResetEmailDeadQueue)
+                .to(passwordResetEmailDeadExchange)
+                .with(properties.getRoutingKey() + ".email.dead");
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/rabbitmq/RabbitMQConfig.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/rabbitmq/RabbitMQConfig.java
@@ -1,0 +1,41 @@
+package kr.co.yeogiga.infrastructure.config.rabbitmq;
+
+import org.springframework.amqp.core.AcknowledgeMode;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(jackson2JsonMessageConverter());
+        return rabbitTemplate;
+    }
+    
+    @Bean
+    public MessageConverter jackson2JsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+    
+    @Bean
+    public SimpleRabbitListenerContainerFactory simpleRabbitListenerContainerFactory(ConnectionFactory connectionFactory) {
+        int processors = Runtime.getRuntime().availableProcessors();
+
+        SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+        factory.setConnectionFactory(connectionFactory);
+        factory.setMessageConverter(jackson2JsonMessageConverter());
+        factory.setConcurrentConsumers(processors * 2);
+        factory.setMaxConcurrentConsumers(processors * 4);
+        factory.setPrefetchCount(5);
+        factory.setAcknowledgeMode(AcknowledgeMode.AUTO);
+        factory.setDefaultRequeueRejected(false);
+
+        return factory;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/properties/RabbitMQProperties.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/properties/RabbitMQProperties.java
@@ -1,0 +1,25 @@
+package kr.co.yeogiga.infrastructure.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties("rabbitmq")
+public class RabbitMQProperties {
+    private Attribute passwordReset;
+    private Attribute emailVerification;
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class Attribute {
+        private final String queue;
+        private final String exchange;
+        private final String routingKey;
+        private final Long ttl;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -87,3 +87,23 @@ weather:
   num-of-rows: ${WEATHER_NUM}
   data-type: ${WEATHER_DATA_TYPE}
 
+--- # rabbitMQ
+spring:
+  rabbitmq:
+    host: ${RABBITMQ_HOST}
+    port: ${RABBITMQ_PORT}
+    username : ${RABBITMQ_USERNAME}
+    password: ${RABBITMQ_PASSWORD}
+    publisher-confirm-type: correlated
+
+rabbitmq:
+  password-reset:
+      queue: ${RABBITMQ_PASSWORD_RESET_QUEUE}
+      exchange: ${RABBITMQ_PASSWORD_RESET_EXCHANGE}
+      routing-key: ${RABBITMQ_PASSWORD_RESET_ROUTING_KEY}
+      ttl: ${RABBITMQ_PASSWORD_RESET_TTL}
+  email-verification:
+      queue: ${RABBITMQ_EMAIL_VERIFICATION_QUEUE}
+      exchange: ${RABBITMQ_EMAIL_VERIFICATION_EXCHANGE}
+      routing-key: ${RABBITMQ_EMAIL_VERIFICATION_ROUTING_KEY}
+      ttl: ${RABBITMQ_EMAIL_VERIFICATION_TTL}


### PR DESCRIPTION
## 배경
- 이벤트 관련 처리 신뢰성 보장 및 향후 이메일 발송 서버 분리를 고려한 메시지브로커 도입
  - 이벤트: PasswordResetEvent, EmailVerificationEvent

## 작업 사항
- RabbitMQ 디펜던시 추가 및 환경변수 프로퍼티 설정 | (18674a76c3f4a204e8fae9df9238f30a106b4426)
- RabbitMQ 환경변수 프로퍼티 바인딩 | (5ff8b3c6571776a9cc10c531a946312a758862f7)
- RabbitMQ 관련 설정 코드 작성 | (7919cb58c71d3f78f2eadeae1dd4709e673f187a)
  - 가독성을 위한 설정 파일 분리
  - RabbitMQ 수동 지연큐를 통한 재시도 로직을 도입하기 위하여 work / retry / dead 목적의 리소스 정의
    
<img width="1320" height="366" alt="image" src="https://github.com/user-attachments/assets/f82a4435-742e-4ebb-a86f-bc86b9e7d7a3" />

## 추가 논의
- 기존 서버와 동일한 이미지로 서버를 개설하여 테스트 진행하였습니다. swap 메모리 설정 후 진행하였고, 평균적으로 사용 가능 메모리는 1.5GiB 이상으로 충분히 남았습니다. 따라서, RabbitMQ 도입 Transactional Outbox Pattern 도입 진행 예정이고, 단계적으로 적용하도록 하겠습니다.
- DLQ에 적재된 메시지의 경우에는 향후 실패 메시지 확인 후 수동 삭제하는 방향 또는 일정 시간 후 자동 삭제 로직 도입 고려하고 있습니다.
- PR 병합 전 docker-compose 파일 수정 등 진행하고 말씀드리도록 하겠습니다.