### PR TITLE
Feature: 이벤트 아웃박스 삭제 로직 구현

### DIFF
--- a/src/main/java/kr/co/yeogiga/application/event/cleaner/EventCleanupContext.java
+++ b/src/main/java/kr/co/yeogiga/application/event/cleaner/EventCleanupContext.java
@@ -1,0 +1,61 @@
+package kr.co.yeogiga.application.event.cleaner;
+
+import kr.co.yeogiga.application.event.cleaner.strategy.EventCleanupStrategy;
+import kr.co.yeogiga.domain.outbox.service.EventOutboxService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventCleanupContext {
+    private final EventOutboxService eventOutboxService;
+    
+    /**
+     * 이벤트 삭제 로직을 안전하게 수행하기 위한 래핑 메서드
+     *
+     * <p> 삭제 진행 시 발생 예외를 감싸 후처리를 가능하도록 한다.
+     *
+     * @param strategy
+     */
+    public void executeSafe(EventCleanupStrategy strategy) {
+        try {
+            execute(strategy);
+        } catch (Exception e) {
+            log.error(strategy.getFailMessage());
+        }
+    }
+    
+    /**
+     * 이벤트 삭제 로직 실행 메서드
+     *
+     * <p> 인자로 전달받은 이벤트 삭제 전략에 따라 이벤트 삭제 처리를 진행
+     *
+     * <p> GAP Lock, DB 부하 및 병목 현상을 방지하기 위한 청크 단위 삭제
+     *
+     * @param strategy 이벤트 아웃박스 삭제 전략
+     */
+    private void execute(EventCleanupStrategy strategy) {
+        long deletedCount = 0;
+        
+        while (true) {
+            List<Long> ids = strategy.getIdsToDelete();
+            
+            if (ids.isEmpty()) {
+                break;
+            }
+            
+            eventOutboxService.deleteByIds(ids);
+            deletedCount += ids.size();
+            
+            if (ids.size() < strategy.getChunkSize()) {
+                break;
+            }
+        }
+        
+        log.info("{} Count: {}", strategy.getSuccessMessage(), deletedCount);
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/event/cleaner/EventCleanupJobRegistrar.java
+++ b/src/main/java/kr/co/yeogiga/application/event/cleaner/EventCleanupJobRegistrar.java
@@ -1,0 +1,36 @@
+package kr.co.yeogiga.application.event.cleaner;
+
+import jakarta.annotation.PostConstruct;
+import kr.co.yeogiga.application.event.cleaner.strategy.EventCleanupStrategy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventCleanupJobRegistrar {
+    private final List<EventCleanupStrategy> eventCleanupStrategies;
+    private final ThreadPoolTaskScheduler eventCleanupTaskScheduler;
+    private final EventCleanupContext eventCleanupContext;
+    
+    @PostConstruct
+    public void init() {
+        log.info("Register Event Outbox Cleanup Scheduler...");
+        for (EventCleanupStrategy strategy : eventCleanupStrategies) {
+            try {
+                eventCleanupTaskScheduler.schedule(
+                    () -> eventCleanupContext.executeSafe(strategy),
+                    new CronTrigger(strategy.getCronExpression())
+                );
+                log.info("\"{}\" scheduling job registered.", strategy.getName());
+            } catch (Exception e) {
+                log.error("Failed to register EventCleanup scheduling job. strategy = {}.", strategy.getName(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/event/cleaner/strategy/EventCleanupStrategy.java
+++ b/src/main/java/kr/co/yeogiga/application/event/cleaner/strategy/EventCleanupStrategy.java
@@ -1,0 +1,17 @@
+package kr.co.yeogiga.application.event.cleaner.strategy;
+
+import java.util.List;
+
+public interface EventCleanupStrategy {
+    String getName();
+    
+    String getCronExpression();
+    
+    long getChunkSize();
+    
+    List<Long> getIdsToDelete();
+    
+    String getSuccessMessage();
+    
+    String getFailMessage();
+}

--- a/src/main/java/kr/co/yeogiga/application/event/cleaner/strategy/FailedEventCleanupStrategy.java
+++ b/src/main/java/kr/co/yeogiga/application/event/cleaner/strategy/FailedEventCleanupStrategy.java
@@ -1,0 +1,45 @@
+package kr.co.yeogiga.application.event.cleaner.strategy;
+
+import kr.co.yeogiga.domain.outbox.service.EventOutboxService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class FailedEventCleanupStrategy implements EventCleanupStrategy {
+    private final EventOutboxService eventOutboxService;
+    private final long CHUNK_SIZE = 300L;
+    
+    @Override
+    public String getName() {
+        return "FailedEventCleanupStrategy";
+    }
+    
+    @Override
+    public String getCronExpression() {
+        return "0 30 0 * * *";
+    }
+    
+    @Override
+    public long getChunkSize() {
+        return CHUNK_SIZE;
+    }
+    
+    @Override
+    public List<Long> getIdsToDelete() {
+        return eventOutboxService.findOldFailedEventIds(3, LocalDateTime.now().minusDays(1), CHUNK_SIZE);
+    }
+    
+    @Override
+    public String getSuccessMessage() {
+        return "Success to delete FAILED event.";
+    }
+    
+    @Override
+    public String getFailMessage() {
+        return "Failed to delete FAILED event.";
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/event/cleaner/strategy/PublishedEventCleanupStrategy.java
+++ b/src/main/java/kr/co/yeogiga/application/event/cleaner/strategy/PublishedEventCleanupStrategy.java
@@ -1,0 +1,45 @@
+package kr.co.yeogiga.application.event.cleaner.strategy;
+
+import kr.co.yeogiga.domain.outbox.service.EventOutboxService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PublishedEventCleanupStrategy implements EventCleanupStrategy {
+    private final EventOutboxService eventOutboxService;
+    private final long CHUNK_SIZE = 1_000L;
+    
+    @Override
+    public String getName() {
+        return "PublishedEventCleanupStrategy";
+    }
+    
+    @Override
+    public String getCronExpression() {
+        return "0 0,30 * * * *";
+    }
+    
+    @Override
+    public long getChunkSize() {
+        return CHUNK_SIZE;
+    }
+    
+    @Override
+    public List<Long> getIdsToDelete() {
+        return eventOutboxService.findOldPublishedEventIds(LocalDateTime.now().minusMinutes(30), CHUNK_SIZE);
+    }
+    
+    @Override
+    public String getSuccessMessage() {
+        return "Success to delete PUBLISHED event.";
+    }
+    
+    @Override
+    public String getFailMessage() {
+        return "Failed to delete PUBLISHED event.";
+    }
+}

--- a/src/main/java/kr/co/yeogiga/application/event/cleaner/strategy/WaitingEventCleanupStrategy.java
+++ b/src/main/java/kr/co/yeogiga/application/event/cleaner/strategy/WaitingEventCleanupStrategy.java
@@ -1,0 +1,45 @@
+package kr.co.yeogiga.application.event.cleaner.strategy;
+
+import kr.co.yeogiga.domain.outbox.service.EventOutboxService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class WaitingEventCleanupStrategy implements EventCleanupStrategy {
+    private final EventOutboxService eventOutboxService;
+    private final long CHUNK_SIZE = 300L;
+    
+    @Override
+    public String getName() {
+        return "WaitingEventCleanupStrategy";
+    }
+    
+    @Override
+    public String getCronExpression() {
+        return "0 0 0 * * *";
+    }
+    
+    @Override
+    public long getChunkSize() {
+        return CHUNK_SIZE;
+    }
+    
+    @Override
+    public List<Long> getIdsToDelete() {
+        return eventOutboxService.findOldWaitingEventIds(LocalDateTime.now().minusDays(1), CHUNK_SIZE);
+    }
+    
+    @Override
+    public String getSuccessMessage() {
+        return "Success to delete WAITING event.";
+    }
+    
+    @Override
+    public String getFailMessage() {
+        return "Failed to delete WAITING event.";
+    }
+}

--- a/src/main/java/kr/co/yeogiga/domain/outbox/repository/CustomEventOutboxRepository.java
+++ b/src/main/java/kr/co/yeogiga/domain/outbox/repository/CustomEventOutboxRepository.java
@@ -9,6 +9,9 @@ import java.util.List;
 public interface CustomEventOutboxRepository {
     List<EventOutbox> findByStatusAndCreatedAt(EventOutboxStatus status, LocalDateTime start, LocalDateTime end);
     List<EventOutbox> findByStatusAndFailCount(EventOutboxStatus status, int failCount);
+    List<Long> findIdsByStatusAndCreatedAtBefore(EventOutboxStatus status, LocalDateTime dateTime, long limit);
+    List<Long> findIdsByStatusAndCreatedAtBeforeAndFailCountGreaterThanEqual(EventOutboxStatus status, int failCount, LocalDateTime dateTime, long limit);
     void updateStatusPublishedInEventIds(List<String> eventIds);
     void updateStatusFailedInEventIds(List<String> eventIds);
+    void deleteByIds(List<Long> ids);
 }

--- a/src/main/java/kr/co/yeogiga/domain/outbox/repository/CustomEventOutboxRepositoryImpl.java
+++ b/src/main/java/kr/co/yeogiga/domain/outbox/repository/CustomEventOutboxRepositoryImpl.java
@@ -39,6 +39,33 @@ public class CustomEventOutboxRepositoryImpl implements CustomEventOutboxReposit
     }
     
     @Override
+    public List<Long> findIdsByStatusAndCreatedAtBefore(EventOutboxStatus status, LocalDateTime dateTime, long limit) {
+        return jpaQueryFactory
+                .select(eventOutbox.id)
+                .from(eventOutbox)
+                .where(
+                        eventOutbox.status.eq(status),
+                        eventOutbox.createdAt.before(dateTime)
+                )
+                .limit(limit)
+                .fetch();
+    }
+
+    @Override
+    public List<Long> findIdsByStatusAndCreatedAtBeforeAndFailCountGreaterThanEqual(EventOutboxStatus status, int failCount, LocalDateTime dateTime, long limit) {
+        return jpaQueryFactory
+                .select(eventOutbox.id)
+                .from(eventOutbox)
+                .where(
+                        eventOutbox.status.eq(status),
+                        eventOutbox.failCount.goe(failCount),
+                        eventOutbox.createdAt.before(dateTime)
+                )
+                .limit(limit)
+                .fetch();
+    }
+    
+    @Override
     public void updateStatusPublishedInEventIds(List<String> eventIds) {
         if (eventIds.isEmpty()) return;
         
@@ -61,6 +88,13 @@ public class CustomEventOutboxRepositoryImpl implements CustomEventOutboxReposit
                 .execute();
     }
     
+    @Override
+    public void deleteByIds(List<Long> ids) {
+        jpaQueryFactory
+                .delete(eventOutbox)
+                .where(eventOutbox.id.in(ids))
+                .execute();
+    }
     
     private BooleanExpression createdAtBetween(LocalDateTime start, LocalDateTime end) {
         if (start == null && end == null) return null;

--- a/src/main/java/kr/co/yeogiga/domain/outbox/service/EventOutboxService.java
+++ b/src/main/java/kr/co/yeogiga/domain/outbox/service/EventOutboxService.java
@@ -59,4 +59,25 @@ public class EventOutboxService {
     public void updateToFailedByEventId(String eventId) {
         eventOutboxRepository.updateStatusFailedByEventId(eventId);
     }
+
+    @Transactional(readOnly = true)
+    public List<Long> findOldPublishedEventIds(LocalDateTime dateTime, long limit) {
+        return eventOutboxRepository.findIdsByStatusAndCreatedAtBefore(EventOutboxStatus.PUBLISHED, dateTime, limit);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> findOldFailedEventIds(int failCount, LocalDateTime dateTime, long limit) {
+        return eventOutboxRepository.findIdsByStatusAndCreatedAtBeforeAndFailCountGreaterThanEqual(EventOutboxStatus.FAILED, failCount, dateTime, limit);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> findOldWaitingEventIds(LocalDateTime dateTime, long limit) {
+        return eventOutboxRepository.findIdsByStatusAndCreatedAtBefore(EventOutboxStatus.WAITING, dateTime, limit);
+    }
+
+    @Transactional
+    public void deleteByIds(List<Long> ids) {
+        if (ids.isEmpty()) return;
+        eventOutboxRepository.deleteByIds(ids);
+    }
 }

--- a/src/main/java/kr/co/yeogiga/infrastructure/config/SchedulingConfig.java
+++ b/src/main/java/kr/co/yeogiga/infrastructure/config/SchedulingConfig.java
@@ -1,9 +1,28 @@
 package kr.co.yeogiga.infrastructure.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Configuration
 @EnableScheduling
 public class SchedulingConfig {
+    @Bean(name = "taskScheduler")
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(4);
+        taskScheduler.setThreadNamePrefix("general-scheduling-");
+        return taskScheduler;
+    }
+    
+    @Bean(name = "eventCleanupTaskScheduler")
+    public ThreadPoolTaskScheduler eventCleanupTaskScheduler() {
+        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(4);
+        taskScheduler.setThreadNamePrefix("event-cleanup-scheduling-");
+        taskScheduler.setWaitForTasksToCompleteOnShutdown(true);
+        taskScheduler.setAwaitTerminationSeconds(60);
+        return taskScheduler;
+    }
 }

--- a/src/test/java/kr/co/yeogiga/application/event/cleaner/EventCleanupContextTest.java
+++ b/src/test/java/kr/co/yeogiga/application/event/cleaner/EventCleanupContextTest.java
@@ -1,0 +1,118 @@
+package kr.co.yeogiga.application.event.cleaner;
+
+import kr.co.yeogiga.application.event.cleaner.strategy.EventCleanupStrategy;
+import kr.co.yeogiga.application.event.cleaner.strategy.PublishedEventCleanupStrategy;
+import kr.co.yeogiga.domain.outbox.service.EventOutboxService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class EventCleanupContextTest {
+    @Mock
+    private EventOutboxService eventOutboxService;
+    
+    @InjectMocks
+    private EventCleanupContext eventCleanupContext;
+    
+    private EventCleanupStrategy strategy;
+    
+    @Captor
+    private ArgumentCaptor<List<Long>> idsCaptor;
+    
+    @BeforeEach
+    void setUp() {
+        strategy = new PublishedEventCleanupStrategy(eventOutboxService);
+    }
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+        // given
+        when(eventOutboxService.findOldPublishedEventIds(any(LocalDateTime.class), anyLong()))
+                .thenReturn(List.of(1L, 2L, 3L, 4L));
+        
+        // when
+        eventCleanupContext.executeSafe(strategy);
+        
+        // then
+        verify(eventOutboxService, times(1)).deleteByIds(idsCaptor.capture());
+        
+        List<Long> capturedIds = idsCaptor.getValue();
+        assertThat(capturedIds).usingRecursiveComparison().isEqualTo(List.of(1L, 2L, 3L, 4L));
+    }
+    
+    @Test
+    @DisplayName("성공 - 청크 범위를 벗어날 경우")
+    void successDeleteChunk() {
+        // given
+        List<Long> chunkIds1 = LongStream.rangeClosed(1, 1000).boxed().collect(Collectors.toList());
+        List<Long> chunkIds2 = List.of(1001L);
+        
+        when(eventOutboxService.findOldPublishedEventIds(any(LocalDateTime.class), anyLong()))
+                .thenReturn(chunkIds1)
+                .thenReturn(chunkIds2);
+        
+        // when
+        eventCleanupContext.executeSafe(strategy);
+        
+        // then
+        verify(eventOutboxService, times(2)).deleteByIds(anyList());
+    }
+    
+    @Test
+    @DisplayName("성공 - 청크 범위를 벗어나고, 반환된 리스트의 크기가 청크단위과 동일할 경우")
+    void successIfChunkAndListSizeSame() {
+        // given
+        List<Long> chunkIds1 = LongStream.rangeClosed(1, 1000).boxed().collect(Collectors.toList());
+        List<Long> chunkIds2 = LongStream.rangeClosed(1001, 2000).boxed().collect(Collectors.toList());
+        
+        when(eventOutboxService.findOldPublishedEventIds(any(LocalDateTime.class), anyLong()))
+                .thenReturn(chunkIds1)
+                .thenReturn(chunkIds2)
+                .thenReturn(Collections.emptyList());
+        
+        // when
+        eventCleanupContext.executeSafe(strategy);
+        
+        // then
+        verify(eventOutboxService, times(2)).deleteByIds(anyList());
+    }
+    
+    @Test
+    @DisplayName("삭제 중 예외가 발생한 경우")
+    void fail() {
+        // given
+        doThrow(new RuntimeException("Unexpected Error")).when(eventOutboxService).deleteByIds(anyList());
+        when(eventOutboxService.findOldPublishedEventIds(any(LocalDateTime.class), anyLong()))
+                .thenReturn(List.of(1L));
+        
+        // when & then
+        assertDoesNotThrow(() -> eventCleanupContext.executeSafe(strategy));
+        
+        verify(eventOutboxService, times(1))
+                .findOldPublishedEventIds(any(LocalDateTime.class), anyLong());
+    }
+}


### PR DESCRIPTION
## 배경
- 불필요한 레코드 제거를 위한 발행 완료 / 장기 대기 / 완전 실패 이벤트 아웃박스에 대한 삭제 필요

## 작업 사항
- 이벤트 아웃박스 상태별 조회 및 일괄 삭제 도메인 로직 구현 |(72baaf382b2dd89abadfd089175c0b578fa73b39)
- 이벤트 상태별 삭제 로직 구현 | (bba51cd8afb06b6cf9fd1374765d22959d380537)
  - GAP Lock, DB 병목 현상 등을 막기 위한 청크 단위 삭제
  - 전략(Strategy) 패턴 사용
    - `PUBLISHED`: 30분 주기 / 생성된지 30분 이상
        : `PUBLISHED`된 이벤트가 압도적으로 많기 때문에 30분 단위 삭제
    - `WAITING`: 매일 자정 / 생성된지 1일 이상
    - `FAILED`: 매일 00:30 / 생성된지 1일 이상
      : WAITING, FAILED 이벤트는 추후 로그 확인을 위한 24시간 주기 삭제
- 스케줄링 방식 별 사용 쓰레드풀 구분 설정 | (079ca48e752f4ed157f6924c2f95d02bad22228f)
  - `@Scheduled`
    - 기본적으로 `taskScheduler`라는 이름의 빈을 사용
  - 이벤트 삭제 용 `ThreadPoolTaskScheduler`
    - 동일 시점 내 최대 2개의 이벤트 삭제 로직이 실행 가능 → 2배 정도의 쓰레드풀 설정
- 이벤트 삭제 전략에 따른 삭제 로직  실행 클래스 구현 | (de7d39a595cc35cbdb201396264f2916d656aa7a)
- 이벤트 전략을 적용한 삭제 로직 스케줄링 | (8c42fc90fcf30ecd3dc70181b8bdef2e716acebb)

## 추가 논의
- 향후 주기적으로 적재되는 로그(이벤트 폴링 시점 / 이벤트 삭제 시점) 처리를 위한 로그 단계 및 logback 제한 설정 예정