### PR TITLE
Feature: 이벤트 아웃박스 및 기록용 리스너 클래스 정의

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/auth/event/listener/EmailVerificationEventEmailListenerLegacy.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/event/listener/EmailVerificationEventEmailListenerLegacy.java
@@ -1,7 +1,7 @@
 package kr.co.yeogiga.application.auth.event.listener;
 
 import kr.co.yeogiga.application.auth.event.EmailVerificationEvent;
-import kr.co.yeogiga.application.event.listener.DomainEventListener;
+import kr.co.yeogiga.application.event.listener.DomainEventListenerLegacy;
 import kr.co.yeogiga.infrastructure.mail.VerificationCodeEmailSender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
@@ -13,7 +13,7 @@ import static kr.co.yeogiga.infrastructure.config.AsyncConfig.EMAIL_TASK_EXECUTO
 
 @Component
 @RequiredArgsConstructor
-public class EmailVerificationEventEmailListener extends DomainEventListener<EmailVerificationEvent> {
+public class EmailVerificationEventEmailListenerLegacy extends DomainEventListenerLegacy<EmailVerificationEvent> {
     private final VerificationCodeEmailSender verificationCodeEmailSender;
     
     @Override

--- a/src/main/java/kr/co/yeogiga/application/auth/event/listener/PasswordResetEventEmailListenerLegacy.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/event/listener/PasswordResetEventEmailListenerLegacy.java
@@ -1,7 +1,7 @@
 package kr.co.yeogiga.application.auth.event.listener;
 
 import kr.co.yeogiga.application.auth.event.PasswordResetEvent;
-import kr.co.yeogiga.application.event.listener.DomainEventListener;
+import kr.co.yeogiga.application.event.listener.DomainEventListenerLegacy;
 import kr.co.yeogiga.infrastructure.mail.PasswordResetEmailSender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
@@ -13,7 +13,7 @@ import static kr.co.yeogiga.infrastructure.config.AsyncConfig.EMAIL_TASK_EXECUTO
 
 @Component
 @RequiredArgsConstructor
-public class PasswordResetEventEmailListener extends DomainEventListener<PasswordResetEvent> {
+public class PasswordResetEventEmailListenerLegacy extends DomainEventListenerLegacy<PasswordResetEvent> {
     private final PasswordResetEmailSender passwordResetEmailSender;
     
     @Override

--- a/src/main/java/kr/co/yeogiga/application/event/listener/DomainEventListener.java
+++ b/src/main/java/kr/co/yeogiga/application/event/listener/DomainEventListener.java
@@ -2,6 +2,6 @@ package kr.co.yeogiga.application.event.listener;
 
 import kr.co.yeogiga.domain.event.DomainEvent;
 
-public abstract class DomainEventListener <T extends DomainEvent> {
-    public abstract void handleEvent(T event);
+public interface DomainEventListener {
+    void handleEvent(DomainEvent event);
 }

--- a/src/main/java/kr/co/yeogiga/application/event/listener/DomainEventListenerLegacy.java
+++ b/src/main/java/kr/co/yeogiga/application/event/listener/DomainEventListenerLegacy.java
@@ -1,0 +1,7 @@
+package kr.co.yeogiga.application.event.listener;
+
+import kr.co.yeogiga.domain.event.DomainEvent;
+
+public abstract class DomainEventListenerLegacy<T extends DomainEvent> {
+    public abstract void handleEvent(T event);
+}

--- a/src/main/java/kr/co/yeogiga/application/event/listener/DomainEventRecordListener.java
+++ b/src/main/java/kr/co/yeogiga/application/event/listener/DomainEventRecordListener.java
@@ -1,0 +1,30 @@
+package kr.co.yeogiga.application.event.listener;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yeogiga.domain.event.DomainEvent;
+import kr.co.yeogiga.domain.outbox.entity.EventOutbox;
+import kr.co.yeogiga.domain.outbox.service.EventOutboxService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class DomainEventRecordListener implements DomainEventListener {
+    private final EventOutboxService eventOutboxService;
+    private final ObjectMapper objectMapper;
+    
+    @Override
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleEvent(DomainEvent event) {
+        try {
+            String payload = objectMapper.writeValueAsString(event);
+            
+            eventOutboxService.save(EventOutbox.fromEvent(event, payload));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to parse Event - " + event.getEventId(), e);
+        }
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/outbox/entity/EventOutbox.java
+++ b/src/main/java/kr/co/yeogiga/domain/outbox/entity/EventOutbox.java
@@ -1,0 +1,68 @@
+package kr.co.yeogiga.domain.outbox.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import kr.co.yeogiga.domain.event.DomainEvent;
+import kr.co.yeogiga.domain.outbox.type.EventOutboxStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "event_outbox")
+@NoArgsConstructor
+public class EventOutbox {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "event_id", nullable = false, length = 26)
+    private String eventId;
+    
+    @Column(name = "event_type", nullable = false)
+    private String eventType;
+    
+    @Column(nullable = false)
+    private String payload;
+    
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private EventOutboxStatus status;
+    
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+    
+    @Column(name = "last_retried_at")
+    private LocalDateTime lastRetriedAt;
+    
+    @Column(name = "fail_count")
+    private int failCount;
+    
+        @Builder
+    public EventOutbox(String eventId, String eventType, String payload, LocalDateTime createdAt) {
+        this.eventId = eventId;
+        this.eventType = eventType;
+        this.payload = payload;
+        this.createdAt = createdAt;
+        this.status = EventOutboxStatus.WAITING;
+    }
+    
+    public static EventOutbox fromEvent(DomainEvent event, String payload) {
+        return EventOutbox.builder()
+                .eventId(event.getEventId())
+                .eventType(event.getClass().getName())
+                .payload(payload)
+                .createdAt(event.getCreatedAt())
+                .build();
+    }
+}
+

--- a/src/main/java/kr/co/yeogiga/domain/outbox/entity/EventOutbox.java
+++ b/src/main/java/kr/co/yeogiga/domain/outbox/entity/EventOutbox.java
@@ -7,9 +7,9 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Table;
 import kr.co.yeogiga.domain.event.DomainEvent;
 import kr.co.yeogiga.domain.outbox.type.EventOutboxStatus;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,9 +17,8 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Getter
-@Entity
-@Table(name = "event_outbox")
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "event_outbox")
 public class EventOutbox {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -47,7 +46,7 @@ public class EventOutbox {
     @Column(name = "fail_count")
     private int failCount;
     
-        @Builder
+    @Builder
     public EventOutbox(String eventId, String eventType, String payload, LocalDateTime createdAt) {
         this.eventId = eventId;
         this.eventType = eventType;

--- a/src/main/java/kr/co/yeogiga/domain/outbox/repository/EventOutboxRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/outbox/repository/EventOutboxRepository.java
@@ -1,0 +1,8 @@
+package kr.co.yeogiga.domain.outbox.repository;
+
+import kr.co.yeogiga.domain.outbox.entity.EventOutbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventOutboxRepository extends JpaRepository<EventOutbox, Long> {
+
+}

--- a/src/main/java/kr/co/yeogiga/domain/outbox/service/EventOutboxService.java
+++ b/src/main/java/kr/co/yeogiga/domain/outbox/service/EventOutboxService.java
@@ -1,0 +1,16 @@
+package kr.co.yeogiga.domain.outbox.service;
+
+import kr.co.yeogiga.domain.outbox.entity.EventOutbox;
+import kr.co.yeogiga.domain.outbox.repository.EventOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EventOutboxService {
+    private final EventOutboxRepository eventOutboxRepository;
+    
+    public EventOutbox save(EventOutbox eventOutbox) {
+        return eventOutboxRepository.save(eventOutbox);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/outbox/type/EventOutboxStatus.java
+++ b/src/main/java/kr/co/yeogiga/domain/outbox/type/EventOutboxStatus.java
@@ -1,0 +1,5 @@
+package kr.co.yeogiga.domain.outbox.type;
+
+public enum EventOutboxStatus {
+    WAITING, PUBLISHED, FAILED
+}


### PR DESCRIPTION
## 배경
- Transactional Outbox Pattern 적용을 위한 이벤트 아웃박스(EventOutbox) 정의 필요

## 작업 사항
- 이벤트 아웃박스(EvnetOutbox) 엔티티 및 도메인 로직 클래스 정의 | (a4fbe37e72d7c728cc3912aadd2efab474b5ea6e)
- EventOutbox 엔티티 기록용 리스너 클래스 정의 | (284ac044ae29026062ea856ec2cd36dc78ce4123)
  - DomainEventListener 인터페이스 정의 | (12a8f75603d18f1fc401c284e7adf1ea7e087e8e)
  - DomainEventListener 인터페이스 정의를 위한 기존 클래스명 변경 | (ebdfa2cf89ebf53a40f825e780f3bae38ac3019c)
    - `DomainEventListener` → `DomainEventListenerLegacy`
    - 향후, 제너릭 제거 및 DomainEvent 파라미터를 통한 통합 기록 / 발행 리스너 클래스 정의 예정
 