### PR TITLE
Feature: 이메일 인증, 비밀번호 초기화 로직 만료기한 설정 중앙화

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/auth/event/EmailVerificationEvent.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/event/EmailVerificationEvent.java
@@ -11,10 +11,10 @@ public class EmailVerificationEvent extends DomainEvent {
     private final String code;
     private final ZonedDateTime expiredAt;
     
-    public EmailVerificationEvent(String email, String code) {
+    public EmailVerificationEvent(String email, String code, int expiration) {
         super();
         this.email = email;
         this.code = code;
-        this.expiredAt = getCreatedAt().plusMinutes(3);
+        this.expiredAt = getCreatedAt().plusSeconds(expiration);
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/event/PasswordResetEvent.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/event/PasswordResetEvent.java
@@ -11,10 +11,10 @@ public class PasswordResetEvent extends DomainEvent {
     private final String code;
     private final ZonedDateTime expiredAt;
     
-    public PasswordResetEvent(String email, String code) {
+    public PasswordResetEvent(String email, String code, int expiration) {
         super();
         this.email = email;
         this.code = code;
-        this.expiredAt = getCreatedAt().plusMinutes(3);
+        this.expiredAt = getCreatedAt().plusSeconds(expiration);
     }
 }

--- a/src/main/java/kr/co/yeogiga/application/auth/service/PasswordManagementService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/PasswordManagementService.java
@@ -9,6 +9,7 @@ import kr.co.yeogiga.domain.auth.service.PasswordCodeService;
 import kr.co.yeogiga.domain.user.entity.User;
 import kr.co.yeogiga.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +21,9 @@ public class PasswordManagementService {
     private final PasswordCodeService passwordCodeService;
     private final PasswordEncoder passwordEncoder;
     private final DomainEventPublisher eventPublisher;
+    
+    @Value("${auth.expiration.password-reset}")
+    private int passwordResetExpiration;
     
     /**
      * 비밀번호 초기화 요청 메서드
@@ -45,9 +49,9 @@ public class PasswordManagementService {
         }
         
         String code = PasswordCodeGenerator.generate();
-        passwordCodeService.save(email, code);
+        passwordCodeService.save(email, code, passwordResetExpiration);
         
-        eventPublisher.publish(new PasswordResetEvent(email, code));
+        eventPublisher.publish(new PasswordResetEvent(email, code, passwordResetExpiration));
     }
     
     /**

--- a/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeService.java
+++ b/src/main/java/kr/co/yeogiga/application/auth/service/VerificationCodeService.java
@@ -8,6 +8,7 @@ import kr.co.yeogiga.domain.auth.exception.AuthErrorType;
 import kr.co.yeogiga.domain.auth.repository.VerificationCodeRepository;
 import kr.co.yeogiga.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +20,9 @@ public class VerificationCodeService {
     private final DomainEventPublisher eventPublisher;
     
     private final Long VERIFICATION_CODE_SEND_TIME_LIMIT = 2 * 60L;
+    
+    @Value("${auth.expiration.email-verification}")
+    private int emailVerificationExpiration;
     
     /**
      * 사용자가 인증 요청한 이메일로 인증 번호를 발송하는 메서드
@@ -41,9 +45,9 @@ public class VerificationCodeService {
             throw new CustomException(AuthErrorType.EMAIL_VERIFICATION_TIME_LIMIT);
         }
         
-        verificationCodeRepository.save(email, code);
+        verificationCodeRepository.save(email, code, emailVerificationExpiration);
         
-        eventPublisher.publish(new EmailVerificationEvent(email, code));
+        eventPublisher.publish(new EmailVerificationEvent(email, code, emailVerificationExpiration));
     }
     
     /**

--- a/src/main/java/kr/co/yeogiga/domain/auth/repository/PasswordCodeCache.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/repository/PasswordCodeCache.java
@@ -10,12 +10,11 @@ import java.time.Duration;
 @RequiredArgsConstructor
 public class PasswordCodeCache implements PasswordCodeRepository {
     private final RedisRepository redisRepository;
-    private final Duration DURATION = Duration.ofMinutes(3);
     private final String PASSWORD_CODE_KEY_FORMAT = "password-code:%s";
     
     @Override
-    public void save(String email, String code) {
-        redisRepository.set(getPasswordCodeKey(email), code, DURATION);
+    public void save(String email, String code, int duration) {
+        redisRepository.set(getPasswordCodeKey(email), code, Duration.ofSeconds(duration));
     }
     
     @Override

--- a/src/main/java/kr/co/yeogiga/domain/auth/repository/PasswordCodeRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/repository/PasswordCodeRepository.java
@@ -1,7 +1,7 @@
 package kr.co.yeogiga.domain.auth.repository;
 
 public interface PasswordCodeRepository {
-    void save(String email, String code);
+    void save(String email, String code, int duration);
     String getCode(String email);
     boolean existsCode(String email);
     void del(String email);

--- a/src/main/java/kr/co/yeogiga/domain/auth/repository/VerificationCodeCache.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/repository/VerificationCodeCache.java
@@ -13,12 +13,10 @@ import java.util.Optional;
 public class VerificationCodeCache implements VerificationCodeRepository {
     private final RedisRepository redisRepository;
     
-    private final Duration DURATION = Duration.ofMinutes(3);
-    
     @Override
-    public void save(String email, String code) {
+    public void save(String email, String code, int duration) {
         String key = MailConstant.formatVerificationCodePrefix(email);
-        redisRepository.set(key, code, DURATION);
+        redisRepository.set(key, code, Duration.ofSeconds(duration));
     }
     
     @Override

--- a/src/main/java/kr/co/yeogiga/domain/auth/repository/VerificationCodeRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/repository/VerificationCodeRepository.java
@@ -3,7 +3,7 @@ package kr.co.yeogiga.domain.auth.repository;
 import java.util.Optional;
 
 public interface VerificationCodeRepository {
-    void save(String email, String code);
+    void save(String email, String code, int duration);
     
     Optional<String> getCode(String email);
     

--- a/src/main/java/kr/co/yeogiga/domain/auth/service/PasswordCodeService.java
+++ b/src/main/java/kr/co/yeogiga/domain/auth/service/PasswordCodeService.java
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Service;
 public class PasswordCodeService {
     private final PasswordCodeRepository passwordCodeRepository;
     
-    public void save(String email, String code) {
-        passwordCodeRepository.save(email, code);
+    public void save(String email, String code, int expiration) {
+        passwordCodeRepository.save(email, code, expiration);
     }
     
     public String getCode(String email) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,3 +107,9 @@ rabbitmq:
       exchange: ${RABBITMQ_EMAIL_VERIFICATION_EXCHANGE}
       routing-key: ${RABBITMQ_EMAIL_VERIFICATION_ROUTING_KEY}
       ttl: ${RABBITMQ_EMAIL_VERIFICATION_TTL}
+
+--- # auth
+auth:
+  expiration:
+    password-reset: ${PASSWORD_RESET_EXPIRATION}
+    email-verification: ${EMAIL_VERIFICATION_EXPIRATION}

--- a/src/test/java/kr/co/yeogiga/application/auth/service/PasswordManagementServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/PasswordManagementServiceTest.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -58,14 +59,14 @@ public class PasswordManagementServiceTest {
             // given
             when(userService.existsIncludeDeletedByEmailAndUsername(email, username)).thenReturn(true);
             when(passwordCodeService.existsCode(email)).thenReturn(false);
-            doNothing().when(passwordCodeService).save(eq(email), anyString());
+            doNothing().when(passwordCodeService).save(eq(email), anyString(), anyInt());
             doNothing().when(eventPublisher).publish(any(PasswordResetEvent.class));
             
             // when
             passwordManagementService.requestPasswordReset(email, username);
             
             // then
-            verify(passwordCodeService, times(1)).save(eq(email), anyString());
+            verify(passwordCodeService, times(1)).save(eq(email), anyString(), anyInt());
             verify(eventPublisher, times(1)).publish(any(PasswordResetEvent.class));
         }
         

--- a/src/test/java/kr/co/yeogiga/application/auth/service/VerificationCodeServiceTest.java
+++ b/src/test/java/kr/co/yeogiga/application/auth/service/VerificationCodeServiceTest.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -52,7 +53,7 @@ public class VerificationCodeServiceTest {
         void success() {
             // given
             when(userService.existsIncludeDeletedByEmail(anyString())).thenReturn(false);
-            doNothing().when(verificationCodeCache).save(anyString(), anyString());
+            doNothing().when(verificationCodeCache).save(anyString(), anyString(), anyInt());
             when(verificationCodeCache.getExpire(anyString())).thenReturn(-1L);
             doNothing().when(eventPublisher).publish(any(EmailVerificationEvent.class));
             
@@ -60,7 +61,7 @@ public class VerificationCodeServiceTest {
             verificationCodeService.issueCode(email);
             
             // then
-            verify(verificationCodeCache, times(1)).save(eq(email), anyString());
+            verify(verificationCodeCache, times(1)).save(eq(email), anyString(), anyInt());
             verify(eventPublisher, times(1)).publish(any(EmailVerificationEvent.class));
         }
         

--- a/src/test/java/kr/co/yeogiga/infrastructure/event/consumer/EmailVerificationEmailConsumerTest.java
+++ b/src/test/java/kr/co/yeogiga/infrastructure/event/consumer/EmailVerificationEmailConsumerTest.java
@@ -47,6 +47,8 @@ public class EmailVerificationEmailConsumerTest {
     private final String DLX = "x.email-verification";
     private final String DLK = "email-verification";
     
+    private final int EMAIL_VERIFICATION_EXPIRATION = 180;
+    
     @BeforeEach
     void setUp() {
         when(rabbitMQProperties.getEmailVerification()).thenReturn(emailVerificationProperties);
@@ -61,7 +63,7 @@ public class EmailVerificationEmailConsumerTest {
     @DisplayName("성공 - 메시지 수신 후 이메일 발행 성공")
     void success() {
         // given
-        EmailVerificationEvent event = new EmailVerificationEvent("test@test.com", "123456");
+        EmailVerificationEvent event = new EmailVerificationEvent("test@test.com", "123456", EMAIL_VERIFICATION_EXPIRATION);
         
         // when
         consumer.handleMessage(event, null);
@@ -74,7 +76,7 @@ public class EmailVerificationEmailConsumerTest {
     @DisplayName("실패 - 재시도 가능한 예외가 발생한 경우")
     void failRetry() {
         // given
-        EmailVerificationEvent event = new EmailVerificationEvent("test@test.com", "123456");
+        EmailVerificationEvent event = new EmailVerificationEvent("test@test.com", "123456", EMAIL_VERIFICATION_EXPIRATION);
         
         MailException mockMailException = mock(MailException.class);
         doThrow(new RetryableEmailException("Retryable Exception", mockMailException)).when(emailSender)
@@ -92,7 +94,7 @@ public class EmailVerificationEmailConsumerTest {
     @DisplayName("실패 - 재시도 최대 횟수(3회) 초과하여 DLQ로 이동하는 경우")
     void failRetryExceed() {
         // given
-        EmailVerificationEvent event = new EmailVerificationEvent("test@test.com", "123456");
+        EmailVerificationEvent event = new EmailVerificationEvent("test@test.com", "123456", EMAIL_VERIFICATION_EXPIRATION);
         List<Map<String, Object>> xDeath = List.of(Map.of(
                 "reason", "rejected",
                 "queue", WORK_QUEUE + ".email",
@@ -114,7 +116,7 @@ public class EmailVerificationEmailConsumerTest {
     @DisplayName("실패 - 재시도가 불가능한 예외가 발생한 경우")
     void failFatal() {
         // given
-        EmailVerificationEvent event = new EmailVerificationEvent("test@test.com", "123456");
+        EmailVerificationEvent event = new EmailVerificationEvent("test@test.com", "123456", EMAIL_VERIFICATION_EXPIRATION);
         
         MessagingException mockMessagingException = mock(MessagingException.class);
         doThrow((new FatalEmailException("Fatal Exception", mockMessagingException)))

--- a/src/test/java/kr/co/yeogiga/infrastructure/event/consumer/PasswordResetEmailConsumerTest.java
+++ b/src/test/java/kr/co/yeogiga/infrastructure/event/consumer/PasswordResetEmailConsumerTest.java
@@ -47,6 +47,8 @@ public class PasswordResetEmailConsumerTest {
     private final String DLX = "x.password-reset";
     private final String DLK = "password-reset";
     
+    private final int PASSWORD_RESET_EXPIRATION = 180;
+    
     @BeforeEach
     void setUp() {
         when(rabbitMQProperties.getPasswordReset()).thenReturn(passwordResetProperties);
@@ -61,7 +63,7 @@ public class PasswordResetEmailConsumerTest {
     @DisplayName("성공 - 메시지 수신 후 이메일 발행 성공")
     void success() {
         // given
-        PasswordResetEvent event = new PasswordResetEvent("test@test.com", "123456");
+        PasswordResetEvent event = new PasswordResetEvent("test@test.com", "123456", PASSWORD_RESET_EXPIRATION);
         
         // when
         consumer.handleMessage(event, null);
@@ -74,7 +76,7 @@ public class PasswordResetEmailConsumerTest {
     @DisplayName("실패 - 재시도 가능한 예외가 발생한 경우")
     void failRetry() {
         // given
-        PasswordResetEvent event = new PasswordResetEvent("test@test.com", "123456");
+        PasswordResetEvent event = new PasswordResetEvent("test@test.com", "123456", PASSWORD_RESET_EXPIRATION);
         
         MailException mockMailException = mock(MailException.class);
         doThrow(new RetryableEmailException("Retryable Exception", mockMailException)).when(emailSender)
@@ -92,7 +94,7 @@ public class PasswordResetEmailConsumerTest {
     @DisplayName("실패 - 재시도 최대 횟수(3회) 초과하여 DLQ로 이동하는 경우")
     void failRetryExceed() {
         // given
-        PasswordResetEvent event = new PasswordResetEvent("test@test.com", "123456");
+        PasswordResetEvent event = new PasswordResetEvent("test@test.com", "123456", PASSWORD_RESET_EXPIRATION);
         List<Map<String, Object>> xDeath = List.of(Map.of(
                 "reason", "rejected",
                 "queue", WORK_QUEUE + ".email",
@@ -114,7 +116,7 @@ public class PasswordResetEmailConsumerTest {
     @DisplayName("실패 - 재시도가 불가능한 예외가 발생한 경우")
     void failFatal() {
         // given
-        PasswordResetEvent event = new PasswordResetEvent("test@test.com", "123456");
+        PasswordResetEvent event = new PasswordResetEvent("test@test.com", "123456", PASSWORD_RESET_EXPIRATION);
         
         MessagingException mockMessagingException = mock(MessagingException.class);
         doThrow((new FatalEmailException("Fatal Exception", mockMessagingException)))

--- a/src/test/java/kr/co/yeogiga/infrastructure/event/publisher/RabbitMQEventPublisherTest.java
+++ b/src/test/java/kr/co/yeogiga/infrastructure/event/publisher/RabbitMQEventPublisherTest.java
@@ -42,7 +42,9 @@ public class RabbitMQEventPublisherTest {
     @InjectMocks
     private RabbitMQEventPublisher rabbitMQEventPublisher;
     
-    private DomainEvent event = new PasswordResetEvent("test@test.com", "123456");
+    private final int PASSWORD_RESET_EXPIRATION = 180;
+    
+    private DomainEvent event = new PasswordResetEvent("test@test.com", "123456", PASSWORD_RESET_EXPIRATION);
     private String eventId = "01KFQ007TN82P4155GX1X0T6SJ";
     
     @Captor


### PR DESCRIPTION
## 배경
- 이메일 인증, 비밀번호 초기화 로직 관련 `Event` - `Repository 구현체` 내 만료기한을 별도로 직접 설정
  → 공통으로 적용되는 만료 기한을 별도로 적용하여, 단일소스(SSOT) 원칙 위배 및 향후 유지보수 위험성 판단

## 작업 사항
- 인증 도메인(PasswordReset, EmailVerification) 프로퍼티 값 설정 | (248ec103f11e1026ade4145a4b139851342c6768)
- 비밀번호 초기화 로직 내 만료기한 단일 소스 적용 | (b7842a56cfbe78f7f4ee2b0859a7b8980d438e16)
- 이메일 인증 요청 로직 내 만료기한 단일 소스 적용 | (2f639f7b85a9ed7c5a48dfb6f519b9cd99cd05d8)