### PR TITLE
Feature: RabbitMQ 이벤트 메시지 발행 로직 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/infrastructure/event/converter/RabbitMQPropertyResolver.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/event/converter/RabbitMQPropertyResolver.java
@@ -1,0 +1,38 @@
+package kr.co.yeogiga.infrastructure.event.converter;
+
+import kr.co.yeogiga.application.auth.event.EmailVerificationEvent;
+import kr.co.yeogiga.application.auth.event.PasswordResetEvent;
+import kr.co.yeogiga.domain.event.DomainEvent;
+import kr.co.yeogiga.infrastructure.properties.RabbitMQProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RabbitMQPropertyResolver {
+    private final RabbitMQProperties properties;
+    
+    public String getPublishExchange(DomainEvent event) {
+        if (event instanceof PasswordResetEvent) {
+            return properties.getPasswordReset().getExchange();
+        }
+        
+        if (event instanceof EmailVerificationEvent) {
+            return properties.getEmailVerification().getExchange();
+        }
+        
+        throw new IllegalArgumentException("Unsupported event: " + event.getClass().getSimpleName());
+    }
+    
+    public String getPublishRoutingKey(DomainEvent event) {
+        if (event instanceof PasswordResetEvent) {
+            return properties.getPasswordReset().getRoutingKey() + ".requested";
+        }
+        
+        if (event instanceof EmailVerificationEvent) {
+            return properties.getEmailVerification().getExchange() + ".requested";
+        }
+        
+        throw new IllegalArgumentException("Unsupported event: " + event.getClass().getSimpleName());
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/event/dto/EventPublishResult.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/event/dto/EventPublishResult.java
@@ -1,0 +1,15 @@
+package kr.co.yeogiga.infrastructure.event.dto;
+
+public record EventPublishResult(
+        String eventId,
+        boolean isSuccess,
+        String cause
+) {
+    public static EventPublishResult success(String eventId) {
+        return new EventPublishResult(eventId, true, null);
+    }
+    
+    public static EventPublishResult fail(String eventId, String cause) {
+        return new EventPublishResult(eventId, false, cause);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/event/publisher/DomainEventExternalPublisher.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/event/publisher/DomainEventExternalPublisher.java
@@ -1,0 +1,10 @@
+package kr.co.yeogiga.infrastructure.event.publisher;
+
+import kr.co.yeogiga.infrastructure.event.dto.EventPublishResult;
+import kr.co.yeogiga.domain.event.DomainEvent;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface DomainEventExternalPublisher {
+    CompletableFuture<EventPublishResult> publish(DomainEvent event);
+}

--- a/src/main/java/kr/co/yeogiga/infrastructure/event/publisher/RabbitMQEventPublisher.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/event/publisher/RabbitMQEventPublisher.java
@@ -1,0 +1,57 @@
+package kr.co.yeogiga.infrastructure.event.publisher;
+
+import kr.co.yeogiga.domain.event.DomainEvent;
+import kr.co.yeogiga.infrastructure.event.converter.RabbitMQPropertyResolver;
+import kr.co.yeogiga.infrastructure.event.dto.EventPublishResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RabbitMQEventPublisher implements DomainEventExternalPublisher {
+    private final RabbitTemplate rabbitTemplate;
+    private final RabbitMQPropertyResolver rabbitMQPropertyResolver;
+    
+    /**
+     * RabbitMQ 메시지브로커로 이벤트를 발행하는 메서드
+     *
+     * <p> {@code CorrelationData}를 통해 메시지브로커로의 발행 여부를 확인
+     *
+     * <p> 메시지 발행 중 예외 발생 시 실패 상태 객체를 반환, 성공 시 성공 객체를 반환
+     *
+     *
+     * @param event 도메인 이벤트 객체
+     * @return      실행 결과 {@link EventPublishResult}를 감싸고 있는 {@code CompletableFuture} 객체
+     */
+    @Override
+    public CompletableFuture<EventPublishResult> publish(DomainEvent event) {
+        CorrelationData correlationData = new CorrelationData(event.getEventId());
+        
+        CompletableFuture<EventPublishResult> result = correlationData.getFuture().thenApply(confirm -> {
+            if (confirm.isAck()) {
+                return EventPublishResult.success(event.getEventId());
+            } else {
+                return EventPublishResult.fail(event.getEventId(), confirm.getReason());
+            }
+        }).exceptionally(ex -> EventPublishResult.fail(event.getEventId(), ex.getMessage()));
+        
+        try {
+            rabbitTemplate.convertAndSend(
+                    rabbitMQPropertyResolver.getPublishExchange(event),
+                    rabbitMQPropertyResolver.getPublishRoutingKey(event),
+                    event,
+                    correlationData
+            );
+        } catch (Exception e) {
+            result.complete(EventPublishResult.fail(event.getEventId(), e.getMessage()));
+        }
+        
+        return result;
+    }
+}

--- a/src/test/java/kr/co/yeogiga/infrastructure/event/publisher/RabbitMQEventPublisherTest.java
+++ b/src/test/java/kr/co/yeogiga/infrastructure/event/publisher/RabbitMQEventPublisherTest.java
@@ -1,0 +1,127 @@
+package kr.co.yeogiga.infrastructure.event.publisher;
+
+import kr.co.yeogiga.application.auth.event.PasswordResetEvent;
+import kr.co.yeogiga.domain.event.DomainEvent;
+import kr.co.yeogiga.infrastructure.event.converter.RabbitMQPropertyResolver;
+import kr.co.yeogiga.infrastructure.event.dto.EventPublishResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class RabbitMQEventPublisherTest {
+    @Mock
+    private RabbitTemplate rabbitTemplate;
+    
+    @Mock
+    private RabbitMQPropertyResolver rabbitMQPropertyResolver;
+    
+    @InjectMocks
+    private RabbitMQEventPublisher rabbitMQEventPublisher;
+    
+    private DomainEvent event = new PasswordResetEvent("test@test.com", "123456");
+    private String eventId = "01KFQ007TN82P4155GX1X0T6SJ";
+    
+    @Captor
+    private ArgumentCaptor<CorrelationData> captor;
+    
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(event, "eventId", eventId);
+    }
+    
+    
+    @Test
+    @DisplayName("성공 - 메시지 발행 후 ACK 수신")
+    void success() throws ExecutionException, InterruptedException {
+        // given
+        String exchange = "x.test";
+        String routingKey = "test";
+        when(rabbitMQPropertyResolver.getPublishExchange(event)).thenReturn(exchange);
+        when(rabbitMQPropertyResolver.getPublishRoutingKey(event)).thenReturn(routingKey);
+        
+        // when
+        CompletableFuture<EventPublishResult> result = rabbitMQEventPublisher.publish(event);
+        
+        verify(rabbitTemplate).convertAndSend(eq(exchange), eq(routingKey), eq(event), captor.capture());
+        
+        // CorrelationData를 캡쳐해 성공 상태의 Confirm을 설정하여 완료 처리
+        CorrelationData correlationData = captor.getValue();
+        CorrelationData.Confirm confirm = new CorrelationData.Confirm(true, null);
+        correlationData.getFuture().complete(confirm);
+        
+        // then
+        EventPublishResult eventPublishResult = result.get();
+        assertTrue(eventPublishResult.isSuccess());
+        assertThat(eventPublishResult.eventId()).isEqualTo(eventId);
+    }
+    
+    @Test
+    @DisplayName("실패 - 메시지 발행 후 NACK 수신")
+    void failNack() throws ExecutionException, InterruptedException {
+        // given
+        String exchange = "x.test";
+        String routingKey = "test";
+        when(rabbitMQPropertyResolver.getPublishExchange(event)).thenReturn(exchange);
+        when(rabbitMQPropertyResolver.getPublishRoutingKey(event)).thenReturn(routingKey);
+        
+        // when
+        CompletableFuture<EventPublishResult> result = rabbitMQEventPublisher.publish(event);
+        
+        verify(rabbitTemplate).convertAndSend(eq(exchange), eq(routingKey), eq(event), captor.capture());
+        
+        // CorrelationData를 캡쳐해 성공 상태의 Confirm을 설정하여 완료 처리
+        CorrelationData correlationData = captor.getValue();
+        CorrelationData.Confirm confirm = new CorrelationData.Confirm(false, "NACK");
+        correlationData.getFuture().complete(confirm);
+        
+        // then
+        EventPublishResult eventPublishResult = result.get();
+        assertFalse(eventPublishResult.isSuccess());
+        assertThat(eventPublishResult.eventId()).isEqualTo(eventId);
+        assertEquals(eventPublishResult.cause(), "NACK");
+    }
+    
+    @Test
+    @DisplayName("실패 - RabbitTemplate 발행 실패")
+    void failRabbitTemplate() throws ExecutionException, InterruptedException {
+        // given
+        String exchange = "x.test";
+        String routingKey = "test";
+        when(rabbitMQPropertyResolver.getPublishExchange(event)).thenReturn(exchange);
+        when(rabbitMQPropertyResolver.getPublishRoutingKey(event)).thenReturn(routingKey);
+        doThrow(new RuntimeException("Unexpected Exception")).when(rabbitTemplate).convertAndSend(anyString(), anyString(), any(DomainEvent.class), any(CorrelationData.class));
+        
+        // when
+        CompletableFuture<EventPublishResult> result = rabbitMQEventPublisher.publish(event);
+        
+        // then
+        EventPublishResult eventPublishResult = result.get();
+        assertFalse(eventPublishResult.isSuccess());
+        assertThat(eventPublishResult.eventId()).isEqualTo(eventId);
+        assertEquals(eventPublishResult.cause(), "Unexpected Exception");
+    }
+}


### PR DESCRIPTION
## 배경
- Transactional Outbox Pattern 구현 시 이벤트 재시도 등 효율적인 관리를 위한 메시지 브로커로 이벤트 메시지 발행 필요

## 작업 사항
- 이벤트 발행 결과 래핑 클래스 `EventPublishResult` 정의 | (4996806cbc016a9e9fd0fce0b28d3319711fb2a9)
  - 메시지 발행 결과를 통해, `EvnetOutbox` 엔티티의 `status`를 변경할 예정입니다 (`PUBLISHERD` or `FAILED`)
- RabbitMQ로 메시지 발행용 exchange, routing-key 리졸버 클래스 정의 | (6aca92c427be9ebcaaaa7210fe153541e1eba42d)
  - 공통 라우팅키를 사용하기 위하여 정의
  - #145 참고
- DomainEvent 외부 메시지 발행자 인터페이스 선언 및 구현 클래스 추가 | (6dc26653d56d01f9ab734c2b288b26808ff2bc9b)
  - RabbitMQ에서 제공하는 [Publisher Confirm](https://www.rabbitmq.com/docs/confirms#when-publishes-are-confirmed) 기능을 통해 메시지 발행 여부(Producer → Exchange)를 확인하였습니다.
    메시지 발행 후, 메시지브로커로 메시지가 정상적으로 수신된 경우 ACK을 반환한다고 합니다. 이를 `RabbitTemplate` 에서는 `CorrelationData` 객체를 추가 인자로 주어서 ack/nack 신호를 사용할 수 있다고 하여 해당 방식을 사용하였습니다. 
  - 또한, Exchange → Queue로 메시지가 잘 전달된지 확인하는 Producer Returns 까지 확인하는 방법도 있지만, Routing-key가 잘못되지 않는 한 해당 일은 발생하지 않을 것이라 생각하여 적용시키지 않았습니다.

## 추가 논의
- 현재 실제 AFTER_COMMIT 시점과 연결해버리면 소비자는 구현되지 않은 상태에서 메시지가 발행되어 메시지 브로커에 메시지가 쌓일 수도 있어 실제 연결은 다음 Consumer 작업과 연결하여 진행할 예정입니다.