### PR TITLE
Feature: 이메일 발송 시 발생 예외 분리

### DIFF
--- a/src/main/java/kr/co/yeogiga/infrastructure/mail/JavaEmailSender.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/mail/JavaEmailSender.java
@@ -2,9 +2,12 @@ package kr.co.yeogiga.infrastructure.mail;
 
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
+import kr.co.yeogiga.infrastructure.mail.exception.FatalEmailException;
+import kr.co.yeogiga.infrastructure.mail.exception.RetryableEmailException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
@@ -32,7 +35,9 @@ public class JavaEmailSender extends EmailSender {
             }
             javaMailSender.send(mimeMessage);
         } catch (MessagingException e) {
-            log.error("[ERROR] Failed to send mail - to: {} | subject: {} | message: {}", to, subject, e.getMessage());
+            throw new FatalEmailException("Failed to send email (Fatal)", e);
+        } catch (MailException e) {
+            throw new RetryableEmailException("Failed to send email (Retryable)", e);
         }
     }
 }

--- a/src/main/java/kr/co/yeogiga/infrastructure/mail/exception/EmailException.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/mail/exception/EmailException.java
@@ -1,0 +1,14 @@
+package kr.co.yeogiga.infrastructure.mail.exception;
+
+public abstract class EmailException extends RuntimeException {
+    public EmailException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    
+    /**
+     * 재시도 가능 여부를 반환하는 메서드
+     *
+     * @return 재시도 가능 여부
+     */
+    public abstract boolean isRetryable();
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/mail/exception/FatalEmailException.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/mail/exception/FatalEmailException.java
@@ -1,0 +1,12 @@
+package kr.co.yeogiga.infrastructure.mail.exception;
+
+public class FatalEmailException extends EmailException {
+    public FatalEmailException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    
+    @Override
+    public boolean isRetryable() {
+        return false;
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/mail/exception/RetryableEmailException.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/mail/exception/RetryableEmailException.java
@@ -1,0 +1,12 @@
+package kr.co.yeogiga.infrastructure.mail.exception;
+
+public class RetryableEmailException extends EmailException {
+    public RetryableEmailException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    
+    @Override
+    public boolean isRetryable() {
+        return true;
+    }
+}


### PR DESCRIPTION
## 배경
- 이메일 발송 시 재시도 로직 적용 목적
- 이메일 발송 로직 내 발생하는 예외에 따른 재시도 여부 차이 존재

## 작업 사항
- 이메일 발송 예외 처리를 위한 추상 클래스 `EmailException` 정의 | (802c001f2337da249e9c6077d0cad85538d5432e)
- 이메일 발송 재시도 불가능 예외 `FatalEmailException` 정의 | (022653596fd2d767a7cf47ffa44c55d6dfd221b5)
  - `MessagingException`: 서버 리소스(메일 템플릿 등)에 문제가 발생하여 메일 발송 자체가 불가능한 경우 발생
- 이메일 발송 재시도 가능 예외 `RetryableEmailException` 정의 | (bd7ae2b09e45d0802c3c0248fda4f3d87cfcd4b2)
  - `MailException`: 메일 발송 후 SMTP 서버에서 예외가 발생한 경우 발생
- `JavaEmailSender` 내 예외 종류에 따른 처리 로직 분리 | (ccf8faac0be8ed1dd4cade432b14ab0d43d4da8f)